### PR TITLE
chore(ci): bump release-please-action to v4.4.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## 📋 變更描述

將 `googleapis/release-please-action` 的 pinned SHA 從 v4.3.0 升級至 v4.4.1,以降低 GitHub API GraphQL replica 同步延遲造成的 label mutation 競態條件。

- 舊:`16a9c90856f42705d54a6fda1823352bdc62cf38` # v4 (v4.3.0, 2025-08-20)
- 新:`5c625bfb5d1ff62eadeeb3772007f7f66fdcf071` # v4.4.1 (2026-04-13)

底層 `release-please` 從 v17.1.3 一併升級至 v17.6.0 區間,半年累計的穩定性修正隨之套用。

### 問題背景

Release Please run [`24599156807`](https://github.com/cowcfj/save-to-notion/actions/runs/24599156807)(2026-04-18 06:47 UTC)在成功建立 PR #420 後 **212 毫秒** 即失敗:

```
Validation Failed: Could not resolve to a node with the global id
of 'PR_kwDOPyXKdc7Tie5h'.
```

解碼該 Global Node ID 後確認對應剛建立的 PR #420。真正失敗的是 GraphQL `addLabelsToLabelable` mutation,錯誤訊息中 `/rest/issues/labels` 連結為套件內硬編文件,排查時易產生誤導。

### 修復路徑

1. **立即解卡**:手動為 PR #420 補上 `autorelease: pending` label,讓 merge 後的 tag/release 流程可正常被識別。
2. **本 PR**:升級 action 以吸收上游於此版本期間對 GitHub API 互動的穩定性改進,降低未來再次踩雷的機率。

## 🎯 變更類型

- [ ] ✨ 新功能 (Feature)
- [x] 🐛 Bug 修復 (Bug Fix)
- [ ] 🔨 重構 (Refactor)
- [ ] 📝 文檔更新 (Documentation)
- [ ] 🧪 測試改進 (Testing)
- [ ] ⚡ 性能優化 (Performance)
- [ ] 🔒 安全性改進 (Security)

## 🤖 提交者聲明

- [ ] 👨‍💻 由人類開發者手動提交
- [x] 🤖 由 AI Agent 自動建立

> 本 PR 由 AI Agent 建立,變更僅限 `.github/workflows/release-please.yml` 內一行 action SHA 與註解,不觸碰任何 extension 產物或 backend 程式碼。

## ✅ 提交前檢查清單

- [x] **PR 標題合規**:使用 `chore(ci):` 前綴,符合 Conventional Commits,並不會觸發新版發布。
- [x] **流程與安全自評**:純 CI action SHA pin 升級,已依 `PR_AND_RELEASE_WORKFLOW.md` 要求保留 immutable commit SHA,commit 同時註解對應版本標籤;影響範圍不觸及 `scripts/`、`src/`、`tests/`。

### 風險與回滾

| 項目 | 影響 |
|------|------|
| Extension 產物 | 無變動(workflow 於 `release-please-config.json` 之 `exclude-paths` 已列入 `.github/`) |
| CHANGELOG | 不會出現在下一版 `CHANGELOG.md`(exclude + `chore:` 類型) |
| 回滾 | 還原單行 SHA 即可;無 schema 或 state 依賴 |

## 🔗 相關 Issue

_無對應 Issue;直接由失敗 run 排查後處置。_

Closes #
