### PR TITLE
fix: 修復高亮恢復的回歸問題

### DIFF
--- a/scripts/background/services/TabService.js
+++ b/scripts/background/services/TabService.js
@@ -322,12 +322,11 @@ class TabService {
       return fallbackHighlights;
     }
 
-    const aliasKey = `${URL_ALIAS_PREFIX}${this.normalizeUrl(originalUrl)}`;
-    chrome.storage.local.set({ [aliasKey]: normUrl }).catch(() => {});
-    this.logger.debug('[TabService] Created url_alias for fallback URL', {
-      from: sanitizeUrlForLogging(originalUrl),
-      to: sanitizeUrlForLogging(normUrl),
-    });
+    // ⚠️ 已移除自動補寫 url_alias 的副作用（Phase 2 regression fix）。
+    // 背景：若在 stableUrl miss、originalUrl hit 時立即補寫 alias，
+    // 後續 HighlightStorageGateway.loadHighlights() 會信任此 alias 優先查 page_<stableUrl>，
+    // 但資料仍在 page_<originalUrl>，造成 restore miss（regression 根因）。
+    // 若確實需要建立 alias，應由明確的 canonicalization/migration 流程負責。
 
     return fallbackHighlights;
   }

--- a/scripts/background/services/TabService.js
+++ b/scripts/background/services/TabService.js
@@ -318,15 +318,12 @@ class TabService {
     }
 
     const fallbackHighlights = await this._getHighlightsFromStorage(originalUrl);
-    if (!fallbackHighlights) {
-      return fallbackHighlights;
-    }
-
-    // ⚠️ 已移除自動補寫 url_alias 的副作用（Phase 2 regression fix）。
-    // 背景：若在 stableUrl miss、originalUrl hit 時立即補寫 alias，
-    // 後續 HighlightStorageGateway.loadHighlights() 會信任此 alias 優先查 page_<stableUrl>，
-    // 但資料仍在 page_<originalUrl>，造成 restore miss（regression 根因）。
-    // 若確實需要建立 alias，應由明確的 canonicalization/migration 流程負責。
+    // 這裡僅負責 stableUrl -> originalUrl 的讀取回退，不再夾帶重複 side-effect。
+    // restore 正確性由 HighlightStorageGateway._loadBothFormats() 保證：
+    // 它會同時查 page_<stableUrl> 與 page_<normalizedUrl>，避免 canonical key 與原 permalink
+    // 暫時並存時出現 restore miss。url_alias 仍由 _persistUrlAliasIfNeeded() 在
+    // hasStableUrl=true 時寫入，因此這裡的 regression fix 不是「移除 alias」，而是
+    // 避免在 fallback helper 內再做一次與讀取無關的狀態寫入。
 
     return fallbackHighlights;
   }

--- a/scripts/highlighter/core/HighlightStorageGateway.js
+++ b/scripts/highlighter/core/HighlightStorageGateway.js
@@ -329,12 +329,30 @@ const HighlightStorageGateway = {
     }
 
     const stableUrl = await this._resolveStableUrl(pageUrl, normalizedUrl);
-    const pageKey = `${PAGE_PREFIX}${stableUrl}`;
-    const data = await chrome.storage.local.get([pageKey, legacyKey]);
+    const stablePageKey = `${PAGE_PREFIX}${stableUrl}`;
+    const normalizedPageKey = `${PAGE_PREFIX}${normalizedUrl}`;
 
-    // 優先返回 page_* 格式
-    if (data[pageKey]) {
-      return this._parseHighlightFormat(data[pageKey]);
+    // 同時查詢三個 key：
+    //   1. page_<stableUrl>    — alias 命中的 canonical key
+    //   2. page_<normalizedUrl> — 資料可能仍在 original permalink
+    //   3. highlights_<normalizedUrl> — 舊格式回退
+    // 一次 get 可減少 round-trip，且 stablePageKey 可能等於 normalizedPageKey（無 alias 時）
+    const keysToFetch =
+      stablePageKey === normalizedPageKey
+        ? [normalizedPageKey, legacyKey]
+        : [stablePageKey, normalizedPageKey, legacyKey];
+    const data = await chrome.storage.local.get(keysToFetch);
+
+    // 判定順序（依計劃 §7 Minimal Lookup Contract）：
+    //   1. page_<stableUrl>
+    //   2. page_<normalizedUrl>
+    //   3. highlights_<normalizedUrl>
+    if (data[stablePageKey]) {
+      return this._parseHighlightFormat(data[stablePageKey]);
+    }
+
+    if (data[normalizedPageKey]) {
+      return this._parseHighlightFormat(data[normalizedPageKey]);
     }
 
     // 回退 highlights_* 舊格式
@@ -342,7 +360,7 @@ const HighlightStorageGateway = {
       return this._parseHighlightFormat(data[legacyKey]);
     }
 
-    // 兩個 key 都找不到：回傳 null 表示「未找到」，與「明確空陣列」區分
+    // 三個 key 都找不到：回傳 null 表示「未找到」，與「明確空陣列」區分
     return null;
   },
 

--- a/scripts/highlighter/entryAutoInit.js
+++ b/scripts/highlighter/entryAutoInit.js
@@ -232,17 +232,18 @@ if (globalThis.window !== undefined && !globalThis.HighlighterV2) {
         })(),
       ]);
 
-      // 設置穩定 URL（優先使用 pageStatus，若 waitForStableUrl 已快速完成則回退使用）
-      const resolvedStableUrl = pageStatus?.stableUrl || stableUrlState.value;
+      // 設置穩定 URL 優先權（Phase 3 regression fix）：
+      // SET_STABLE_URL 是 Background 在 preloader 解析完成後主動推送的，
+      // 代表最新且最權威的 canonical source。
+      // checkPageStatus 的 stableUrl 可能來自較舊的快取，優先級較低。
+      // 因此：已收到 SET_STABLE_URL 時，優先使用它；否則才回退到 pageStatus.stableUrl。
+      const resolvedStableUrl = stableUrlState.value || pageStatus?.stableUrl || null;
       if (resolvedStableUrl) {
         globalThis.__NOTION_STABLE_URL__ = resolvedStableUrl;
         Logger.debug('[Highlighter] 已使用穩定 URL 完成初始化', {
           action: 'initializeExtension',
           stableUrl: sanitizeUrlForLogging(resolvedStableUrl),
-          source:
-            pageStatus?.stableUrl || !stableUrlState.resolved || !stableUrlState.value
-              ? 'checkPageStatus'
-              : 'SET_STABLE_URL',
+          source: stableUrlState.value ? 'SET_STABLE_URL' : 'checkPageStatus',
         });
       }
 

--- a/tests/unit/background/services/TabService.test.js
+++ b/tests/unit/background/services/TabService.test.js
@@ -386,8 +386,6 @@ describe('TabService', () => {
         .fn()
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(highlights);
-      service.normalizeUrl = jest.fn(url => `${url}?normalized=true`);
-      chrome.storage.local.set.mockResolvedValue(undefined);
 
       const result = await service._getHighlightsWithFallback(
         'https://example.com/stable',
@@ -416,8 +414,6 @@ describe('TabService', () => {
         .fn()
         .mockResolvedValueOnce(null) // stableUrl miss
         .mockResolvedValueOnce(highlights); // originalUrl hit
-      service.normalizeUrl = jest.fn(url => url);
-      chrome.storage.local.set.mockResolvedValue(undefined);
 
       await service._getHighlightsWithFallback(
         'https://example.com/stable',

--- a/tests/unit/background/services/TabService.test.js
+++ b/tests/unit/background/services/TabService.test.js
@@ -378,7 +378,8 @@ describe('TabService', () => {
       expect(aliasCalls).toHaveLength(0);
     });
 
-    it('stableUrl 查無 highlights 時應 fallback 到 originalUrl 並補寫 url_alias', async () => {
+    it('stableUrl 查無 highlights 時應 fallback 到 originalUrl 並成功回傳 highlights', async () => {
+      // 驗證 fallback 資料命中時確實回傳 highlights（功能正確性）
       const highlights = [{ id: 'fallback-highlight' }];
 
       service._getHighlightsFromStorage = jest
@@ -403,17 +404,32 @@ describe('TabService', () => {
         2,
         'https://example.com/original'
       );
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({
-        [`${URL_ALIAS_PREFIX}https://example.com/original?normalized=true`]:
-          'https://example.com/stable',
-      });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[TabService] Created url_alias for fallback URL',
-        expect.objectContaining({
-          from: expect.any(String),
-          to: expect.any(String),
-        })
+    });
+
+    // ─── Step 0.2 Regression Test ────────────────────────────────────────────
+    // 驗證：fallback 命中 originalUrl 時，不應無條件補寫 url_alias。
+    // 修復前此測試應 FAIL（因為現有程式碼會無條件補寫 alias）。
+    it('[REGRESSION] fallback 命中 page_<originalUrl> 時，不應立即補寫 url_alias', async () => {
+      const highlights = [{ id: 'regression-no-alias' }];
+
+      service._getHighlightsFromStorage = jest
+        .fn()
+        .mockResolvedValueOnce(null) // stableUrl miss
+        .mockResolvedValueOnce(highlights); // originalUrl hit
+      service.normalizeUrl = jest.fn(url => url);
+      chrome.storage.local.set.mockResolvedValue(undefined);
+
+      await service._getHighlightsWithFallback(
+        'https://example.com/stable',
+        true,
+        'https://example.com/original'
       );
+
+      // 修復後：不應在 fallback 命中後補寫 alias
+      const aliasCalls = chrome.storage.local.set.mock.calls.filter(([arg]) =>
+        Object.keys(arg).some(k => k.startsWith(URL_ALIAS_PREFIX))
+      );
+      expect(aliasCalls).toHaveLength(0);
     });
 
     it('refresh 後解析出 stableUrl 且僅有 highlights 時，應保持未保存 badge 並注入 bundle', async () => {

--- a/tests/unit/highlighter/core/HighlightStorageGateway.extended.test.js
+++ b/tests/unit/highlighter/core/HighlightStorageGateway.extended.test.js
@@ -602,6 +602,96 @@ describe('Highlighter HighlightStorageGateway', () => {
 
       expect(result).toEqual([{ text: 'legacy alias highlight' }]);
     });
+
+    // ─── Step 0.1 Regression Tests ───────────────────────────────────────────
+    // 驗證：url_alias 指向 stableUrl，但資料仍存於 page_<originalUrl> 的情境。
+    // 修復前此測試應 FAIL（因為 _loadBothFormats 只查 page_<stableUrl> 而非 page_<normalizedUrl>）。
+    describe('Step 0.1: shortlink/permalink alias regression', () => {
+      test('[REGRESSION] alias 指向 stableUrl 但 page_<stableUrl> 缺資料，應 fallback 到 page_<normalizedUrl>', async () => {
+        const originalUrl = 'https://www.rapbull.net/posts/1838/slug';
+        const stableUrl = 'https://www.rapbull.net/?p=1838'; // shortlink
+        const normalizedUrl = originalUrl; // normalizeUrl 不改變此 URL
+
+        const aliasKey = `${URL_ALIAS_PREFIX}${normalizedUrl}`;
+        const stablePageKey = `${PAGE_PREFIX}${stableUrl}`;
+        const normalizedPageKey = `${PAGE_PREFIX}${normalizedUrl}`;
+        const legacyKey = `${HIGHLIGHTS_PREFIX}${normalizedUrl}`;
+
+        const expectedHighlights = [
+          { id: 'hl-1', text: 'regression test highlight', color: 'yellow' },
+        ];
+
+        // 模擬情境：
+        // - url_alias 存在（stableUrl 已被補寫）
+        // - page_<stableUrl> 不存在（資料還沒遷移過去）
+        // - page_<normalizedUrl> 有資料
+        mockChrome.storage.local.get = jest.fn().mockImplementation(keys => {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+
+          // alias 查詢
+          if (keyList.includes(aliasKey)) {
+            return Promise.resolve({ [aliasKey]: stableUrl });
+          }
+
+          // 同時查 stablePageKey + legacyKey
+          const result = {};
+          if (keyList.includes(stablePageKey)) {
+            // stablePageKey 無資料（尚未遷移）
+          }
+          if (keyList.includes(normalizedPageKey)) {
+            result[normalizedPageKey] = {
+              notion: { pageId: 'page-original-123' },
+              highlights: expectedHighlights,
+              metadata: { lastUpdated: 1000 },
+            };
+          }
+          if (keyList.includes(legacyKey)) {
+            // legacyKey 也無資料
+          }
+          return Promise.resolve(result);
+        });
+
+        const result = await HighlightStorageGateway.loadHighlights(originalUrl);
+
+        // 修復後：應從 page_<normalizedUrl> 命中高亮
+        expect(result).toEqual(expectedHighlights);
+      });
+
+      test('[REGRESSION] alias miss 時應直接從 page_<normalizedUrl> 讀取（無 alias 情境）', async () => {
+        const originalUrl = 'https://www.rapbull.net/posts/1838/slug';
+        const normalizedUrl = originalUrl;
+        const normalizedPageKey = `${PAGE_PREFIX}${normalizedUrl}`;
+        const legacyKey = `${HIGHLIGHTS_PREFIX}${normalizedUrl}`;
+
+        const expectedHighlights = [{ id: 'hl-2', text: 'no alias highlight', color: 'green' }];
+
+        mockChrome.storage.local.get = jest.fn().mockImplementation(keys => {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          const result = {};
+
+          // alias 查詢回空
+          if (keyList.every(k => k.startsWith(URL_ALIAS_PREFIX))) {
+            return Promise.resolve({});
+          }
+
+          if (keyList.includes(normalizedPageKey)) {
+            result[normalizedPageKey] = {
+              notion: { pageId: 'page-no-alias' },
+              highlights: expectedHighlights,
+              metadata: { lastUpdated: 2000 },
+            };
+          }
+          if (keyList.includes(legacyKey)) {
+            // legacyKey 無資料
+          }
+          return Promise.resolve(result);
+        });
+
+        const result = await HighlightStorageGateway.loadHighlights(originalUrl);
+
+        expect(result).toEqual(expectedHighlights);
+      });
+    });
   });
 
   describe('_saveToChromeStorage', () => {

--- a/tests/unit/highlighter/entryAutoInit.test.js
+++ b/tests/unit/highlighter/entryAutoInit.test.js
@@ -408,4 +408,55 @@ describe('entryAutoInit', () => {
     changedHandler({ highlightStyle: { newValue: 'underline' } }, 'sync');
     expect(globalThis.HighlighterV2.manager.updateStyleMode).toHaveBeenCalledWith('underline');
   });
+
+  // ─── Step 0.3 Regression Tests ───────────────────────────────────────────
+  // 驗證：SET_STABLE_URL 先到時，checkPageStatus 回傳的 stableUrl 不應覆蓋它。
+  // 修復前此測試應 FAIL，因為 resolvedStableUrl = pageStatus?.stableUrl || stableUrlState.value
+  // 讓 pageStatus 的值優先。
+  test('[REGRESSION] SET_STABLE_URL 已到達時，checkPageStatus 的 stableUrl 不應覆蓋', async () => {
+    const stableUrlFromRuntime = 'https://example.com/runtime-stable'; // 較早到達的 runtime 訊息
+    const stableUrlFromPageStatus = 'https://example.com/page-status-stable'; // 較弱的 checkPageStatus 來源
+
+    // 模擬 checkPageStatus 同步返回，並有 stableUrl
+    globalThis.chrome.runtime.sendMessage.mockResolvedValueOnce({
+      isSaved: true,
+      stableUrl: stableUrlFromPageStatus,
+    });
+    globalThis.chrome.storage.sync.get.mockResolvedValueOnce({ highlightStyle: 'background' });
+
+    require('../../../scripts/highlighter/entryAutoInit.js');
+
+    // 在 Promise.all 之前模擬 SET_STABLE_URL 先到
+    const waitForStableUrlHandler = runtimeMessageHandlers[0];
+    waitForStableUrlHandler({
+      action: 'SET_STABLE_URL',
+      stableUrl: stableUrlFromRuntime,
+    });
+
+    jest.runAllTimers();
+    await flushAsyncSetup();
+
+    // 修復後：應使用 stableUrlFromRuntime（SET_STABLE_URL 優先）
+    // 修復前：會使用 stableUrlFromPageStatus（pageStatus 優先）
+    expect(globalThis.__NOTION_STABLE_URL__).toBe(stableUrlFromRuntime);
+  });
+
+  test('[REGRESSION] SET_STABLE_URL 未到達時，應 fallback 到 checkPageStatus 的 stableUrl', async () => {
+    // 這個測試確保移除優先權不會破壞基本 fallback 邏輯
+    const stableUrlFromPageStatus = 'https://example.com/page-status-only';
+
+    globalThis.chrome.runtime.sendMessage.mockResolvedValueOnce({
+      isSaved: true,
+      stableUrl: stableUrlFromPageStatus,
+    });
+    globalThis.chrome.storage.sync.get.mockResolvedValueOnce({});
+
+    require('../../../scripts/highlighter/entryAutoInit.js');
+    // 不觸發 SET_STABLE_URL 訊息
+    jest.runAllTimers();
+    await flushAsyncSetup();
+
+    // 應使用 pageStatus.stableUrl 作為 fallback
+    expect(globalThis.__NOTION_STABLE_URL__).toBe(stableUrlFromPageStatus);
+  });
 });

--- a/tests/unit/sidepanel/sidepanel.test.js
+++ b/tests/unit/sidepanel/sidepanel.test.js
@@ -353,28 +353,25 @@ describe('Sidepanel JS Logic', () => {
     // ─── Step 0.4 Alignment Tests ─────────────────────────────────────────────
     // 驗證：sidepanel 的查找路徑與 HighlightStorageGateway.loadHighlights() 一致。
     // 使用同一個 shortlink/permalink regression fixture。
-    it('[ALIGNMENT] alias 指向 stableUrl 但 page_<stableUrl> 缺資料時，sidepanel 應能命中 page_<originalUrl>', async () => {
-      // 此 fixture 與 HighlightStorageGateway.extended.test.js Step 0.1 一致
-      // stableUrl = shortlink，originalUrl = permalink
-      // url_alias: originalUrl -> stableUrl（已被 TabService fallback 補寫）
-      // page_<stableUrl> 不存在，page_<originalUrl> 有資料
+    it('[ALIGNMENT] 當 page_<stableUrl> 缺資料時，sidepanel 應回退讀取 page_<originalUrl>', async () => {
+      const stableUrl = 'https://example.js/stable';
+      const originalTabUrl = 'https://example.js/original-permalink?utm_source=test#frag';
+      const normalizedOriginalUrl = 'https://example.js/original-permalink';
 
-      // sidepanel 的當前 tab URL 為 https://example.js/stable（由 sendMessage 回傳）
-      // 我們模擬 alias 指向 stableUrl，但 stableUrl 查無資料
-      const stableAlias = 'https://example.js/stable'; // 被 url_alias 指向的 stableUrl
-      const originalPermalink = 'https://example.js/original-permalink'; // 資料實際所在
+      normalizeUrl.mockImplementation(url =>
+        url === originalTabUrl ? normalizedOriginalUrl : url
+      );
+      chrome.tabs.get.mockResolvedValueOnce({ id: 500, url: originalTabUrl });
+      chrome.tabs.sendMessage.mockResolvedValueOnce({ stableUrl });
 
       const fakeStore = {
-        // alias 指向 stableUrl
-        'url_alias:https://example.js/stable': stableAlias,
-        // page_<stableUrl> 無資料（刻意省略）
-        // page_<original> 有資料
-        [`page_${originalPermalink}`]: {
+        [`page_${normalizedOriginalUrl}`]: {
           highlights: [{ id: '1', text: 'alignment test', color: 'blue' }],
           notion: { pageId: 'page-align' },
         },
       };
 
+      chrome.storage.local.get.mockClear();
       chrome.storage.local.get.mockImplementation(async k => {
         if (typeof k === 'string') {
           return { [k]: fakeStore[k] };
@@ -398,17 +395,21 @@ describe('Sidepanel JS Logic', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // 注意：sidepanel 目前若只走 alias 路徑而 stableUrl 無資料，可能顯示 empty state。
-      // 修復後此測試應驗證：當 page_<normalizedStableUrl> miss 時能進一步查 page_<originalUrl>。
-      // 目前記錄現狀（若修復前 sidepanel 已有此能力則 PASS，否則 FAIL 代表需要同步修復）。
       const highlightsList = document.querySelector('#highlights-list');
       const emptyState = document.querySelector('#empty-state');
+      const syncButton = document.querySelector('#sync-button');
 
-      // 此測試的主要目的是記錄對齊基線——若任一路徑修復後這裡應 PASS
-      const hasHighlights = highlightsList.children.length > 0;
-      const hasEmptyState = emptyState.style.display === 'flex';
-      // 至少其中一種狀態應該是確定的（不應同時為 none 的 undefined 狀態）
-      expect(hasHighlights || hasEmptyState).toBe(true);
+      expect(chrome.storage.local.get).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          `page_${stableUrl}`,
+          `page_${normalizedOriginalUrl}`,
+          `highlights_${stableUrl}`,
+          `highlights_${normalizedOriginalUrl}`,
+        ])
+      );
+      expect(highlightsList.children).toHaveLength(1);
+      expect(emptyState.style.display).toBe('none');
+      expect(syncButton.dataset.targetUrl).toBe(normalizedOriginalUrl);
     });
   });
 

--- a/tests/unit/sidepanel/sidepanel.test.js
+++ b/tests/unit/sidepanel/sidepanel.test.js
@@ -349,6 +349,67 @@ describe('Sidepanel JS Logic', () => {
 
       expect(document.querySelector('#empty-state').style.display).toBe('flex');
     });
+
+    // ─── Step 0.4 Alignment Tests ─────────────────────────────────────────────
+    // 驗證：sidepanel 的查找路徑與 HighlightStorageGateway.loadHighlights() 一致。
+    // 使用同一個 shortlink/permalink regression fixture。
+    it('[ALIGNMENT] alias 指向 stableUrl 但 page_<stableUrl> 缺資料時，sidepanel 應能命中 page_<originalUrl>', async () => {
+      // 此 fixture 與 HighlightStorageGateway.extended.test.js Step 0.1 一致
+      // stableUrl = shortlink，originalUrl = permalink
+      // url_alias: originalUrl -> stableUrl（已被 TabService fallback 補寫）
+      // page_<stableUrl> 不存在，page_<originalUrl> 有資料
+
+      // sidepanel 的當前 tab URL 為 https://example.js/stable（由 sendMessage 回傳）
+      // 我們模擬 alias 指向 stableUrl，但 stableUrl 查無資料
+      const stableAlias = 'https://example.js/stable'; // 被 url_alias 指向的 stableUrl
+      const originalPermalink = 'https://example.js/original-permalink'; // 資料實際所在
+
+      const fakeStore = {
+        // alias 指向 stableUrl
+        'url_alias:https://example.js/stable': stableAlias,
+        // page_<stableUrl> 無資料（刻意省略）
+        // page_<original> 有資料
+        [`page_${originalPermalink}`]: {
+          highlights: [{ id: '1', text: 'alignment test', color: 'blue' }],
+          notion: { pageId: 'page-align' },
+        },
+      };
+
+      chrome.storage.local.get.mockImplementation(async k => {
+        if (typeof k === 'string') {
+          return { [k]: fakeStore[k] };
+        }
+        if (Array.isArray(k)) {
+          const result = {};
+          for (const key of k) {
+            if (fakeStore[key]) {
+              result[key] = fakeStore[key];
+            }
+          }
+          return result;
+        }
+        return fakeStore;
+      });
+
+      const onActivated = chrome.tabs.onActivated.addListener.mock.calls[0][0];
+      await onActivated({ tabId: 500 });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // 注意：sidepanel 目前若只走 alias 路徑而 stableUrl 無資料，可能顯示 empty state。
+      // 修復後此測試應驗證：當 page_<normalizedStableUrl> miss 時能進一步查 page_<originalUrl>。
+      // 目前記錄現狀（若修復前 sidepanel 已有此能力則 PASS，否則 FAIL 代表需要同步修復）。
+      const highlightsList = document.querySelector('#highlights-list');
+      const emptyState = document.querySelector('#empty-state');
+
+      // 此測試的主要目的是記錄對齊基線——若任一路徑修復後這裡應 PASS
+      const hasHighlights = highlightsList.children.length > 0;
+      const hasEmptyState = emptyState.style.display === 'flex';
+      // 至少其中一種狀態應該是確定的（不應同時為 none 的 undefined 狀態）
+      expect(hasHighlights || hasEmptyState).toBe(true);
+    });
   });
 
   describe('User Interactions', () => {


### PR DESCRIPTION
- 移除自動補寫 url_alias 的副作用，以避免在 stableUrl miss 時錯誤地信任 alias，導致 highlights 恢復失敗。
- 更新 HighlightStorageGateway 以同時查詢 stableUrl 和 normalizedUrl，確保在資料缺失時能正確回退到原始 URL。
- 調整 entryAutoInit 中的穩定 URL 設置邏輯，確保 SET_STABLE_URL 的優先權高於來自 pageStatus 的 stableUrl。
- 增加多個回歸測試，確保在不同情境下的資料查詢邏輯正確性，並驗證 sidepanel 的查找路徑與 HighlightStorageGateway 一致。