### PR TITLE
fix: support camelCase for sourceInstallationId and sourceProfileId

### DIFF
--- a/scripts/auth/driveClient.js
+++ b/scripts/auth/driveClient.js
@@ -333,6 +333,34 @@ export async function setLastKnownRemoteUpdatedAt(updatedAt) {
 // =============================================================================
 
 /**
+ * 在 backend API 改名遷移期間，依 priority 從 JSON response 取出第一個非 nullish 的欄位。
+ *
+ * 用途：後端正將部分欄位從 snake_case 過渡到 camelCase（例如
+ * `remote_updated_at` → `remoteUpdatedAt`），過渡期 extension 必須同時相容
+ * 兩種命名。集中於 helper 後，未來新增/移除欄位只需修改一處；遷移完成後 grep
+ * `coalesce(` 即可定位所有待清理的 callsite。
+ *
+ * 使用範例：`coalesce(json, 'remote_updated_at', 'remoteUpdatedAt', 'updatedAt')`
+ *
+ * @template T
+ * @param {Record<string, T>} source - 原始 JSON 物件
+ * @param {...string} keys - 由舊到新（或由 snake_case 到 camelCase）的欄位優先順序
+ * @returns {T | null} 第一個非 nullish 的值；全部缺席時回傳 null
+ */
+function coalesce(source, ...keys) {
+  if (source == null) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
  * 取得 account auth headers；若無 Bearer token，直接提示使用者重新登入。
  *
  * @returns {Promise<{ Authorization: string }>}
@@ -374,8 +402,8 @@ export async function fetchDriveConnectionStatus() {
   const json = await res.json();
   return {
     connected: true,
-    email: json.provider_account_email ?? json.providerAccountEmail ?? json.email ?? null,
-    connectedAt: json.connected_at ?? json.connectedAt ?? null,
+    email: coalesce(json, 'provider_account_email', 'providerAccountEmail', 'email'),
+    connectedAt: coalesce(json, 'connected_at', 'connectedAt'),
   };
 }
 
@@ -410,17 +438,16 @@ export async function fetchDriveSnapshotStatus() {
   }
 
   const json = await res.json();
+  // 集中解析 timestamp 與 hasSnapshot，避免 fallback chain 散落兩處。
+  const updatedAt = coalesce(json, 'remote_updated_at', 'remoteUpdatedAt', 'updatedAt');
+  const hasSnapshot = json.has_snapshot === true || json.hasSnapshot === true || Boolean(updatedAt);
+
   return {
-    exists:
-      json.has_snapshot === true ||
-      json.hasSnapshot === true ||
-      Boolean(json.remote_updated_at) ||
-      Boolean(json.remoteUpdatedAt) ||
-      Boolean(json.updatedAt),
-    updatedAt: json.remote_updated_at ?? json.remoteUpdatedAt ?? json.updatedAt ?? null,
+    exists: hasSnapshot,
+    updatedAt,
     size: json.size ?? null,
-    sourceInstallationId: json.source_installation_id ?? json.sourceInstallationId ?? null,
-    sourceProfileId: json.source_profile_id ?? json.sourceProfileId ?? null,
+    sourceInstallationId: coalesce(json, 'source_installation_id', 'sourceInstallationId'),
+    sourceProfileId: coalesce(json, 'source_profile_id', 'sourceProfileId'),
   };
 }
 
@@ -460,7 +487,7 @@ export async function uploadDriveSnapshot(snapshotPayload, force = false, option
       success: false,
       errorCode: json.code ?? DRIVE_SYNC_ERROR_CODES.REMOTE_SNAPSHOT_NEWER,
       message: json.message ?? 'Remote snapshot is newer',
-      remoteUpdatedAt: json.remote_updated_at ?? json.updatedAt ?? null,
+      remoteUpdatedAt: coalesce(json, 'remote_updated_at', 'updatedAt'),
     };
   }
 

--- a/scripts/auth/driveClient.js
+++ b/scripts/auth/driveClient.js
@@ -412,11 +412,15 @@ export async function fetchDriveSnapshotStatus() {
   const json = await res.json();
   return {
     exists:
-      json.has_snapshot === true || Boolean(json.remote_updated_at) || Boolean(json.updatedAt),
-    updatedAt: json.remote_updated_at ?? json.updatedAt ?? null,
+      json.has_snapshot === true ||
+      json.hasSnapshot === true ||
+      Boolean(json.remote_updated_at) ||
+      Boolean(json.remoteUpdatedAt) ||
+      Boolean(json.updatedAt),
+    updatedAt: json.remote_updated_at ?? json.remoteUpdatedAt ?? json.updatedAt ?? null,
     size: json.size ?? null,
-    sourceInstallationId: json.source_installation_id ?? null,
-    sourceProfileId: json.source_profile_id ?? null,
+    sourceInstallationId: json.source_installation_id ?? json.sourceInstallationId ?? null,
+    sourceProfileId: json.source_profile_id ?? json.sourceProfileId ?? null,
   };
 }
 

--- a/tests/unit/driveClient.test.js
+++ b/tests/unit/driveClient.test.js
@@ -459,12 +459,45 @@ describe('Drive Client API', () => {
         expect(res.sourceProfileId).toBe('profile-camel');
       });
 
+      it('source_installation_id / source_profile_id 應優先於 camelCase 對應欄位', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            has_snapshot: true,
+            remote_updated_at: 'time',
+            source_installation_id: 'install-snake',
+            sourceInstallationId: 'install-camel',
+            source_profile_id: 'profile-snake',
+            sourceProfileId: 'profile-camel',
+          }),
+        });
+
+        const res = await fetchDriveSnapshotStatus();
+        expect(res.sourceInstallationId).toBe('install-snake');
+        expect(res.sourceProfileId).toBe('profile-snake');
+      });
+
       it('可解析 camelCase 的 hasSnapshot / remoteUpdatedAt', async () => {
         mockFetch.mockResolvedValue({
           ok: true,
           status: 200,
           json: async () => ({
             hasSnapshot: true,
+            remoteUpdatedAt: 'time-remote-camel',
+          }),
+        });
+
+        const res = await fetchDriveSnapshotStatus();
+        expect(res.exists).toBe(true);
+        expect(res.updatedAt).toBe('time-remote-camel');
+      });
+
+      it('exists 應在僅有 camelCase remoteUpdatedAt 時為 true', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
             remoteUpdatedAt: 'time-remote-camel',
           }),
         });

--- a/tests/unit/driveClient.test.js
+++ b/tests/unit/driveClient.test.js
@@ -440,6 +440,40 @@ describe('Drive Client API', () => {
         expect(res.sourceProfileId).toBe('profile-xyz');
       });
 
+      it('可解析 camelCase 的 sourceInstallationId / sourceProfileId', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            hasSnapshot: true,
+            updatedAt: 'time-camel',
+            sourceInstallationId: 'install-camel',
+            sourceProfileId: 'profile-camel',
+          }),
+        });
+
+        const res = await fetchDriveSnapshotStatus();
+        expect(res.exists).toBe(true);
+        expect(res.updatedAt).toBe('time-camel');
+        expect(res.sourceInstallationId).toBe('install-camel');
+        expect(res.sourceProfileId).toBe('profile-camel');
+      });
+
+      it('可解析 camelCase 的 hasSnapshot / remoteUpdatedAt', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            hasSnapshot: true,
+            remoteUpdatedAt: 'time-remote-camel',
+          }),
+        });
+
+        const res = await fetchDriveSnapshotStatus();
+        expect(res.exists).toBe(true);
+        expect(res.updatedAt).toBe('time-remote-camel');
+      });
+
       it('缺少 source_installation_id 欄位時回傳 sourceInstallationId: null', async () => {
         mockFetch.mockResolvedValue({
           ok: true,


### PR DESCRIPTION
### 摘要
更新 `fetchDriveSnapshotStatus` 函數以支援 camelCase 格式的欄位，並新增測試案例以驗證解析能力。

### 變更內容
- 支援 `sourceInstallationId` 和 `sourceProfileId` 的 camelCase 格式。
- 更新邏輯以處理 `hasSnapshot` 和 `remoteUpdatedAt` 的 camelCase 格式。
- 確保在缺少欄位時，正確回傳 null 值。

### 測試方式
新增測試案例以驗證對 camelCase 欄位的解析能力。

### 潛在風險
無顯著風險.

