### PR TITLE
fix: Improve OAuth error handling and messages

### DIFF
--- a/options/AuthManager.js
+++ b/options/AuthManager.js
@@ -548,9 +548,9 @@ export class AuthManager {
         errorMsg = `Notion 授權失敗 (${oauthError})，請確認 Integration 設定正確`;
       }
     } else if (errorCode === 'SERVER_MISCONFIGURATION') {
-      errorMsg = 'OAuth 伺服器設定異常，請稍後再試或聯絡開發者';
+      errorMsg = UI_MESSAGES.AUTH.OAUTH_SERVER_MISCONFIGURATION;
     } else if (errorCode === 'INVALID_REDIRECT_URI' || isRedirectError) {
-      errorMsg = 'OAuth redirect URI 設定不符，請確認伺服器與 Notion 整合設定';
+      errorMsg = UI_MESSAGES.AUTH.OAUTH_INVALID_REDIRECT_URI;
     } else if (error?.code === 'oauth_identity_unavailable') {
       errorMsg = UI_MESSAGES.AUTH.OAUTH_UNAVAILABLE;
     } else {

--- a/options/AuthManager.js
+++ b/options/AuthManager.js
@@ -467,9 +467,13 @@ export class AuthManager {
 
     if (!tokenResponse.ok) {
       const errorData = await tokenResponse.json().catch(() => ({}));
-      throw new Error(
+      const error = new Error(
         errorData.message || errorData.error || `Token 交換失敗 (${tokenResponse.status})`
       );
+      if (typeof errorData.error_code === 'string' && errorData.error_code.trim()) {
+        error.code = errorData.error_code;
+      }
+      throw error;
     }
 
     const tokenData = await tokenResponse.json();
@@ -527,6 +531,7 @@ export class AuthManager {
       error: sanitizeApiError(error, 'oauth_flow'),
     });
     const msg = error?.message ?? '';
+    const errorCode = typeof error?.code === 'string' ? error.code : '';
     const msgLower = msg.toLowerCase();
     const isOAuthCallbackError = msg.startsWith('Notion 授權失敗:');
     const isRedirectError =
@@ -542,7 +547,9 @@ export class AuthManager {
       } else {
         errorMsg = `Notion 授權失敗 (${oauthError})，請確認 Integration 設定正確`;
       }
-    } else if (isRedirectError) {
+    } else if (errorCode === 'SERVER_MISCONFIGURATION') {
+      errorMsg = 'OAuth 伺服器設定異常，請稍後再試或聯絡開發者';
+    } else if (errorCode === 'INVALID_REDIRECT_URI' || isRedirectError) {
       errorMsg = 'OAuth redirect URI 設定不符，請確認伺服器與 Notion 整合設定';
     } else if (error?.code === 'oauth_identity_unavailable') {
       errorMsg = UI_MESSAGES.AUTH.OAUTH_UNAVAILABLE;

--- a/scripts/config/shared/messages.js
+++ b/scripts/config/shared/messages.js
@@ -35,6 +35,8 @@ const AUTH = {
   NOTIFY_SUCCESS: 'Notion 連接成功！',
   NOTIFY_ERROR: 'Notion 連接失敗，請重試。',
   OAUTH_TARGET_REQUIRED: '已連接 Notion，下一步請選擇保存目標並按儲存。',
+  OAUTH_SERVER_MISCONFIGURATION: 'OAuth 伺服器設定異常，請稍後再試或聯絡開發者',
+  OAUTH_INVALID_REDIRECT_URI: 'OAuth redirect URI 設定不符，請確認伺服器與 Notion 整合設定',
 
   OPENING_NOTION: '正在打開 Notion...',
   OPEN_NOTION_FAILED: error => `打開 Notion 頁面失敗: ${error}`,

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -777,6 +777,54 @@ describe('AuthManager Extended', () => {
       });
     });
 
+    test('token exchange 回傳 INVALID_REDIRECT_URI 時應顯示 redirect mismatch 訊息', async () => {
+      jest.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('state-invalid-redirect');
+      chrome.identity.launchWebAuthFlow.mockResolvedValueOnce(
+        'https://mocked.chromiumapp.org/?code=oauth_code_invalid_redirect&state=state-invalid-redirect'
+      );
+      chrome.storage.session.get.mockResolvedValueOnce({ oauthState: 'state-invalid-redirect' });
+      globalThis.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: jest.fn().mockResolvedValue({
+          error_code: 'INVALID_REDIRECT_URI',
+          message: 'Invalid redirect_uri',
+        }),
+      });
+
+      await authManager.startOAuthFlow();
+
+      expect(mockUiManager.showStatus).toHaveBeenCalledWith(
+        'OAuth 連接失敗：OAuth redirect URI 設定不符，請確認伺服器與 Notion 整合設定',
+        'error'
+      );
+    });
+
+    test('token exchange 回傳 SERVER_MISCONFIGURATION 時應顯示伺服器設定異常訊息', async () => {
+      jest.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('state-server-misconfiguration');
+      chrome.identity.launchWebAuthFlow.mockResolvedValueOnce(
+        'https://mocked.chromiumapp.org/?code=oauth_code_server_error&state=state-server-misconfiguration'
+      );
+      chrome.storage.session.get.mockResolvedValueOnce({
+        oauthState: 'state-server-misconfiguration',
+      });
+      globalThis.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValue({
+          error_code: 'SERVER_MISCONFIGURATION',
+          message: 'Server misconfiguration: invalid NOTION_REDIRECT_URI',
+        }),
+      });
+
+      await authManager.startOAuthFlow();
+
+      expect(mockUiManager.showStatus).toHaveBeenCalledWith(
+        'OAuth 連接失敗：OAuth 伺服器設定異常，請稍後再試或聯絡開發者',
+        'error'
+      );
+    });
+
     test('CSRF 驗證失敗時應顯示錯誤且恢復按鈕', async () => {
       jest.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('state-abc');
       chrome.identity.launchWebAuthFlow.mockResolvedValueOnce(

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -795,7 +795,7 @@ describe('AuthManager Extended', () => {
       await authManager.startOAuthFlow();
 
       expect(mockUiManager.showStatus).toHaveBeenCalledWith(
-        'OAuth 連接失敗：OAuth redirect URI 設定不符，請確認伺服器與 Notion 整合設定',
+        `OAuth 連接失敗：${UI_MESSAGES.AUTH.OAUTH_INVALID_REDIRECT_URI}`,
         'error'
       );
     });
@@ -820,7 +820,7 @@ describe('AuthManager Extended', () => {
       await authManager.startOAuthFlow();
 
       expect(mockUiManager.showStatus).toHaveBeenCalledWith(
-        'OAuth 連接失敗：OAuth 伺服器設定異常，請稍後再試或聯絡開發者',
+        `OAuth 連接失敗：${UI_MESSAGES.AUTH.OAUTH_SERVER_MISCONFIGURATION}`,
         'error'
       );
     });


### PR DESCRIPTION
### 摘要
修正 OAuth 錯誤處理邏輯，提供更具體的錯誤訊息。

### 變更內容
- 新增對於 token 交換失敗時的錯誤碼處理。
- 當錯誤碼為 'INVALID_REDIRECT_URI' 時，顯示相應的錯誤訊息，提示用戶檢查伺服器設定。
- 當錯誤碼為 'SERVER_MISCONFIGURATION' 時，顯示伺服器設定異常的提示，建議用戶稍後再試或聯絡開發者。

### 測試方式
已新增測試案例以驗證錯誤處理邏輯。

### 潛在風險
無顯著風險。

