### PR TITLE
fix: Improve C++ term detection in page complexity analysis

### DIFF
--- a/scripts/utils/pageComplexityDetector.js
+++ b/scripts/utils/pageComplexityDetector.js
@@ -126,6 +126,17 @@ const TECHNICAL_TERMS = [
   'version',
 ];
 
+const WORD_CHAR_ONLY = /^\w+$/;
+
+/** 預編譯 technical term regex：純 word term 用 \b，含非 word char 的 term 用 lookaround */
+const TECHNICAL_TERM_REGEXES = TECHNICAL_TERMS.map(term => {
+  const escaped = term.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
+  if (WORD_CHAR_ONLY.test(term)) {
+    return new RegExp(String.raw`\b${escaped}\b`, 'gi');
+  }
+  return new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`, 'gi');
+});
+
 /**
  * 頁面複雜度檢測器
  *
@@ -231,13 +242,9 @@ function countElements(container, selector) {
 function hasTechnicalFeatures(document) {
   const textContent = (document.body?.textContent || '').toLowerCase();
 
-  // 技術關鍵詞計數 (使用統一配置)
   let technicalTermCount = 0;
-  for (const term of TECHNICAL_TERMS) {
-    // Escape special characters in the term to support terms like 'c++'
-    const escapedTerm = term.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
-    /* eslint-disable-next-line security/detect-non-literal-regexp */
-    const regex = new RegExp(String.raw`\b${escapedTerm}\b`, 'gi');
+  for (const regex of TECHNICAL_TERM_REGEXES) {
+    regex.lastIndex = 0;
     const termMatches = textContent.match(regex);
     technicalTermCount += termMatches ? termMatches.length : 0;
   }

--- a/tests/unit/pageComplexityDetector.test.js
+++ b/tests/unit/pageComplexityDetector.test.js
@@ -495,9 +495,8 @@ describe('頁面複雜度檢測器', () => {
     test('"objective-c++ish" should NOT match as standalone c++', () => {
       document.documentElement.innerHTML =
         '<body><article><p>objective-c++ish is not a real language</p></article></body>';
-      const text = document.body.textContent.toLowerCase();
-      const cppMatches = (text.match(/(?<![a-z0-9_])c\+\+(?![a-z0-9_])/gi) || []).length;
-      expect(cppMatches).toBe(0);
+      const result = detectPageComplexity(document);
+      expect(result.technicalFeatures.technicalTermCount).toBe(0);
     });
 
     test('c++ technical term should contribute to hasTechnicalContent', () => {

--- a/tests/unit/pageComplexityDetector.test.js
+++ b/tests/unit/pageComplexityDetector.test.js
@@ -470,6 +470,45 @@ describe('頁面複雜度檢測器', () => {
     });
   });
 
+  describe('Technical term boundary regression (c++)', () => {
+    test('standalone "c++" token should be detected as technical term', () => {
+      document.documentElement.innerHTML =
+        '<body><article><p>Learn c++ programming with modern c++ features and c++ templates</p></article></body>';
+      const result = detectPageComplexity(document);
+      expect(result.technicalFeatures.technicalTermCount).toBeGreaterThanOrEqual(3);
+    });
+
+    test('"c++" at end of text should be detected', () => {
+      document.documentElement.innerHTML =
+        '<body><article><p>This guide covers c++</p></article></body>';
+      const result = detectPageComplexity(document);
+      expect(result.technicalFeatures.technicalTermCount).toBeGreaterThanOrEqual(1);
+    });
+
+    test('"c++" followed by space should be detected', () => {
+      document.documentElement.innerHTML =
+        '<body><article><p>c++ is a powerful language</p></article></body>';
+      const result = detectPageComplexity(document);
+      expect(result.technicalFeatures.technicalTermCount).toBeGreaterThanOrEqual(1);
+    });
+
+    test('"objective-c++ish" should NOT match as standalone c++', () => {
+      document.documentElement.innerHTML =
+        '<body><article><p>objective-c++ish is not a real language</p></article></body>';
+      const text = document.body.textContent.toLowerCase();
+      const cppMatches = (text.match(/(?<![a-z0-9_])c\+\+(?![a-z0-9_])/gi) || []).length;
+      expect(cppMatches).toBe(0);
+    });
+
+    test('c++ technical term should contribute to hasTechnicalContent', () => {
+      document.documentElement.innerHTML =
+        '<body><article><p>c++ c++ c++ c++ c++ c++ c++ c++ c++ c++ c++ short text</p></article></body>';
+      const result = detectPageComplexity(document);
+      expect(result.technicalFeatures.isTechnical).toBe(true);
+      expect(result.hasTechnicalContent).toBe(true);
+    });
+  });
+
   describe('Coverage 補強', () => {
     test('detectPageComplexity 應該在例外時回退到安全預設值', () => {
       const badDoc = {


### PR DESCRIPTION
### 摘要
修正 C++ 技術術語的檢測邊界問題，確保能正確識別包含非字元的術語。

### 變更內容
- 使用 lookaround 邊界替代 `\b` 來處理包含非字元的術語，如 `c++`。
- 在模組範圍內預編譯技術術語的正則表達式，根據術語類型選擇不同的匹配策略。
- 增加回歸測試以驗證獨立的 `c++` 檢測及對嵌入子字串的誤判拒絕。

### 測試方式
已新增測試用例以驗證 C++ 的獨立檢測及邊界情況。

### 潛在風險
無顯著風險。

