### PR TITLE
refactor: Improve tests and stability for `mergeDataSourceConfig`

### DIFF
--- a/scripts/config/shared/storage.js
+++ b/scripts/config/shared/storage.js
@@ -56,9 +56,11 @@ export const LOCAL_STORAGE_KEYS = new Set(DATA_SOURCE_KEYS);
  * 合併後的 data source 設定。
  */
 export function mergeDataSourceConfig(localData = {}, syncData = {}) {
+  const safeLocal = localData || {};
+  const safeSync = syncData || {};
   return {
-    notionDataSourceId: localData.notionDataSourceId || syncData.notionDataSourceId,
-    notionDatabaseId: localData.notionDatabaseId || syncData.notionDatabaseId,
-    notionDataSourceType: localData.notionDataSourceType || syncData.notionDataSourceType,
+    notionDataSourceId: safeLocal.notionDataSourceId || safeSync.notionDataSourceId,
+    notionDatabaseId: safeLocal.notionDatabaseId || safeSync.notionDatabaseId,
+    notionDataSourceType: safeLocal.notionDataSourceType || safeSync.notionDataSourceType,
   };
 }

--- a/tests/unit/config/storageKeys.test.js
+++ b/tests/unit/config/storageKeys.test.js
@@ -68,5 +68,50 @@ describe('配置模組 - storageKeys.js', () => {
         notionDataSourceType: undefined,
       });
     });
+
+    test('當 local 設定為 falsy (如空字串) 時，應回退使用 sync 設定', () => {
+      const local = {
+        notionDataSourceId: '',
+        notionDatabaseId: null,
+        notionDataSourceType: false,
+      };
+      const sync = {
+        notionDataSourceId: 'sync-id',
+        notionDatabaseId: 'sync-db',
+        notionDataSourceType: 'database',
+      };
+      expect(mergeDataSourceConfig(local, sync)).toEqual({
+        notionDataSourceId: 'sync-id',
+        notionDatabaseId: 'sync-db',
+        notionDataSourceType: 'database',
+      });
+    });
+
+    test('當 local 與 sync 包含無關緊要的屬性時，應只回傳目標欄位 (過濾多餘屬性)', () => {
+      const local = {
+        notionDataSourceId: 'local-id',
+        extraLocalProp: 'should-be-ignored',
+      };
+      const sync = {
+        notionDataSourceId: 'sync-id',
+        notionDatabaseId: 'sync-db',
+        notionDataSourceType: 'database',
+        extraSyncProp: 'should-also-be-ignored',
+      };
+      expect(mergeDataSourceConfig(local, sync)).toEqual({
+        notionDataSourceId: 'local-id',
+        notionDatabaseId: 'sync-db',
+        notionDataSourceType: 'database',
+      });
+    });
+
+    test('輸入 null 參數時應優雅降級不拋錯', () => {
+      expect(() => mergeDataSourceConfig(null, null)).not.toThrow();
+      expect(mergeDataSourceConfig(null, null)).toEqual({
+        notionDataSourceId: undefined,
+        notionDatabaseId: undefined,
+        notionDataSourceType: undefined,
+      });
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** Add missing unit tests for `mergeDataSourceConfig` edge cases and gracefully handle `null` arguments. The original implementation would throw a `TypeError` when explicitly passed `null`.
📊 **Coverage:** Falsy local config values, extra/irrelevant object properties in arguments, and gracefully handle `null` arguments.
✨ **Result:** Improved system reliability and improved test coverage.

---
*PR created automatically by Jules for task [10627551960572517833](https://jules.google.com/task/10627551960572517833) started by @cowcfj*