### PR TITLE
chore: Remove deprecated injectGlobalStyles no-op function

### DIFF
--- a/scripts/highlighter/ui/styles/toolbarStyles.js
+++ b/scripts/highlighter/ui/styles/toolbarStyles.js
@@ -312,14 +312,3 @@ export function injectStylesIntoShadowRoot(shadowRoot) {
   style.textContent = css;
   shadowRoot.prepend(style);
 }
-
-/**
- * 向後相容的空函式（舊版 API，已不再注入到 document.head）。
- *
- * @deprecated 請改用 injectStylesIntoShadowRoot(shadowRoot)
- *
- * 樣式已改為在 Shadow DOM 中注入，這個函式僅保留為 no-op 相容入口。
- */
-export function injectGlobalStyles() {
-  // No-op：樣式現由 Toolbar.js 透過 Shadow DOM 注入
-}

--- a/tests/unit/highlighter/ui/Toolbar_actions.test.js
+++ b/tests/unit/highlighter/ui/Toolbar_actions.test.js
@@ -23,7 +23,6 @@ jest.mock('../../../../scripts/highlighter/ui/components/ColorPicker.js', () => 
 jest.mock('../../../../scripts/highlighter/ui/styles/toolbarStyles.js', () => ({
   injectStylesIntoShadowRoot: jest.fn(),
   getToolbarCSS: jest.fn(() => ''),
-  injectGlobalStyles: jest.fn(),
 }));
 
 // Mock ToolbarRuntime - 替代 Chrome runtime API 呼叫

--- a/tests/unit/highlighter/ui/Toolbar_edge-cases.test.js
+++ b/tests/unit/highlighter/ui/Toolbar_edge-cases.test.js
@@ -46,7 +46,6 @@ jest.mock('../../../../scripts/highlighter/ui/components/ColorPicker.js', () => 
 jest.mock('../../../../scripts/highlighter/ui/styles/toolbarStyles.js', () => ({
   injectStylesIntoShadowRoot: jest.fn(),
   getToolbarCSS: jest.fn(() => ''),
-  injectGlobalStyles: jest.fn(), // 向後相容
 }));
 
 // Mock ToolbarRuntime - 避免在測試中觸發真實 Chrome API

--- a/tests/unit/highlighter/ui/styles/toolbarStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toolbarStyles.test.js
@@ -111,13 +111,4 @@ describe('toolbarStyles', () => {
     expect(styleElement).toBeTruthy();
     expect(styleElement.textContent).toContain(':host');
   });
-
-  test('injectGlobalStyles 應保持 no-op 且不拋錯', () => {
-    const headChildrenCount = document.head.children.length;
-    // 透過 any 取得 legacy API，避免 IDE 對 @deprecated 簽名噪音
-    const legacyInjectGlobalStyles = /** @type {any} */ (toolbarStylesModule).injectGlobalStyles;
-
-    expect(() => legacyInjectGlobalStyles()).not.toThrow();
-    expect(document.head.children).toHaveLength(headChildrenCount);
-  });
 });


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `injectGlobalStyles` no-op function and its related mocks and tests from the codebase.
💡 **Why:** The function was an empty placeholder retained for backwards compatibility after the UI style injection strategy migrated to Shadow DOM. Removing this dead code simplifies the codebase, improves maintainability, and prevents developer confusion about how styles are managed.
✅ **Verification:** Verified by ensuring the code compiled, running `npm run lint`, and running `npm run test` (test failures present are unrelated).
✨ **Result:** Cleaned up `toolbarStyles.js` by removing obsolete legacy API stubs, resulting in a cleaner and more maintainable module.

---
*PR created automatically by Jules for task [6734545693909693365](https://jules.google.com/task/6734545693909693365) started by @cowcfj*