### PR TITLE
🧹 chore: Remove deprecated env.js module

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ vim scripts/highlighter/core/Range.js
 2. **申請 Notion Public Integration**：
    - 在 Notion Integrations 頁面建立一組 Public API，取得 `client_id`。
 3. **配置本地環境變數**：
-   - `scripts/config/env.js` 是被 Git 追蹤的 façade；首次執行 `npm install` 後，專案會自動將模板複製為 `scripts/config/env/build.js`。
+   - 首次執行 `npm install` 後，專案會自動將模板複製為 `scripts/config/env/build.js`。
    - 開啟 `scripts/config/env/build.js`，將尾段的 `BUILD_ENV` 區塊修改為您的專屬配置：
      ```javascript
      export const BUILD_ENV = Object.freeze({

--- a/examples/cloudflare-worker-oauth.js
+++ b/examples/cloudflare-worker-oauth.js
@@ -11,8 +11,8 @@
  *    - OAUTH_CLIENT_ID: 您的 Notion Public Integration Client ID
  *    - OAUTH_CLIENT_SECRET: 您的 Notion Public Integration Client Secret (⚠️ 設定為 Encrypt)
  *    - EXTENSION_API_KEY: 您自訂的安全金鑰，用於防止他人濫用這個代理伺服器 (⚠️ 設定為 Encrypt)
- * 4. 將 Worker 的網址（例如 https://notion-proxy.your-name.workers.dev）填入本地 env.js 的 OAUTH_SERVER_URL 中
- * 5. 將上述的 EXTENSION_API_KEY 填入本地 env.js 的 EXTENSION_API_KEY 中
+ * 4. 將 Worker 的網址（例如 https://notion-proxy.your-name.workers.dev）填入本地 scripts/config/env/build.js 的 OAUTH_SERVER_URL 中
+ * 5. 將上述的 EXTENSION_API_KEY 填入本地 scripts/config/env/build.js 的 EXTENSION_API_KEY 中
  */
 
 export default {

--- a/scripts/config/env.js
+++ b/scripts/config/env.js
@@ -1,9 +1,0 @@
-/**
- * 環境檢測與配置模組 Façade
- *
- * @deprecated 新增程式碼請直接匯入 './env/index.js'
- * 穩定的相容入口，保持向後相容，所有既有消費者仍可從此路徑匯入
- */
-
-export * from './env/index.js';
-export { default } from './env/index.js';

--- a/tests/unit/config/auth.callback-page.test.js
+++ b/tests/unit/config/auth.callback-page.test.js
@@ -24,7 +24,6 @@ describe('auth callback page regressions', () => {
   test('auth.js 應從 env/index.js 讀取 BUILD_ENV', () => {
     expect(authJs).toContain("import { BUILD_ENV } from '../config/env/index.js';");
     expect(authJs).not.toContain("import { BUILD_ENV } from '../config/env.example.js';");
-    expect(authJs).not.toContain("import { BUILD_ENV } from '../config/env.js';");
   });
 
   test('auth.html 應引用共用 callback stylesheet', () => {

--- a/tests/unit/config/env.test.js
+++ b/tests/unit/config/env.test.js
@@ -3,10 +3,10 @@
  */
 
 /**
- * env.js 配置測試
+ * env/index.js 配置測試
  */
 
-const envModule = require('../../../scripts/config/env.js');
+const envModule = require('../../../scripts/config/env/index.js');
 
 const {
   isExtensionContext,
@@ -30,7 +30,7 @@ function setWindow(value) {
   globalThis.window = value;
 }
 
-describe('配置模組 - env.js', () => {
+describe('配置模組 - env/index.js', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();

--- a/tests/unit/scripts/accountSession.test.js
+++ b/tests/unit/scripts/accountSession.test.js
@@ -12,6 +12,12 @@
  * @see scripts/auth/accountSession.js
  */
 
+jest.mock('../../../scripts/config/env/index.js', () => ({
+  BUILD_ENV: {
+    OAUTH_SERVER_URL: 'https://test-server.example.com',
+  },
+}));
+
 jest.mock('../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
   default: {

--- a/tests/unit/scripts/accountSession.test.js
+++ b/tests/unit/scripts/accountSession.test.js
@@ -13,6 +13,7 @@
  */
 
 jest.mock('../../../scripts/config/env/index.js', () => ({
+  __esModule: true,
   BUILD_ENV: {
     OAUTH_SERVER_URL: 'https://test-server.example.com',
   },

--- a/tools/package-extension.sh
+++ b/tools/package-extension.sh
@@ -119,7 +119,6 @@ rsync -a \
     --exclude='content' \
     --exclude='destinations/ProfileResolver.js' \
     --exclude='config/env/build.example.js' \
-    --exclude='config/env.js' \
     --exclude='config/extension/index.js' \
     --exclude='highlighter' \
     --exclude='legacy' \


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `scripts/config/env.js` module and updated all lingering references to point to `scripts/config/env/index.js` or `scripts/config/env/build.js` where appropriate.
💡 **Why:** To eliminate dead/deprecated code and improve clarity of the codebase. Previously `env.js` was kept as a facade for backwards compatibility but we no longer need it.
✅ **Verification:** Ran `npm run test` and `npm run build` locally. The main test referencing this module was updated to `env/index.js` and assertions pointing to the old facade were safely removed. 
✨ **Result:** A cleaner codebase without deprecated configuration entry points.

---
*PR created automatically by Jules for task [3997392366152051562](https://jules.google.com/task/3997392366152051562) started by @cowcfj*