### PR TITLE
feat: Optimize DOM operations for performance

### DIFF
--- a/popup/popupUI.js
+++ b/popup/popupUI.js
@@ -104,8 +104,10 @@ export function renderDestinationSelector(elements, state) {
     return;
   }
 
-  elements.destinationMenu.innerHTML = '';
+  elements.destinationMenu.replaceChildren();
   elements.destinationMenu.style.display = 'none';
+
+  const fragment = document.createDocumentFragment();
 
   for (const profile of profiles) {
     const item = document.createElement('button');
@@ -114,8 +116,10 @@ export function renderDestinationSelector(elements, state) {
     item.dataset.profileId = profile.id;
     item.textContent = formatDestinationLabel(profile);
     item.setAttribute('aria-pressed', profile.id === selectedProfile.id ? 'true' : 'false');
-    elements.destinationMenu.append(item);
+    fragment.append(item);
   }
+
+  elements.destinationMenu.append(fragment);
 }
 
 /**
@@ -127,7 +131,7 @@ export function renderDestinationSelector(elements, state) {
  */
 export function setStatus(elements, content, color = '') {
   if (elements.status) {
-    elements.status.innerHTML = '';
+    elements.status.replaceChildren();
     elements.status.style.color = color;
 
     // Support simple string

--- a/sidepanel/sidepanelUI.js
+++ b/sidepanel/sidepanelUI.js
@@ -263,8 +263,9 @@ export function hideMessage(elements) {
  * @param {(highlightId: string, storageKey: string) => void} onDelete - 刪除回調
  */
 export function renderList(elements, highlights, storageKey, onDelete) {
-  elements.highlightsList.textContent = '';
+  elements.highlightsList.replaceChildren();
   const highlightColorCache = buildHighlightColorCache();
+  const fragment = document.createDocumentFragment();
 
   highlights.forEach(hl => {
     const clone = elements.template.content.cloneNode(true);
@@ -281,8 +282,10 @@ export function renderList(elements, highlights, storageKey, onDelete) {
     // 綁定刪除事件（回調由呼叫端 sidepanel.js 的 handleDelete 提供）
     delBtn.addEventListener('click', () => onDelete(hl.id, storageKey));
 
-    elements.highlightsList.append(card);
+    fragment.append(card);
   });
+
+  elements.highlightsList.append(fragment);
 
   elements.loadingState.style.display = 'none';
   elements.emptyState.style.display = 'none';
@@ -349,7 +352,7 @@ export function renderUnsyncedEmptyState(elements) {
     return;
   }
 
-  container.textContent = '';
+  container.replaceChildren();
   const emptyMessage = document.createElement('p');
   emptyMessage.className = 'unsynced-empty';
   emptyMessage.textContent = UI_MESSAGES.SIDEPANEL.ALL_SYNCED;
@@ -388,6 +391,7 @@ export function appendCards(elements, pages, startIndex, count, callbacks) {
     return 0;
   }
   const batch = pages.slice(startIndex, startIndex + count);
+  const fragment = document.createDocumentFragment();
 
   batch.forEach(page => {
     const cardNode = template.content.cloneNode(true);
@@ -440,8 +444,10 @@ export function appendCards(elements, pages, startIndex, count, callbacks) {
       });
     }
 
-    container.append(card);
+    fragment.append(card);
   });
+
+  container.append(fragment);
 
   const renderedCount = batch.length;
   const hasMore = startIndex + renderedCount < pages.length;

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -35,7 +35,12 @@ describe('popupUI.js', () => {
         querySelector: jest.fn(),
         setAttribute: jest.fn(),
       },
-      status: { textContent: '', style: { color: '' } },
+      status: {
+        textContent: '',
+        style: { color: '' },
+        replaceChildren: jest.fn(),
+        append: jest.fn(),
+      },
       accountSection: { style: { display: 'none' }, classList: { toggle: jest.fn() } },
       accountStatus: {
         textContent: '',
@@ -52,7 +57,12 @@ describe('popupUI.js', () => {
       settingsLinkText: { textContent: '' },
       destinationSection: { style: { display: 'none' } },
       destinationCurrent: { textContent: '', style: {}, dataset: {} },
-      destinationMenu: { innerHTML: '', append: jest.fn(), style: { display: 'none' } },
+      destinationMenu: {
+        innerHTML: '',
+        append: jest.fn(),
+        replaceChildren: jest.fn(),
+        style: { display: 'none' },
+      },
       destinationToggle: {
         style: { display: 'none' },
         disabled: false,


### PR DESCRIPTION
### 摘要
優化 DOM 操作以提升性能，減少不必要的更新。

### 變更內容
- 使用 `replaceChildren` 取代 `innerHTML` 和 `append`，減少 DOM 更新次數。
- 在 `renderDestinationSelector` 和 `renderList` 函數中，使用 DocumentFragment 批量添加子元素，提升渲染效率。
- 更新測試以反映新的 DOM 操作方法，確保測試的準確性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

