### PR TITLE
feat: add save button icon toggle functionality

### DIFF
--- a/scripts/highlighter/ui/FloatingRailUI.js
+++ b/scripts/highlighter/ui/FloatingRailUI.js
@@ -8,6 +8,10 @@
 import { UI_MESSAGES } from '../../config/shared/messages.js';
 import { COLORS } from '../utils/color.js';
 import { hexToRgba } from '../../../styles/ui-token-constants.js';
+import { createSafeIcon } from '../../utils/securityUtils.js';
+import { RAIL_ICONS } from './components/FloatingRailContainer.js';
+
+const SAVE_ICON_SIZE = '18px';
 
 export function getRailElements(container) {
   const highlightBtn = container.querySelector('[data-action="highlight"]');
@@ -48,6 +52,30 @@ export function applySaveActionVisibility(saveBtn, pageStatus) {
     isSaved ? UI_MESSAGES.FLOATING_RAIL.SYNC_LABEL : UI_MESSAGES.FLOATING_RAIL.SAVE_LABEL
   );
   saveBtn.dataset.action = isSaved ? 'sync' : 'save';
+
+  swapSaveActionIcon(saveBtn, isSaved);
+}
+
+function swapSaveActionIcon(saveBtn, isSaved) {
+  const targetIconKey = isSaved ? 'sync' : 'save';
+  const currentSvg = saveBtn.querySelector('svg');
+  if (currentSvg?.dataset.railIcon === targetIconKey) {
+    return;
+  }
+
+  const nextIconWrapper = createSafeIcon(isSaved ? RAIL_ICONS.SYNC : RAIL_ICONS.NOTION);
+  const nextSvg = nextIconWrapper.querySelector('svg');
+  if (!nextSvg) {
+    return;
+  }
+  nextSvg.style.width = SAVE_ICON_SIZE;
+  nextSvg.style.height = SAVE_ICON_SIZE;
+
+  if (currentSvg) {
+    currentSvg.replaceWith(nextSvg);
+  } else {
+    saveBtn.prepend(nextSvg);
+  }
 }
 
 export function applySelectedColor(container, colorName) {

--- a/scripts/highlighter/ui/FloatingRailUI.js
+++ b/scripts/highlighter/ui/FloatingRailUI.js
@@ -58,23 +58,22 @@ export function applySaveActionVisibility(saveBtn, pageStatus) {
 
 function swapSaveActionIcon(saveBtn, isSaved) {
   const targetIconKey = isSaved ? 'sync' : 'save';
-  const currentSvg = saveBtn.querySelector('svg');
-  if (currentSvg?.dataset.railIcon === targetIconKey) {
+  const currentWrapper = saveBtn.querySelector('.icon');
+  if (currentWrapper?.querySelector('svg')?.dataset.railIcon === targetIconKey) {
     return;
   }
 
-  const nextIconWrapper = createSafeIcon(isSaved ? RAIL_ICONS.SYNC : RAIL_ICONS.NOTION);
-  const nextSvg = nextIconWrapper.querySelector('svg');
-  if (!nextSvg) {
+  const nextWrapper = createSafeIcon(isSaved ? RAIL_ICONS.SYNC : RAIL_ICONS.NOTION);
+  if (!nextWrapper.querySelector('svg')) {
     return;
   }
-  nextSvg.style.width = SAVE_ICON_SIZE;
-  nextSvg.style.height = SAVE_ICON_SIZE;
+  nextWrapper.style.width = SAVE_ICON_SIZE;
+  nextWrapper.style.height = SAVE_ICON_SIZE;
 
-  if (currentSvg) {
-    currentSvg.replaceWith(nextSvg);
+  if (currentWrapper) {
+    currentWrapper.replaceWith(nextWrapper);
   } else {
-    saveBtn.prepend(nextSvg);
+    saveBtn.prepend(nextWrapper);
   }
 }
 

--- a/scripts/highlighter/ui/FloatingRailUI.js
+++ b/scripts/highlighter/ui/FloatingRailUI.js
@@ -9,9 +9,7 @@ import { UI_MESSAGES } from '../../config/shared/messages.js';
 import { COLORS } from '../utils/color.js';
 import { hexToRgba } from '../../../styles/ui-token-constants.js';
 import { createSafeIcon } from '../../utils/securityUtils.js';
-import { RAIL_ICONS } from './components/FloatingRailContainer.js';
-
-const SAVE_ICON_SIZE = '18px';
+import { RAIL_ICONS, ICON_SIZE_SM } from './components/FloatingRailContainer.js';
 
 export function getRailElements(container) {
   const highlightBtn = container.querySelector('[data-action="highlight"]');
@@ -67,8 +65,8 @@ function swapSaveActionIcon(saveBtn, isSaved) {
   if (!nextWrapper.querySelector('svg')) {
     return;
   }
-  nextWrapper.style.width = SAVE_ICON_SIZE;
-  nextWrapper.style.height = SAVE_ICON_SIZE;
+  nextWrapper.style.width = ICON_SIZE_SM;
+  nextWrapper.style.height = ICON_SIZE_SM;
 
   if (currentWrapper) {
     currentWrapper.replaceWith(nextWrapper);

--- a/scripts/highlighter/ui/components/FloatingRailContainer.js
+++ b/scripts/highlighter/ui/components/FloatingRailContainer.js
@@ -10,7 +10,7 @@ import { createSafeIcon } from '../../../utils/securityUtils.js';
 
 const ARIA_LABEL = 'aria-label';
 const ACTION_BTN_CLASS = 'rail-action-btn';
-const ICON_SIZE_SM = '18px';
+export const ICON_SIZE_SM = '18px';
 const TRIGGER_ICON_SIZE = '22px';
 
 export const RAIL_ICONS = {

--- a/scripts/highlighter/ui/components/FloatingRailContainer.js
+++ b/scripts/highlighter/ui/components/FloatingRailContainer.js
@@ -13,12 +13,14 @@ const ACTION_BTN_CLASS = 'rail-action-btn';
 const ICON_SIZE_SM = '18px';
 const TRIGGER_ICON_SIZE = '22px';
 
-const RAIL_ICONS = {
+export const RAIL_ICONS = {
   CLOSE:
     '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>',
   // Save action — Heroicons solid `arrow-down-tray`，與 popup #save-button 同款
   NOTION:
-    '<svg viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12 2.25a.75.75 0 0 1 .75.75v11.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 1 1 1.06-1.06l3.22 3.22V3a.75.75 0 0 1 .75-.75Zm-9 13.5a.75.75 0 0 1 .75.75v2.25a1.5 1.5 0 0 0 1.5 1.5h13.5a1.5 1.5 0 0 0 1.5-1.5V16.5a.75.75 0 0 1 1.5 0v2.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V16.5a.75.75 0 0 1 .75-.75Z" clip-rule="evenodd"/></svg>',
+    '<svg viewBox="0 0 24 24" fill="currentColor" data-rail-icon="save"><path fill-rule="evenodd" d="M12 2.25a.75.75 0 0 1 .75.75v11.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 1 1 1.06-1.06l3.22 3.22V3a.75.75 0 0 1 .75-.75Zm-9 13.5a.75.75 0 0 1 .75.75v2.25a1.5 1.5 0 0 0 1.5 1.5h13.5a1.5 1.5 0 0 0 1.5-1.5V16.5a.75.75 0 0 1 1.5 0v2.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V16.5a.75.75 0 0 1 .75-.75Z" clip-rule="evenodd"/></svg>',
+  // Sync action — Heroicons solid `arrow-path`，已保存頁面切換為循環同步圖示
+  SYNC: '<svg viewBox="0 0 24 24" fill="currentColor" data-rail-icon="sync"><path fill-rule="evenodd" d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" clip-rule="evenodd"/></svg>',
   HIGHLIGHT:
     '<svg viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"><path d="M15.2 3.8l5 5L8.5 20.5 3 21l.5-5.5L15.2 3.8z"/></svg>',
   // Manage action — Heroicons solid `document-text`，與 popup #manage-button 同款

--- a/tests/unit/highlighter/ui/FloatingRailUI.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailUI.test.js
@@ -28,11 +28,17 @@ function createMockContainer() {
   saveBtn.className = 'rail-action-btn';
   saveBtn.dataset.action = 'save';
   saveBtn.setAttribute('aria-label', '保存網頁');
-  // 模擬 FloatingRailContainer 建構出的初始 SVG（save icon）
+  // 模擬 FloatingRailContainer 透過 createSafeIcon 建構出的初始 wrapper + SVG
+  const initialIconWrapper = document.createElement('span');
+  initialIconWrapper.className = 'icon';
+  initialIconWrapper.style.width = '18px';
+  initialIconWrapper.style.height = '18px';
   const initialSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   initialSvg.setAttribute('viewBox', '0 0 24 24');
+  initialSvg.classList.add('icon-svg');
   initialSvg.dataset.railIcon = 'save';
-  saveBtn.append(initialSvg);
+  initialIconWrapper.append(initialSvg);
+  saveBtn.append(initialIconWrapper);
   // 模擬 .rail-error-tooltip sibling，確保 swap 時不會被誤刪
   const errorTooltip = document.createElement('span');
   errorTooltip.className = 'rail-error-tooltip';
@@ -196,11 +202,28 @@ describe('applySaveActionVisibility', () => {
     const saveBtn = container.querySelector('[data-action="save"]');
 
     applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    const firstWrapper = saveBtn.querySelector('.icon');
     const firstSvg = saveBtn.querySelector('svg');
     applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    const secondWrapper = saveBtn.querySelector('.icon');
     const secondSvg = saveBtn.querySelector('svg');
 
+    expect(secondWrapper).toBe(firstWrapper);
     expect(secondSvg).toBe(firstSvg);
+  });
+
+  test('[REGRESSION] icon 切換應保留 .icon wrapper 結構並套用尺寸樣式', () => {
+    const container = createMockContainer();
+    const saveBtn = container.querySelector('[data-action="save"]');
+
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+
+    const wrappers = saveBtn.querySelectorAll('.icon');
+    expect(wrappers).toHaveLength(1);
+    const [wrapper] = wrappers;
+    expect(wrapper.style.width).toBe('18px');
+    expect(wrapper.style.height).toBe('18px');
+    expect(wrapper.querySelector('svg')?.dataset.railIcon).toBe('sync');
   });
 
   test('null saveBtn 不應拋錯', () => {

--- a/tests/unit/highlighter/ui/FloatingRailUI.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailUI.test.js
@@ -28,6 +28,16 @@ function createMockContainer() {
   saveBtn.className = 'rail-action-btn';
   saveBtn.dataset.action = 'save';
   saveBtn.setAttribute('aria-label', '保存網頁');
+  // 模擬 FloatingRailContainer 建構出的初始 SVG（save icon）
+  const initialSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  initialSvg.setAttribute('viewBox', '0 0 24 24');
+  initialSvg.dataset.railIcon = 'save';
+  saveBtn.append(initialSvg);
+  // 模擬 .rail-error-tooltip sibling，確保 swap 時不會被誤刪
+  const errorTooltip = document.createElement('span');
+  errorTooltip.className = 'rail-error-tooltip';
+  errorTooltip.setAttribute('role', 'alert');
+  saveBtn.append(errorTooltip);
   actions.append(saveBtn);
 
   const highlightGroup = document.createElement('div');
@@ -146,6 +156,51 @@ describe('applySaveActionVisibility', () => {
 
     expect(saveBtn.getAttribute('aria-label')).toBe('同步標註');
     expect(saveBtn.dataset.action).toBe('sync');
+  });
+
+  test('已保存頁面應將按鈕內 SVG 切換為 sync icon', () => {
+    const container = createMockContainer();
+    const saveBtn = container.querySelector('[data-action="save"]');
+
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+
+    const svg = saveBtn.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg.dataset.railIcon).toBe('sync');
+  });
+
+  test('未保存頁面應將按鈕內 SVG 切換回 save icon', () => {
+    const container = createMockContainer();
+    const saveBtn = container.querySelector('[data-action="save"]');
+
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    applySaveActionVisibility(saveBtn, { canSave: true, isSaved: false });
+
+    const svg = saveBtn.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg.dataset.railIcon).toBe('save');
+  });
+
+  test('[REGRESSION] icon 切換不應移除 .rail-error-tooltip sibling', () => {
+    const container = createMockContainer();
+    const saveBtn = container.querySelector('[data-action="save"]');
+
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    applySaveActionVisibility(saveBtn, { canSave: true, isSaved: false });
+
+    expect(saveBtn.querySelector('.rail-error-tooltip')).not.toBeNull();
+  });
+
+  test('連續呼叫相同狀態時不應重新建立 SVG 節點', () => {
+    const container = createMockContainer();
+    const saveBtn = container.querySelector('[data-action="save"]');
+
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    const firstSvg = saveBtn.querySelector('svg');
+    applySaveActionVisibility(saveBtn, { canSave: false, isSaved: true });
+    const secondSvg = saveBtn.querySelector('svg');
+
+    expect(secondSvg).toBe(firstSvg);
   });
 
   test('null saveBtn 不應拋錯', () => {


### PR DESCRIPTION
### 摘要
新增保存按鈕的圖示切換功能，根據頁面狀態顯示不同的圖示。

### 變更內容
- 新增 `swapSaveActionIcon` 函數以根據頁面狀態切換保存按鈕的圖示。
- 當頁面已保存時，按鈕顯示同步圖示；未保存時顯示保存圖示。
- 確保在切換圖示時不會移除錯誤提示工具提示。
- 更新單元測試以驗證圖示切換的正確性及邊界情況。

### 測試方式
更新了單元測試以驗證圖示切換的正確性。

### 潛在風險
無顯著風險。

