### PR TITLE
test: add coverage for ProfileManager and FloatingRailRuntime

### DIFF
--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -510,6 +510,7 @@ describe('Destination profile domain services', () => {
       );
       expect(storageData.destinationProfiles).toHaveLength(2);
       expect(storageData.destinationProfiles[1].id).toBe(created.id);
+      expect(created.color).toBe('#16a34a');
     });
 
     it('updateProfile 對不存在 id 拋 NOT_FOUND', async () => {

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -1,6 +1,7 @@
 import {
   ACCOUNT_GATED_FOUNDATION_ENTITLEMENT_SOURCE,
   AccountGatedDestinationEntitlementProvider,
+  DESTINATION_PROFILE_ERRORS,
   DESTINATION_PROFILE_STORAGE_KEYS,
   LocalDestinationProfileRepository,
 } from '../../../scripts/destinations/ProfileStore.js';
@@ -422,6 +423,151 @@ describe('Destination profile domain services', () => {
       PROFILES: 'destinationProfiles',
       LAST_USED_PROFILE_ID: 'destinationLastUsedProfileId',
       VERSION: 'destinationProfilesVersion',
+    });
+  });
+
+  describe('ProfileManager error branches', () => {
+    const buildProfile = overrides => ({
+      id: 'default',
+      name: 'Default',
+      icon: 'bookmark',
+      color: '#2563eb',
+      notionDataSourceId: 'source-1',
+      notionDataSourceType: 'database',
+      createdAt: 1,
+      updatedAt: 1,
+      ...overrides,
+    });
+
+    it('getProfile 找不到 id 時拋 NOT_FOUND', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.getProfile('missing')).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.NOT_FOUND
+      );
+    });
+
+    it('getLastUsedProfile 在 entitlement.maxProfiles 為 0 時回 null', async () => {
+      entitlementProvider.getDestinationEntitlement.mockResolvedValue({
+        maxProfiles: 0,
+        source: 'test',
+      });
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.getLastUsedProfile()).resolves.toBeNull();
+    });
+
+    it('setLastUsedProfile happy path 會寫入 lastUsedProfileId 並回傳 profile', async () => {
+      storageData.destinationProfiles = [
+        buildProfile(),
+        buildProfile({
+          id: 'second',
+          name: 'Second',
+          notionDataSourceId: 'source-2',
+          notionDataSourceType: 'page',
+          createdAt: 2,
+          updatedAt: 2,
+        }),
+      ];
+
+      const result = await manager.setLastUsedProfile('second');
+
+      expect(result.id).toBe('second');
+      expect(storageData.destinationLastUsedProfileId).toBe('second');
+    });
+
+    it('setLastUsedProfile 對不存在 id 拋 NOT_FOUND', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.setLastUsedProfile('missing')).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.NOT_FOUND
+      );
+    });
+
+    it('createProfile 完全空的 input 觸發 TARGET_REQUIRED', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.createProfile({})).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.TARGET_REQUIRED
+      );
+    });
+
+    it('createProfile happy path 會寫入新 profile 並沿用 entitlement 配色', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      const created = await manager.createProfile({
+        name: 'Second',
+        notionDataSourceId: 'source-2',
+        notionDataSourceType: 'page',
+      });
+
+      expect(created).toEqual(
+        expect.objectContaining({
+          name: 'Second',
+          notionDataSourceId: 'source-2',
+          notionDataSourceType: 'page',
+        })
+      );
+      expect(storageData.destinationProfiles).toHaveLength(2);
+      expect(storageData.destinationProfiles[1].id).toBe(created.id);
+    });
+
+    it('updateProfile 對不存在 id 拋 NOT_FOUND', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(
+        manager.updateProfile('missing', { notionDataSourceId: 'source-2' })
+      ).rejects.toThrow(DESTINATION_PROFILE_ERRORS.NOT_FOUND);
+    });
+
+    it('updateProfile 將 notionDataSourceId 更新為空字串時拋 TARGET_REQUIRED', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.updateProfile('default', { notionDataSourceId: '' })).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.TARGET_REQUIRED
+      );
+    });
+
+    it('deleteProfile 在僅剩一個 profile 時拋 LAST_DELETE', async () => {
+      storageData.destinationProfiles = [buildProfile()];
+
+      await expect(manager.deleteProfile('default')).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.LAST_DELETE
+      );
+    });
+
+    it('deleteProfile 對不存在 id 拋 NOT_FOUND', async () => {
+      storageData.destinationProfiles = [
+        buildProfile(),
+        buildProfile({
+          id: 'second',
+          notionDataSourceId: 'source-2',
+          createdAt: 2,
+          updatedAt: 2,
+        }),
+      ];
+
+      await expect(manager.deleteProfile('missing')).rejects.toThrow(
+        DESTINATION_PROFILE_ERRORS.NOT_FOUND
+      );
+    });
+
+    it('deleteProfile 刪除非 last-used profile 時保留原 lastUsedProfileId', async () => {
+      storageData.destinationLastUsedProfileId = 'default';
+      storageData.destinationProfiles = [
+        buildProfile(),
+        buildProfile({
+          id: 'second',
+          notionDataSourceId: 'source-2',
+          createdAt: 2,
+          updatedAt: 2,
+        }),
+      ];
+
+      const remaining = await manager.deleteProfile('second');
+
+      expect(remaining.map(profile => profile.id)).toEqual(['default']);
+      expect(storageData.destinationLastUsedProfileId).toBe('default');
     });
   });
 });

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -509,7 +509,7 @@ describe('Destination profile domain services', () => {
         })
       );
       expect(storageData.destinationProfiles).toHaveLength(2);
-      expect(storageData.destinationProfiles[1].id).toBe(created.id);
+      expect(storageData.destinationProfiles.find(p => p.id === created.id)).toBeTruthy();
       expect(created.color).toBe('#16a34a');
     });
 

--- a/tests/unit/highlighter/ui/FloatingRailRuntime.node.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailRuntime.node.test.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+import { RUNTIME_ERROR_MESSAGES } from '../../../../scripts/config/runtimeActions/errorMessages.js';
+
+describe('FloatingRailRuntime (node env — no window)', () => {
+  it('window 不存在時拋 EXTENSION_UNAVAILABLE', async () => {
+    const { checkPageStatus } =
+      await import('../../../../scripts/highlighter/ui/FloatingRailRuntime.js');
+
+    await expect(checkPageStatus()).rejects.toThrow(RUNTIME_ERROR_MESSAGES.EXTENSION_UNAVAILABLE);
+  });
+});

--- a/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
@@ -54,12 +54,12 @@ describe('FloatingRailRuntime', () => {
       });
     });
 
-    it('savePageFromRail 送出 SAVE_PAGE_FROM_TOOLBAR', async () => {
-      const sendMessage = jest.fn().mockResolvedValue({ ok: true });
+    it('savePageFromRail 送出 SAVE_PAGE_FROM_TOOLBAR 並透傳 sendMessage 回應', async () => {
+      const response = { ok: true };
+      const sendMessage = jest.fn().mockResolvedValue(response);
       globalThis.chrome.runtime.sendMessage = sendMessage;
 
-      await savePageFromRail();
-
+      await expect(savePageFromRail()).resolves.toBe(response);
       expect(sendMessage).toHaveBeenCalledWith({
         action: PAGE_SAVE_ACTIONS.SAVE_PAGE_FROM_TOOLBAR,
       });

--- a/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
@@ -1,0 +1,99 @@
+/**
+ * FloatingRailRuntime.js 單元測試
+ *
+ * 直接 import 真實模組（不可 jest.mock），覆蓋：
+ *  - ensureChromeRuntimeAvailable sendMessage 不存在分支
+ *  - 4 個 action wrapper 的 payload contract 與 sendMessage return 透傳
+ *  - sendMessage rejection 冒泡
+ *
+ * 注意：window === undefined 分支需要 node 環境，見 FloatingRailRuntime.node.test.js
+ */
+
+import {
+  checkPageStatus,
+  openSidePanel,
+  savePageFromRail,
+  syncHighlights,
+} from '../../../../scripts/highlighter/ui/FloatingRailRuntime.js';
+import { HIGHLIGHTER_ACTIONS } from '../../../../scripts/config/runtimeActions/highlighterActions.js';
+import { PAGE_SAVE_ACTIONS } from '../../../../scripts/config/runtimeActions/pageSaveActions.js';
+import { RUNTIME_ERROR_MESSAGES } from '../../../../scripts/config/runtimeActions/errorMessages.js';
+
+describe('FloatingRailRuntime', () => {
+  let originalSendMessage;
+
+  beforeEach(() => {
+    originalSendMessage = globalThis.chrome?.runtime?.sendMessage;
+  });
+
+  afterEach(() => {
+    if (globalThis.chrome?.runtime) {
+      globalThis.chrome.runtime.sendMessage = originalSendMessage;
+    }
+  });
+
+  describe('ensureChromeRuntimeAvailable guard', () => {
+    it('chrome.runtime.sendMessage 不存在時拋 EXTENSION_UNAVAILABLE', async () => {
+      globalThis.chrome.runtime.sendMessage = undefined;
+
+      await expect(savePageFromRail()).rejects.toThrow(
+        RUNTIME_ERROR_MESSAGES.EXTENSION_UNAVAILABLE
+      );
+    });
+  });
+
+  describe('action wrappers', () => {
+    it('checkPageStatus 送出 CHECK_PAGE_STATUS 並透傳 sendMessage 回應', async () => {
+      const response = { saved: true };
+      const sendMessage = jest.fn().mockResolvedValue(response);
+      globalThis.chrome.runtime.sendMessage = sendMessage;
+
+      await expect(checkPageStatus()).resolves.toBe(response);
+      expect(sendMessage).toHaveBeenCalledWith({
+        action: PAGE_SAVE_ACTIONS.CHECK_PAGE_STATUS,
+      });
+    });
+
+    it('savePageFromRail 送出 SAVE_PAGE_FROM_TOOLBAR', async () => {
+      const sendMessage = jest.fn().mockResolvedValue({ ok: true });
+      globalThis.chrome.runtime.sendMessage = sendMessage;
+
+      await savePageFromRail();
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        action: PAGE_SAVE_ACTIONS.SAVE_PAGE_FROM_TOOLBAR,
+      });
+    });
+
+    it('syncHighlights 送出 SYNC_HIGHLIGHTS 並夾帶 highlights payload', async () => {
+      const highlights = [{ id: 'h1', text: 'sample' }];
+      const sendMessage = jest.fn().mockResolvedValue(undefined);
+      globalThis.chrome.runtime.sendMessage = sendMessage;
+
+      await syncHighlights(highlights);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        action: HIGHLIGHTER_ACTIONS.SYNC_HIGHLIGHTS,
+        highlights,
+      });
+    });
+
+    it('openSidePanel 送出 OPEN_SIDE_PANEL', async () => {
+      const sendMessage = jest.fn().mockResolvedValue(undefined);
+      globalThis.chrome.runtime.sendMessage = sendMessage;
+
+      await openSidePanel();
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        action: PAGE_SAVE_ACTIONS.OPEN_SIDE_PANEL,
+      });
+    });
+
+    it('sendMessage rejection 會冒泡給 caller', async () => {
+      const failure = new Error('runtime disconnected');
+      globalThis.chrome.runtime.sendMessage = jest.fn().mockRejectedValue(failure);
+
+      await expect(checkPageStatus()).rejects.toBe(failure);
+    });
+  });
+});

--- a/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailRuntime.test.js
@@ -23,7 +23,9 @@ describe('FloatingRailRuntime', () => {
   let originalSendMessage;
 
   beforeEach(() => {
-    originalSendMessage = globalThis.chrome?.runtime?.sendMessage;
+    globalThis.chrome ??= {};
+    globalThis.chrome.runtime ??= {};
+    originalSendMessage = globalThis.chrome.runtime.sendMessage;
   });
 
   afterEach(() => {


### PR DESCRIPTION
### 摘要
增加對 ProfileManager 錯誤分支和 FloatingRailRuntime IPC 的測試覆蓋率。

### 變更內容
- 為 ProfileManager 增加錯誤處理的單元測試，包括 `getProfile`、`getLastUsedProfile`、`setLastUsedProfile`、`createProfile`、`updateProfile` 和 `deleteProfile` 的各種情況。
- 為 FloatingRailRuntime 增加測試，確保在 Node 環境下正確處理 `sendMessage` 的可用性和行為。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

