### PR TITLE
feat: Simplify toolbar creation and enhance testing

### DIFF
--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -189,11 +189,6 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}) {
     clearAll: () => manager.clearAll(),
     getCount: () => manager.getCount(),
     forceRestoreHighlights: () => restoreManager.restore(),
-    createAndShowToolbar: () => {
-      const legacyUi = getLegacyUiController(state);
-      legacyUi?.show?.();
-      return legacyUi;
-    },
   };
 
   // 🔑 全域函數別名（向後兼容）

--- a/tests/unit/highlighter/highlighter-index.test.js
+++ b/tests/unit/highlighter/highlighter-index.test.js
@@ -189,11 +189,11 @@ describe('Highlighter Index', () => {
       expect(globalThis.HighlighterV2.getToolbar()).toBeNull();
       expect(globalThis.HighlighterV2.toolbar).toBeNull();
 
-      const toolbar = globalThis.notionHighlighter.createAndShowToolbar();
+      globalThis.notionHighlighter.show();
 
-      expect(toolbar).toBe(mockToolbar);
       expect(globalThis.HighlighterV2.getToolbar()).toBe(mockToolbar);
       expect(globalThis.HighlighterV2.toolbar).toBe(mockToolbar);
+      expect(mockToolbar.show).toHaveBeenCalled();
     });
   });
 
@@ -259,7 +259,7 @@ describe('Highlighter Index', () => {
     });
 
     test('isActive() 應該根據 toolbar state 回傳布林值', () => {
-      globalThis.notionHighlighter.createAndShowToolbar();
+      globalThis.notionHighlighter.show();
 
       mockToolbar.stateManager.currentState = 'hidden';
       expect(globalThis.notionHighlighter.isActive()).toBe(false);

--- a/tests/unit/highlighter/windowAPI.test.js
+++ b/tests/unit/highlighter/windowAPI.test.js
@@ -258,5 +258,41 @@ describe('windowAPI', () => {
 
       expect(railCollapse).toHaveBeenCalledTimes(1);
     });
+
+    test('Branch A indirect alive: notionHighlighter.collectHighlights() 應委派到 manager', () => {
+      prodManager.collectHighlightsForNotion.mockReturnValue([{ id: 'mock' }]);
+      prodMountWindowAPI(prodManager, null, prodStorage);
+
+      const result = globalThis.notionHighlighter.collectHighlights();
+
+      expect(prodManager.collectHighlightsForNotion).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: 'mock' }]);
+    });
+
+    test('Branch A indirect alive: notionHighlighter.clearAll() 應委派到 manager', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+
+      globalThis.notionHighlighter.clearAll();
+
+      expect(prodManager.clearAll).toHaveBeenCalledTimes(1);
+    });
+
+    test('Branch A direct alive: globalThis.collectHighlights() 應透過 alias 委派到 manager (executeScript page-context contract)', () => {
+      prodManager.collectHighlightsForNotion.mockReturnValue([{ id: 'via-alias' }]);
+      prodMountWindowAPI(prodManager, null, prodStorage);
+
+      const result = globalThis.collectHighlights();
+
+      expect(prodManager.collectHighlightsForNotion).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: 'via-alias' }]);
+    });
+
+    test('Branch A direct alive: globalThis.clearPageHighlights() 應透過 alias 委派到 manager (executeScript page-context contract)', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+
+      globalThis.clearPageHighlights();
+
+      expect(prodManager.clearAll).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
### 摘要
移除不必要的工具列創建方法，並增強測試以確保功能正常。

### 變更內容
- 移除 `notionHighlighter` 的 `createAndShowToolbar` 方法，簡化 API。
- 更新測試以使用 `notionHighlighter.show()` 驗證工具列顯示。
- 新增測試確保 `collectHighlights` 和 `clearAll` 方法正確委派到 `manager`。
- 確保全域函數別名功能正常運作，增強代碼可維護性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

