### PR TITLE
fix: Adjust alignment of floating toolbar icons

### DIFF
--- a/scripts/highlighter/ui/FloatingRailUI.js
+++ b/scripts/highlighter/ui/FloatingRailUI.js
@@ -9,7 +9,7 @@ import { UI_MESSAGES } from '../../config/shared/messages.js';
 import { COLORS } from '../utils/color.js';
 import { hexToRgba } from '../../../styles/ui-token-constants.js';
 import { createSafeIcon } from '../../utils/securityUtils.js';
-import { RAIL_ICONS, ICON_SIZE_SM } from './components/FloatingRailContainer.js';
+import { RAIL_ICONS } from './components/FloatingRailContainer.js';
 
 export function getRailElements(container) {
   const highlightBtn = container.querySelector('[data-action="highlight"]');
@@ -65,8 +65,6 @@ function swapSaveActionIcon(saveBtn, isSaved) {
   if (!nextWrapper.querySelector('svg')) {
     return;
   }
-  nextWrapper.style.width = ICON_SIZE_SM;
-  nextWrapper.style.height = ICON_SIZE_SM;
 
   if (currentWrapper) {
     currentWrapper.replaceWith(nextWrapper);

--- a/scripts/highlighter/ui/components/FloatingRailContainer.js
+++ b/scripts/highlighter/ui/components/FloatingRailContainer.js
@@ -10,8 +10,6 @@ import { createSafeIcon } from '../../../utils/securityUtils.js';
 
 const ARIA_LABEL = 'aria-label';
 const ACTION_BTN_CLASS = 'rail-action-btn';
-export const ICON_SIZE_SM = '18px';
-const TRIGGER_ICON_SIZE = '22px';
 
 export const RAIL_ICONS = {
   CLOSE:
@@ -55,8 +53,6 @@ export function createFloatingRailContainer(options = {}) {
   trigger.setAttribute('aria-expanded', 'false');
   trigger.setAttribute('aria-pressed', 'false');
   const logoIcon = createSafeIcon(RAIL_ICONS.LOGO);
-  logoIcon.style.width = TRIGGER_ICON_SIZE;
-  logoIcon.style.height = TRIGGER_ICON_SIZE;
   trigger.append(logoIcon);
   container.append(trigger);
 
@@ -70,8 +66,6 @@ export function createFloatingRailContainer(options = {}) {
   saveBtn.setAttribute(ARIA_LABEL, UI_MESSAGES.FLOATING_RAIL.SAVE_LABEL);
   saveBtn.dataset.action = 'save';
   const saveIcon = createSafeIcon(RAIL_ICONS.NOTION);
-  saveIcon.style.width = ICON_SIZE_SM;
-  saveIcon.style.height = ICON_SIZE_SM;
   saveBtn.append(saveIcon);
 
   const errorTooltip = document.createElement('span');
@@ -128,8 +122,6 @@ export function createFloatingRailContainer(options = {}) {
   manageBtn.setAttribute(ARIA_LABEL, UI_MESSAGES.FLOATING_RAIL.MANAGE_LABEL);
   manageBtn.dataset.action = 'manage';
   const manageIcon = createSafeIcon(RAIL_ICONS.MANAGE);
-  manageIcon.style.width = ICON_SIZE_SM;
-  manageIcon.style.height = ICON_SIZE_SM;
   manageBtn.append(manageIcon);
   actions.append(manageBtn);
 

--- a/scripts/highlighter/ui/components/FloatingRailContainer.js
+++ b/scripts/highlighter/ui/components/FloatingRailContainer.js
@@ -41,8 +41,6 @@ export function createFloatingRailContainer(options = {}) {
   closeBtn.setAttribute(ARIA_LABEL, UI_MESSAGES.FLOATING_RAIL.CLOSE_LABEL);
   closeBtn.dataset.action = 'close';
   const closeIcon = createSafeIcon(RAIL_ICONS.CLOSE);
-  closeIcon.style.width = '12px';
-  closeIcon.style.height = '12px';
   closeBtn.append(closeIcon);
   container.append(closeBtn);
 

--- a/scripts/highlighter/ui/styles/floatingRailStyles.js
+++ b/scripts/highlighter/ui/styles/floatingRailStyles.js
@@ -98,6 +98,22 @@ export function getFloatingRailCSS() {
       outline-offset: 1px;
     }
 
+    .rail-close-btn > .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--rail-close-icon-size, 12px);
+      height: var(--rail-close-icon-size, 12px);
+    }
+
+    .rail-close-btn svg {
+      width: 100%;
+      height: 100%;
+      color: currentColor;
+      fill: currentColor;
+      stroke: currentColor;
+    }
+
     @media (prefers-color-scheme: dark) {
       .rail-container {
         background: ${theme.dark.surface};
@@ -178,8 +194,8 @@ export function getFloatingRailCSS() {
     }
 
     .rail-trigger svg {
-      width: var(--rail-trigger-icon-size, 22px);
-      height: var(--rail-trigger-icon-size, 22px);
+      width: 100%;
+      height: 100%;
       color: currentColor;
       fill: currentColor;
       stroke: currentColor;
@@ -248,8 +264,8 @@ export function getFloatingRailCSS() {
     }
 
     .rail-action-btn svg {
-      width: var(--rail-action-icon-size, 18px);
-      height: var(--rail-action-icon-size, 18px);
+      width: 100%;
+      height: 100%;
       color: currentColor;
       fill: currentColor;
       stroke: currentColor;

--- a/scripts/highlighter/ui/styles/floatingRailStyles.js
+++ b/scripts/highlighter/ui/styles/floatingRailStyles.js
@@ -169,6 +169,14 @@ export function getFloatingRailCSS() {
       --rail-brand-fill: ${color.brandHover};
     }
 
+    .rail-trigger > .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--rail-trigger-icon-size, 22px);
+      height: var(--rail-trigger-icon-size, 22px);
+    }
+
     .rail-trigger svg {
       width: var(--rail-trigger-icon-size, 22px);
       height: var(--rail-trigger-icon-size, 22px);
@@ -229,6 +237,14 @@ export function getFloatingRailCSS() {
       background: ${color.actionManageHover};
       transform: translateY(-1px);
       box-shadow: 0 2px 6px ${hexToRgba(color.actionManage, 0.35)};
+    }
+
+    .rail-action-btn > .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--rail-action-icon-size, 18px);
+      height: var(--rail-action-icon-size, 18px);
     }
 
     .rail-action-btn svg {

--- a/tests/unit/highlighter/ui/FloatingRailUI.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailUI.test.js
@@ -31,8 +31,6 @@ function createMockContainer() {
   // 模擬 FloatingRailContainer 透過 createSafeIcon 建構出的初始 wrapper + SVG
   const initialIconWrapper = document.createElement('span');
   initialIconWrapper.className = 'icon';
-  initialIconWrapper.style.width = '18px';
-  initialIconWrapper.style.height = '18px';
   const initialSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   initialSvg.setAttribute('viewBox', '0 0 24 24');
   initialSvg.classList.add('icon-svg');
@@ -212,7 +210,7 @@ describe('applySaveActionVisibility', () => {
     expect(secondSvg).toBe(firstSvg);
   });
 
-  test('[REGRESSION] icon 切換應保留 .icon wrapper 結構並套用尺寸樣式', () => {
+  test('[REGRESSION] icon 切換應保留 .icon wrapper 結構，尺寸由 CSS variable 控制', () => {
     const container = createMockContainer();
     const saveBtn = container.querySelector('[data-action="save"]');
 
@@ -221,8 +219,9 @@ describe('applySaveActionVisibility', () => {
     const wrappers = saveBtn.querySelectorAll('.icon');
     expect(wrappers).toHaveLength(1);
     const [wrapper] = wrappers;
-    expect(wrapper.style.width).toBe('18px');
-    expect(wrapper.style.height).toBe('18px');
+    expect(wrapper.style.width).toBe('');
+    expect(wrapper.style.height).toBe('');
+    expect(wrapper.classList.contains('icon')).toBe(true);
     expect(wrapper.querySelector('svg')?.dataset.railIcon).toBe('sync');
   });
 

--- a/tests/unit/highlighter/ui/styles/floatingRailStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/floatingRailStyles.test.js
@@ -111,5 +111,19 @@ describe('floatingRailStyles', () => {
       expect(matches).not.toBeNull();
       expect(matches.length).toBeGreaterThanOrEqual(2);
     });
+
+    test('[REGRESSION] rail-trigger > .icon wrapper 應跟著 trigger icon size CSS variable，避免 small 模式錯位', () => {
+      const css = getFloatingRailCSS();
+      expect(css).toMatch(
+        /\.rail-trigger\s*>\s*\.icon\s*\{[\s\S]*?width:\s*var\(--rail-trigger-icon-size,\s*22px\)[\s\S]*?height:\s*var\(--rail-trigger-icon-size,\s*22px\)/
+      );
+    });
+
+    test('[REGRESSION] rail-action-btn > .icon wrapper 應跟著 action icon size CSS variable，避免 small 模式錯位', () => {
+      const css = getFloatingRailCSS();
+      expect(css).toMatch(
+        /\.rail-action-btn\s*>\s*\.icon\s*\{[\s\S]*?width:\s*var\(--rail-action-icon-size,\s*18px\)[\s\S]*?height:\s*var\(--rail-action-icon-size,\s*18px\)/
+      );
+    });
   });
 });


### PR DESCRIPTION
### 摘要
調整浮動工具列小圖示的對齊方式，提升樣式的一致性與可維護性。

### 變更內容
- 移除不必要的圖示尺寸設定，改由 CSS 變數控制。
- 更新樣式以使用 CSS 變數，確保在小模式下不會錯位。
- 增加單元測試以驗證圖示包裝器的尺寸與對齊行為。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

