### PR TITLE
fix: namespace floating rail for extension co-existence

### DIFF
--- a/scripts/highlighter/ui/FloatingRail.js
+++ b/scripts/highlighter/ui/FloatingRail.js
@@ -31,8 +31,8 @@ import {
   playFireworkAnimation,
   playFailAnimation,
 } from './FloatingRailAnimations.js';
+import { RAIL_INSTANCE_ID } from './floatingRailInstance.js';
 
-const RAIL_INSTANCE_ID = globalThis.chrome?.runtime?.id ?? 'unknown';
 const RAIL_HOST_ID = `notion-floating-rail-host-${RAIL_INSTANCE_ID}`;
 const RAIL_HOST_OWNER_ATTR = 'data-rail-owner';
 const RAIL_HOST_OWNER_VALUE = 'true';

--- a/scripts/highlighter/ui/FloatingRail.js
+++ b/scripts/highlighter/ui/FloatingRail.js
@@ -32,11 +32,13 @@ import {
   playFailAnimation,
 } from './FloatingRailAnimations.js';
 
-const RAIL_HOST_ID = 'notion-floating-rail-host';
+const RAIL_INSTANCE_ID = globalThis.chrome?.runtime?.id ?? 'unknown';
+const RAIL_HOST_ID = `notion-floating-rail-host-${RAIL_INSTANCE_ID}`;
 const RAIL_HOST_OWNER_ATTR = 'data-rail-owner';
 const RAIL_HOST_OWNER_VALUE = 'true';
-const RAIL_OWNED_HOST_SELECTOR = `#${RAIL_HOST_ID}[${RAIL_HOST_OWNER_ATTR}="${RAIL_HOST_OWNER_VALUE}"]`;
-const RAIL_POSITION_STORAGE_KEY = 'notion-floating-rail-position';
+const escapeCssIdent = globalThis.CSS?.escape ?? (value => value);
+const RAIL_OWNED_HOST_SELECTOR = `#${escapeCssIdent(RAIL_HOST_ID)}[${RAIL_HOST_OWNER_ATTR}="${RAIL_HOST_OWNER_VALUE}"]`;
+const RAIL_POSITION_STORAGE_KEY = `notion-floating-rail-position-${RAIL_INSTANCE_ID}`;
 const RAIL_EDGE_MARGIN_PX = 8;
 const RAIL_DRAG_LONG_PRESS_MS = 280;
 const RAIL_DRAG_MOVE_THRESHOLD_PX = 2;

--- a/scripts/highlighter/ui/FloatingRailState.js
+++ b/scripts/highlighter/ui/FloatingRailState.js
@@ -7,9 +7,10 @@
 
 import Logger from '../../utils/Logger.js';
 import { COLORS } from '../utils/color.js';
+import { RAIL_INSTANCE_ID } from './floatingRailInstance.js';
 
-const STORAGE_KEY = 'notion-floating-rail-state';
-const DISMISSED_KEY = 'notion-floating-rail-dismissed';
+const STORAGE_KEY = `notion-floating-rail-state-${RAIL_INSTANCE_ID}`;
+const DISMISSED_KEY = `notion-floating-rail-dismissed-${RAIL_INSTANCE_ID}`;
 const VALID_COLORS = new Set(Object.keys(COLORS));
 
 export const RailStates = Object.freeze({

--- a/scripts/highlighter/ui/floatingRailInstance.js
+++ b/scripts/highlighter/ui/floatingRailInstance.js
@@ -1,0 +1,9 @@
+/**
+ * Floating Rail instance namespace
+ *
+ * 同一 page-origin 內的 sessionStorage 與 DOM 由 page 與所有 content scripts 共享，
+ * 多個 extension instance 共存時必須以 chrome.runtime.id 作 namespace 邊界，
+ * 才能避免 host id、storage key 互相覆蓋。
+ */
+
+export const RAIL_INSTANCE_ID = globalThis.chrome?.runtime?.id ?? 'unknown';

--- a/tests/unit/highlighter/ui/FloatingRail.test.js
+++ b/tests/unit/highlighter/ui/FloatingRail.test.js
@@ -42,6 +42,8 @@ import Logger from '../../../../scripts/utils/Logger.js';
 
 const TEST_RAIL_HOST_ID = `notion-floating-rail-host-${chrome.runtime.id}`;
 const TEST_RAIL_POSITION_KEY = `notion-floating-rail-position-${chrome.runtime.id}`;
+const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${chrome.runtime.id}`;
+const TEST_RAIL_DISMISSED_KEY = `notion-floating-rail-dismissed-${chrome.runtime.id}`;
 
 function createMockContainerElement() {
   const container = document.createElement('div');
@@ -272,7 +274,7 @@ describe('FloatingRail', () => {
 
     test('從 sessionStorage 恢復 HIGHLIGHTING 狀態時應啟動標註功能', async () => {
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'highlighting', color: 'green' })
       );
 
@@ -285,7 +287,7 @@ describe('FloatingRail', () => {
 
     test('從 sessionStorage 恢復非 HIGHLIGHTING 狀態時不應啟動標註', async () => {
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'expanded', color: 'yellow' })
       );
 
@@ -341,7 +343,7 @@ describe('FloatingRail', () => {
     });
 
     test('[REGRESSION] dismissed 狀態初始化後，undismiss 仍應保有事件綁定', async () => {
-      sessionStorage.setItem('notion-floating-rail-dismissed', 'true');
+      sessionStorage.setItem(TEST_RAIL_DISMISSED_KEY, 'true');
 
       const rail = new FloatingRail(manager);
       await rail.initialize();
@@ -379,7 +381,7 @@ describe('FloatingRail', () => {
     });
 
     test('dismissed 狀態下 show 不應重新顯示 host', async () => {
-      sessionStorage.setItem('notion-floating-rail-dismissed', 'true');
+      sessionStorage.setItem(TEST_RAIL_DISMISSED_KEY, 'true');
 
       const rail = new FloatingRail(manager);
       await rail.initialize();

--- a/tests/unit/highlighter/ui/FloatingRail.test.js
+++ b/tests/unit/highlighter/ui/FloatingRail.test.js
@@ -40,6 +40,9 @@ import {
 } from '../../../../scripts/highlighter/ui/FloatingRailAnimations.js';
 import Logger from '../../../../scripts/utils/Logger.js';
 
+const TEST_RAIL_HOST_ID = `notion-floating-rail-host-${chrome.runtime.id}`;
+const TEST_RAIL_POSITION_KEY = `notion-floating-rail-position-${chrome.runtime.id}`;
+
 function createMockContainerElement() {
   const container = document.createElement('div');
   container.className = 'rail-container collapsed';
@@ -156,7 +159,7 @@ describe('FloatingRail', () => {
 
     test('應該建立 Shadow DOM host', () => {
       const rail = new FloatingRail(manager);
-      const host = document.querySelector('#notion-floating-rail-host');
+      const host = document.querySelector(`#${TEST_RAIL_HOST_ID}`);
 
       expect(host).not.toBeNull();
       expect(host.dataset.railOwner).toBe('true');
@@ -165,7 +168,7 @@ describe('FloatingRail', () => {
 
     test('應該重用既有 host', () => {
       const existingHost = document.createElement('div');
-      existingHost.id = 'notion-floating-rail-host';
+      existingHost.id = TEST_RAIL_HOST_ID;
       existingHost.dataset.railOwner = 'true';
       existingHost.attachShadow({ mode: 'open' });
       document.body.append(existingHost);
@@ -176,7 +179,7 @@ describe('FloatingRail', () => {
 
     test('應該重用既有 host 內的 rail container', () => {
       const existingHost = document.createElement('div');
-      existingHost.id = 'notion-floating-rail-host';
+      existingHost.id = TEST_RAIL_HOST_ID;
       existingHost.dataset.railOwner = 'true';
       const shadowRoot = existingHost.attachShadow({ mode: 'open' });
       const existingContainer = createMockContainerElement();
@@ -191,7 +194,7 @@ describe('FloatingRail', () => {
 
     test('不應重用無 owner 標記的同 ID 元素', () => {
       const fakeHost = document.createElement('div');
-      fakeHost.id = 'notion-floating-rail-host';
+      fakeHost.id = TEST_RAIL_HOST_ID;
       document.body.append(fakeHost);
 
       const rail = new FloatingRail(manager);
@@ -217,7 +220,7 @@ describe('FloatingRail', () => {
 
         document.dispatchEvent(new Event('DOMContentLoaded'));
 
-        expect(document.querySelector('#notion-floating-rail-host')).toBeNull();
+        expect(document.querySelector(`#${TEST_RAIL_HOST_ID}`)).toBeNull();
       } finally {
         if (originalBodyDescriptor) {
           Object.defineProperty(document, 'body', originalBodyDescriptor);
@@ -239,7 +242,7 @@ describe('FloatingRail', () => {
         new FloatingRail(manager);
         document.dispatchEvent(new Event('DOMContentLoaded'));
 
-        expect(document.querySelector('#notion-floating-rail-host')).toBeNull();
+        expect(document.querySelector(`#${TEST_RAIL_HOST_ID}`)).toBeNull();
       } finally {
         if (originalBodyDescriptor) {
           Object.defineProperty(document, 'body', originalBodyDescriptor);
@@ -557,7 +560,7 @@ describe('FloatingRail', () => {
       await rail.initialize();
       rail.destroy();
 
-      expect(document.querySelector('#notion-floating-rail-host')).toBeNull();
+      expect(document.querySelector(`#${TEST_RAIL_HOST_ID}`)).toBeNull();
       expect(rail._initialized).toBe(false);
     });
   });
@@ -751,7 +754,7 @@ describe('FloatingRail', () => {
 
         expect(rail.host.style.top).toBe('180px');
         expect(rail.host.style.right).not.toBe('0px');
-        expect(sessionStorage.getItem('notion-floating-rail-position')).toEqual(
+        expect(sessionStorage.getItem(TEST_RAIL_POSITION_KEY)).toEqual(
           expect.stringContaining('"top":180')
         );
       } finally {
@@ -876,10 +879,7 @@ describe('FloatingRail', () => {
     });
 
     test('[REGRESSION] 新 rail instance 應恢復先前拖曳位置', async () => {
-      sessionStorage.setItem(
-        'notion-floating-rail-position',
-        JSON.stringify({ top: 144, right: 24 })
-      );
+      sessionStorage.setItem(TEST_RAIL_POSITION_KEY, JSON.stringify({ top: 144, right: 24 }));
 
       const rail = new FloatingRail(manager);
       await rail.initialize();
@@ -901,7 +901,7 @@ describe('FloatingRail', () => {
         document.dispatchEvent(new MouseEvent('pointerup', { clientX: 700, clientY: 180 }));
 
         expect(rail.host.style.top).not.toBe('180px');
-        expect(sessionStorage.getItem('notion-floating-rail-position')).toBeNull();
+        expect(sessionStorage.getItem(TEST_RAIL_POSITION_KEY)).toBeNull();
       } finally {
         jest.useRealTimers();
       }
@@ -965,7 +965,7 @@ describe('FloatingRail', () => {
 
     test('restorePosition 遇到損壞的 sessionStorage 資料時應記錄警告', () => {
       const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation(() => {});
-      sessionStorage.setItem('notion-floating-rail-position', '{invalid-json');
+      sessionStorage.setItem(TEST_RAIL_POSITION_KEY, '{invalid-json');
 
       const rail = new FloatingRail(manager);
 

--- a/tests/unit/highlighter/ui/FloatingRail.test.js
+++ b/tests/unit/highlighter/ui/FloatingRail.test.js
@@ -38,12 +38,13 @@ import {
   playFireworkAnimation,
   playFailAnimation,
 } from '../../../../scripts/highlighter/ui/FloatingRailAnimations.js';
+import { RAIL_INSTANCE_ID } from '../../../../scripts/highlighter/ui/floatingRailInstance.js';
 import Logger from '../../../../scripts/utils/Logger.js';
 
-const TEST_RAIL_HOST_ID = `notion-floating-rail-host-${chrome.runtime.id}`;
-const TEST_RAIL_POSITION_KEY = `notion-floating-rail-position-${chrome.runtime.id}`;
-const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${chrome.runtime.id}`;
-const TEST_RAIL_DISMISSED_KEY = `notion-floating-rail-dismissed-${chrome.runtime.id}`;
+const TEST_RAIL_HOST_ID = `notion-floating-rail-host-${RAIL_INSTANCE_ID}`;
+const TEST_RAIL_POSITION_KEY = `notion-floating-rail-position-${RAIL_INSTANCE_ID}`;
+const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${RAIL_INSTANCE_ID}`;
+const TEST_RAIL_DISMISSED_KEY = `notion-floating-rail-dismissed-${RAIL_INSTANCE_ID}`;
 
 function createMockContainerElement() {
   const container = document.createElement('div');

--- a/tests/unit/highlighter/ui/FloatingRailState.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailState.test.js
@@ -7,6 +7,8 @@ import {
   FloatingRailStateManager,
 } from '../../../../scripts/highlighter/ui/FloatingRailState.js';
 
+const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${chrome.runtime.id}`;
+
 describe('RailStates', () => {
   test('應該定義三種狀態', () => {
     expect(RailStates.COLLAPSED).toBe('collapsed');
@@ -38,7 +40,7 @@ describe('FloatingRailStateManager', () => {
 
     test('initialize() 應從 sessionStorage 讀取狀態', () => {
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'expanded', color: 'blue' })
       );
 
@@ -51,7 +53,7 @@ describe('FloatingRailStateManager', () => {
 
     test('initialize() 應忽略無效的 sessionStorage 狀態', () => {
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'invalid_state', color: 'blue' })
       );
 
@@ -64,7 +66,7 @@ describe('FloatingRailStateManager', () => {
 
     test('[REGRESSION] initialize() 應忽略無效的 persisted color', () => {
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'expanded', color: 'injected-invalid-color' })
       );
 
@@ -80,7 +82,7 @@ describe('FloatingRailStateManager', () => {
       stateManager.currentState = RailStates.EXPANDED;
 
       sessionStorage.setItem(
-        'notion-floating-rail-state',
+        TEST_RAIL_STATE_KEY,
         JSON.stringify({ state: 'collapsed', color: 'red' })
       );
 
@@ -123,7 +125,7 @@ describe('FloatingRailStateManager', () => {
     test('應該持久化到 sessionStorage', () => {
       stateManager.currentState = RailStates.HIGHLIGHTING;
 
-      const stored = JSON.parse(sessionStorage.getItem('notion-floating-rail-state'));
+      const stored = JSON.parse(sessionStorage.getItem(TEST_RAIL_STATE_KEY));
       expect(stored.state).toBe('highlighting');
     });
   });
@@ -157,7 +159,7 @@ describe('FloatingRailStateManager', () => {
     test('應該持久化到 sessionStorage', () => {
       stateManager.selectedColor = 'blue';
 
-      const stored = JSON.parse(sessionStorage.getItem('notion-floating-rail-state'));
+      const stored = JSON.parse(sessionStorage.getItem(TEST_RAIL_STATE_KEY));
       expect(stored.color).toBe('blue');
     });
   });

--- a/tests/unit/highlighter/ui/FloatingRailState.test.js
+++ b/tests/unit/highlighter/ui/FloatingRailState.test.js
@@ -6,8 +6,9 @@ import {
   RailStates,
   FloatingRailStateManager,
 } from '../../../../scripts/highlighter/ui/FloatingRailState.js';
+import { RAIL_INSTANCE_ID } from '../../../../scripts/highlighter/ui/floatingRailInstance.js';
 
-const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${chrome.runtime.id}`;
+const TEST_RAIL_STATE_KEY = `notion-floating-rail-state-${RAIL_INSTANCE_ID}`;
 
 describe('RailStates', () => {
   test('應該定義三種狀態', () => {


### PR DESCRIPTION
### 摘要
修正浮動工具條的命名空間，以支持多個擴展同時運行時的共存。

### 變更內容
- 將浮動工具條的 host ID 和 sessionStorage 鍵改為使用 `chrome.runtime.id` 作為命名空間，確保每個擴展實例擁有獨立的 DOM 節點和存儲條目。
- 引入防禦性編碼，確保在缺少 `CSS.escape` 的環境中不會出錯。
- 更新測試檔案中的硬編碼字串，以與生產常數同步。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

