### PR TITLE
fix: 修正高亮清除邏輯與命名空間問題

### DIFF
--- a/scripts/highlighter/core/StyleManager.js
+++ b/scripts/highlighter/core/StyleManager.js
@@ -9,12 +9,16 @@ import { COLORS, TEXT_COLORS, VALID_STYLES } from '../utils/color.js';
 import { supportsHighlightAPI } from '../utils/dom.js';
 import Logger from '../../utils/Logger.js';
 
-const STYLE_ELEMENT_ID = 'notion-highlight-styles';
-const STYLE_SELECTOR = `#${STYLE_ELEMENT_ID}`;
+const STYLE_ELEMENT_ID_PREFIX = 'notion-highlight-styles';
+const HIGHLIGHT_KEY_PREFIX = 'notion';
 
 /**
  * StyleManager
  * 管理 CSS Highlight API 樣式的初始化和更新
+ *
+ * 同一 page 內 `CSS.highlights` 與 `<style>` 元素是 page-global 共享，
+ * 多個 extension instance 共存時必須以 chrome.runtime.id 作 namespace 邊界，
+ * 避免互相覆蓋彼此的 highlight 物件與 stylesheet。
  */
 export class StyleManager {
   /**
@@ -26,6 +30,19 @@ export class StyleManager {
     this.colors = COLORS;
     this.textColors = TEXT_COLORS;
     this.highlightObjects = {}; // 顏色 -> Highlight 對象
+    this.instanceId = globalThis.chrome?.runtime?.id ?? 'unknown';
+    this.styleElementId = `${STYLE_ELEMENT_ID_PREFIX}-${this.instanceId}`;
+    this.styleSelector = `#${this.styleElementId}`;
+  }
+
+  /**
+   * 取得指定顏色在 CSS.highlights registry 的 namespaced key
+   *
+   * @param {string} colorName - 顏色名稱（如 'yellow'）
+   * @returns {string} `notion-${instanceId}-${color}`
+   */
+  getHighlightKey(colorName) {
+    return `${HIGHLIGHT_KEY_PREFIX}-${this.instanceId}-${colorName}`;
   }
 
   /**
@@ -57,8 +74,8 @@ export class StyleManager {
         // 創建 Highlight 對象
         this.highlightObjects[colorName] = new HighlightConstructor();
 
-        // 註冊到 CSS.highlights
-        CSS.highlights.set(`notion-${colorName}`, this.highlightObjects[colorName]);
+        // 註冊到 CSS.highlights（帶 chrome.runtime.id namespace）
+        CSS.highlights.set(this.getHighlightKey(colorName), this.highlightObjects[colorName]);
       } catch (error) {
         Logger.error(`[StyleManager] 初始化 ${colorName} 顏色樣式失敗:`, error);
       }
@@ -76,7 +93,7 @@ export class StyleManager {
       return;
     }
 
-    const existingStyle = document.querySelector(STYLE_SELECTOR);
+    const existingStyle = document.querySelector(this.styleSelector);
     if (existingStyle) {
       // 如果樣式已存在，檢查是否需要更新（例如樣式模式改變）
       if (existingStyle.dataset.styleMode === this.styleMode) {
@@ -86,7 +103,7 @@ export class StyleManager {
     }
 
     const style = document.createElement('style');
-    style.id = STYLE_ELEMENT_ID;
+    style.id = this.styleElementId;
     style.dataset.styleMode = this.styleMode;
 
     style.textContent = Object.entries(this.colors)
@@ -129,7 +146,7 @@ export class StyleManager {
         }
 
         return `
-            ::highlight(notion-${colorName}) {
+            ::highlight(${this.getHighlightKey(colorName)}) {
                 ${cssRules}
                 cursor: pointer;
             }
@@ -191,13 +208,13 @@ export class StyleManager {
   cleanup() {
     if (typeof CSS !== 'undefined' && CSS?.highlights) {
       Object.keys(this.highlightObjects).forEach(color => {
-        CSS.highlights.delete(`notion-${color}`);
+        CSS.highlights.delete(this.getHighlightKey(color));
       });
     }
 
     // 移除樣式元素
     if (typeof document !== 'undefined') {
-      const styleEl = document.querySelector(STYLE_SELECTOR);
+      const styleEl = document.querySelector(this.styleSelector);
       if (styleEl) {
         styleEl.remove();
       }

--- a/scripts/highlighter/core/StyleManager.js
+++ b/scripts/highlighter/core/StyleManager.js
@@ -30,7 +30,13 @@ export class StyleManager {
     this.colors = COLORS;
     this.textColors = TEXT_COLORS;
     this.highlightObjects = {}; // 顏色 -> Highlight 對象
-    this.instanceId = globalThis.chrome?.runtime?.id ?? 'unknown';
+    const runtimeId = globalThis.chrome?.runtime?.id;
+    if (runtimeId == null) {
+      Logger.warn(
+        "[StyleManager] chrome.runtime.id missing, using 'unknown' instanceId — risk of namespace collisions across extension instances"
+      );
+    }
+    this.instanceId = runtimeId ?? 'unknown';
     this.styleElementId = `${STYLE_ELEMENT_ID_PREFIX}-${this.instanceId}`;
     this.styleSelector = `#${this.styleElementId}`;
   }

--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -186,7 +186,7 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}) {
       }
     },
     collectHighlights: () => manager.collectHighlightsForNotion(),
-    clearAll: () => manager.clearAll(),
+    clearAll: (options = {}) => manager.clearAll(options),
     getCount: () => manager.getCount(),
     forceRestoreHighlights: () => restoreManager.restore(),
   };
@@ -208,7 +208,7 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}) {
 
   globalThis.clearPageHighlights = () => {
     if (globalThis.notionHighlighter) {
-      globalThis.notionHighlighter.clearAll();
+      globalThis.notionHighlighter.clearAll({ skipStorage: true });
     }
   };
 }

--- a/tests/unit/highlighter/core/HighlightManager.deleteRecursionGuard.test.js
+++ b/tests/unit/highlighter/core/HighlightManager.deleteRecursionGuard.test.js
@@ -1,0 +1,137 @@
+/**
+ * 遞迴守門：刪除最後一個 highlight 後，background 注入回的
+ * `globalThis.clearPageHighlights()` 不應再次觸發 CLEAR_HIGHLIGHTS。
+ *
+ * 修復前：page → background → page 形成自我遞迴閉環，sendMessage('CLEAR_HIGHLIGHTS') ≥ 2 次。
+ * 修復後：clearPageHighlights() 走 skipStorage: true，sendMessage 計數固定 = 1。
+ */
+
+jest.mock('../../../../scripts/highlighter/ui/Toolbar.js', () => ({
+  Toolbar: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    updateHighlightCount: jest.fn(),
+    show: jest.fn(),
+    hide: jest.fn(),
+    minimize: jest.fn(),
+    stateManager: { currentState: 'hidden' },
+  })),
+}));
+
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    start: jest.fn(),
+    ready: jest.fn(),
+  },
+}));
+
+import { HighlightManager } from '../../../../scripts/highlighter/core/HighlightManager.js';
+import { HighlightStorage } from '../../../../scripts/highlighter/core/HighlightStorage.js';
+import { mountWindowAPI } from '../../../../scripts/highlighter/windowAPI.js';
+
+describe('HighlightManager delete recursion guard', () => {
+  let manager;
+  let storage;
+  let mockStyleManager;
+  let sendMessage;
+
+  beforeEach(() => {
+    delete globalThis.HighlighterV2;
+    delete globalThis.notionHighlighter;
+    delete globalThis.clearPageHighlights;
+    delete globalThis.collectHighlights;
+    delete globalThis.initHighlighter;
+    delete globalThis.__NOTION_STABLE_URL__;
+
+    globalThis.window = globalThis;
+    globalThis.__NOTION_STABLE_URL__ = 'https://example.com/page';
+
+    sendMessage = jest.fn(() => Promise.resolve({ success: true }));
+    globalThis.chrome = {
+      runtime: {
+        id: 'test-extension-id',
+        sendMessage,
+        lastError: null,
+      },
+      storage: {
+        local: {
+          get: jest.fn((_, cb) => cb?.({})),
+          set: jest.fn((_, cb) => cb?.()),
+          remove: jest.fn((_, cb) => cb?.()),
+        },
+      },
+    };
+
+    const fakeHighlightObject = {
+      add: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+    };
+    mockStyleManager = {
+      initialize: jest.fn(),
+      clearAllHighlights: jest.fn(),
+      getHighlightObject: jest.fn(() => fakeHighlightObject),
+      injectStyles: jest.fn(),
+    };
+
+    manager = new HighlightManager();
+    storage = new HighlightStorage(manager);
+    manager.setDependencies({
+      styleManager: mockStyleManager,
+      interaction: null,
+      storage,
+      migration: null,
+    });
+
+    manager.highlights.set('h1', {
+      id: 'h1',
+      range: { startOffset: 0, endOffset: 5 },
+      color: 'yellow',
+      text: 'hello',
+      timestamp: 1,
+      rangeInfo: {},
+    });
+
+    mountWindowAPI(manager, null, storage);
+  });
+
+  afterEach(() => {
+    delete globalThis.HighlighterV2;
+    delete globalThis.notionHighlighter;
+    delete globalThis.clearPageHighlights;
+    delete globalThis.chrome;
+    delete globalThis.location;
+  });
+
+  function countClearHighlights() {
+    return sendMessage.mock.calls.filter(args => args[0]?.action === 'CLEAR_HIGHLIGHTS').length;
+  }
+
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  test('removeHighlight 後 background 注入的 clearPageHighlights 不應再次觸發 CLEAR_HIGHLIGHTS', async () => {
+    manager.removeHighlight('h1');
+    await flush();
+
+    expect(countClearHighlights()).toBe(1);
+
+    globalThis.clearPageHighlights();
+    await flush();
+
+    expect(countClearHighlights()).toBe(1);
+    expect(manager.highlights.size).toBe(0);
+  });
+
+  test('rail/toolbar 主動呼叫 manager.clearAll() 仍會觸發 CLEAR_HIGHLIGHTS（契約未退化）', async () => {
+    manager.clearAll();
+    await flush();
+
+    expect(countClearHighlights()).toBe(1);
+  });
+});

--- a/tests/unit/highlighter/core/StyleManager.namespace.test.js
+++ b/tests/unit/highlighter/core/StyleManager.namespace.test.js
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ *
+ * StyleManager 必須以 chrome.runtime.id 作 namespace 邊界。
+ *
+ * 場景：商店版 + 測試版兩個 extension 同時注入同一頁面時，page-global 的
+ * `CSS.highlights` registry 與 `<style id="...">` 元素都會被後初始化的覆蓋，
+ * 導致前者的 highlight ranges 失去視覺渲染。
+ *
+ * 修復前：兩個 instance 都寫 `CSS.highlights.set('notion-yellow', ...)`
+ *         與 `<style id="notion-highlight-styles">`，互相覆蓋。
+ * 修復後：key 與 element id 都帶 `chrome.runtime.id` namespace，互不影響。
+ */
+
+import { StyleManager } from '../../../../scripts/highlighter/core/StyleManager.js';
+import { COLORS } from '../../../../scripts/highlighter/utils/color.js';
+
+jest.mock('../../../../scripts/highlighter/utils/dom.js', () => ({
+  supportsHighlightAPI: jest.fn(() => true),
+}));
+
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  log: jest.fn(),
+}));
+
+function setRuntimeId(id) {
+  globalThis.chrome = globalThis.chrome ?? { runtime: {} };
+  globalThis.chrome.runtime = globalThis.chrome.runtime ?? {};
+  globalThis.chrome.runtime.id = id;
+}
+
+function highlightKeysForRuntimeId(id) {
+  return CSS.highlights.set.mock.calls
+    .map(args => args[0])
+    .filter(key => typeof key === 'string' && key.includes(id));
+}
+
+describe('core/StyleManager — chrome.runtime.id namespace', () => {
+  const ORIGINAL_RUNTIME_ID = globalThis.chrome?.runtime?.id;
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+
+    globalThis.CSS = {
+      highlights: {
+        set: jest.fn(),
+        get: jest.fn(),
+        delete: jest.fn(),
+        clear: jest.fn(),
+      },
+    };
+
+    globalThis.Highlight = jest.fn().mockImplementation(() => ({
+      add: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+    }));
+    globalThis.Highlight.toString = () => 'function Highlight() { [native code] }';
+  });
+
+  afterEach(() => {
+    if (globalThis.chrome?.runtime) {
+      globalThis.chrome.runtime.id = ORIGINAL_RUNTIME_ID;
+    }
+  });
+
+  test('CSS.highlights.set key 必須帶 chrome.runtime.id，避免兩個 extension 互覆蓋', () => {
+    setRuntimeId('ext-aaa');
+    new StyleManager().initialize();
+
+    const colorCount = Object.keys(COLORS).length;
+    const aaaKeys = highlightKeysForRuntimeId('ext-aaa');
+
+    expect(aaaKeys).toHaveLength(colorCount);
+    Object.keys(COLORS).forEach(color => {
+      expect(aaaKeys).toEqual(expect.arrayContaining([expect.stringContaining(color)]));
+    });
+
+    Object.keys(COLORS).forEach(color => {
+      expect(CSS.highlights.set).not.toHaveBeenCalledWith(`notion-${color}`, expect.anything());
+    });
+  });
+
+  test('兩個 StyleManager instance（不同 runtime.id）不應註冊到相同的 CSS.highlights key', () => {
+    setRuntimeId('ext-aaa');
+    new StyleManager().initialize();
+    const aaaKeys = highlightKeysForRuntimeId('ext-aaa');
+
+    setRuntimeId('ext-bbb');
+    new StyleManager().initialize();
+    const bbbKeys = highlightKeysForRuntimeId('ext-bbb');
+
+    const intersection = aaaKeys.filter(key => bbbKeys.includes(key));
+    expect(intersection).toEqual([]);
+
+    Object.keys(COLORS).forEach(color => {
+      expect(aaaKeys).toEqual(expect.arrayContaining([expect.stringContaining(color)]));
+      expect(bbbKeys).toEqual(expect.arrayContaining([expect.stringContaining(color)]));
+    });
+  });
+
+  test('<style> 元素 id 必須帶 namespace，兩個 extension 不會互相覆蓋 stylesheet', () => {
+    setRuntimeId('ext-aaa');
+    new StyleManager().initialize();
+
+    setRuntimeId('ext-bbb');
+    new StyleManager().initialize();
+
+    const styleElements = document.head.querySelectorAll('style[id^="notion-highlight-styles"]');
+    expect(styleElements).toHaveLength(2);
+
+    const ids = Array.from(styleElements).map(el => el.id);
+    expect(ids).toEqual(expect.arrayContaining([expect.stringContaining('ext-aaa')]));
+    expect(ids).toEqual(expect.arrayContaining([expect.stringContaining('ext-bbb')]));
+  });
+
+  test('cleanup 只能移除自己 namespace 下的 highlights，不可誤刪其他 extension 的', () => {
+    setRuntimeId('ext-aaa');
+    const managerA = new StyleManager();
+    managerA.initialize();
+
+    setRuntimeId('ext-bbb');
+    const managerB = new StyleManager();
+    managerB.initialize();
+
+    CSS.highlights.delete.mockClear();
+    managerA.cleanup();
+
+    const deletedKeys = CSS.highlights.delete.mock.calls.map(args => args[0]);
+
+    expect(deletedKeys.length).toBeGreaterThan(0);
+    deletedKeys.forEach(key => {
+      expect(key).toEqual(expect.stringContaining('ext-aaa'));
+      expect(key).not.toEqual(expect.stringContaining('ext-bbb'));
+    });
+  });
+
+  test('CSS rule `::highlight(...)` 名稱必須與註冊的 key 一致（含 namespace）', () => {
+    setRuntimeId('ext-aaa');
+    new StyleManager().initialize();
+
+    const styleEl = document.head.querySelector('style[id^="notion-highlight-styles"]');
+    expect(styleEl).not.toBeNull();
+
+    Object.keys(COLORS).forEach(color => {
+      expect(styleEl.textContent).toContain(`::highlight(notion-ext-aaa-${color})`);
+      expect(styleEl.textContent).not.toMatch(
+        new RegExp(String.raw`::highlight\(notion-${color}\)`)
+      );
+    });
+  });
+});

--- a/tests/unit/highlighter/core/StyleManager.namespace.test.js
+++ b/tests/unit/highlighter/core/StyleManager.namespace.test.js
@@ -14,6 +14,7 @@
 
 import { StyleManager } from '../../../../scripts/highlighter/core/StyleManager.js';
 import { COLORS } from '../../../../scripts/highlighter/utils/color.js';
+import Logger from '../../../../scripts/utils/Logger.js';
 
 jest.mock('../../../../scripts/highlighter/utils/dom.js', () => ({
   supportsHighlightAPI: jest.fn(() => true),
@@ -151,6 +152,40 @@ describe('core/StyleManager — chrome.runtime.id namespace', () => {
       expect(styleEl.textContent).not.toMatch(
         new RegExp(String.raw`::highlight\(notion-${color}\)`)
       );
+    });
+  });
+
+  describe('chrome.runtime.id fallback warning', () => {
+    let originalChrome;
+
+    beforeEach(() => {
+      Logger.warn.mockClear();
+      originalChrome = globalThis.chrome;
+    });
+
+    afterEach(() => {
+      globalThis.chrome = originalChrome;
+    });
+
+    test('chrome.runtime.id 缺失時 MUST 透過 Logger.warn 提示 fallback，避免 namespace collision 被靜默吞掉', () => {
+      delete globalThis.chrome;
+
+      const manager = new StyleManager();
+
+      expect(manager.instanceId).toBe('unknown');
+      expect(Logger.warn).toHaveBeenCalledTimes(1);
+      const [warnMessage] = Logger.warn.mock.calls[0];
+      expect(warnMessage).toEqual(expect.stringContaining('chrome.runtime.id'));
+      expect(warnMessage).toEqual(expect.stringContaining('unknown'));
+    });
+
+    test('chrome.runtime.id 存在時 MUST NOT 觸發 fallback warning', () => {
+      setRuntimeId('ext-aaa');
+
+      const manager = new StyleManager();
+
+      expect(manager.instanceId).toBe('ext-aaa');
+      expect(Logger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/highlighter/core/StyleManager.test.js
+++ b/tests/unit/highlighter/core/StyleManager.test.js
@@ -49,11 +49,10 @@ describe('core/StyleManager', () => {
     if (styleManager) {
       styleManager.cleanup();
     }
-    // 清理樣式元素
-    const style = document.querySelector('#notion-highlight-styles');
-    if (style) {
-      style.remove();
-    }
+    // 清理樣式元素（namespace-aware：用 prefix selector 涵蓋所有 instance）
+    document.head
+      .querySelectorAll('style[id^="notion-highlight-styles"]')
+      .forEach(el => el.remove());
   });
 
   describe('constructor', () => {
@@ -89,14 +88,17 @@ describe('core/StyleManager', () => {
       styleManager.initialize();
 
       Object.keys(COLORS).forEach(color => {
-        expect(CSS.highlights.set).toHaveBeenCalledWith(`notion-${color}`, expect.anything());
+        expect(CSS.highlights.set).toHaveBeenCalledWith(
+          styleManager.getHighlightKey(color),
+          expect.anything()
+        );
       });
     });
 
     test('should inject styles after initialization', () => {
       styleManager.initialize();
 
-      const style = document.querySelector('#notion-highlight-styles');
+      const style = document.querySelector(styleManager.styleSelector);
       expect(style).toBeTruthy();
     });
 
@@ -113,7 +115,7 @@ describe('core/StyleManager', () => {
     test('should inject style element into head', () => {
       styleManager.injectStyles();
 
-      const style = document.querySelector('#notion-highlight-styles');
+      const style = document.querySelector(styleManager.styleSelector);
       expect(style).not.toBeNull();
       expect(document.head.contains(style)).toBe(true);
     });
@@ -122,7 +124,7 @@ describe('core/StyleManager', () => {
       styleManager.styleMode = 'background';
       styleManager.injectStyles();
 
-      const style = document.querySelector('#notion-highlight-styles');
+      const style = document.querySelector(styleManager.styleSelector);
       expect(style.textContent).toContain('background-color:');
       expect(style.textContent).toContain('color: black');
     });
@@ -131,7 +133,7 @@ describe('core/StyleManager', () => {
       styleManager.styleMode = 'text';
       styleManager.injectStyles();
 
-      const style = document.querySelector('#notion-highlight-styles');
+      const style = document.querySelector(styleManager.styleSelector);
       expect(style.textContent).toContain('background-color: transparent');
     });
 
@@ -139,19 +141,19 @@ describe('core/StyleManager', () => {
       styleManager.styleMode = 'underline';
       styleManager.injectStyles();
 
-      const style = document.querySelector('#notion-highlight-styles');
+      const style = document.querySelector(styleManager.styleSelector);
       expect(style.textContent).toContain('text-decoration: underline');
       expect(style.textContent).toContain('text-decoration-color:');
     });
 
     test('should update existing style element', () => {
       styleManager.injectStyles();
-      const style1 = document.querySelector('#notion-highlight-styles');
+      const style1 = document.querySelector(styleManager.styleSelector);
       expect(style1.dataset.styleMode).toBe('background');
 
       styleManager.styleMode = 'text';
       styleManager.injectStyles();
-      const style2 = document.querySelector('#notion-highlight-styles');
+      const style2 = document.querySelector(styleManager.styleSelector);
       expect(style2.dataset.styleMode).toBe('text');
     });
 
@@ -159,7 +161,7 @@ describe('core/StyleManager', () => {
       styleManager.injectStyles();
       styleManager.injectStyles();
 
-      const styles = document.querySelectorAll('#notion-highlight-styles');
+      const styles = document.querySelectorAll(styleManager.styleSelector);
       expect(styles).toHaveLength(1);
     });
   });
@@ -230,10 +232,10 @@ describe('core/StyleManager', () => {
   describe('cleanup', () => {
     test('should remove style element', () => {
       styleManager.injectStyles();
-      expect(document.querySelector('#notion-highlight-styles')).toBeTruthy();
+      expect(document.querySelector(styleManager.styleSelector)).toBeTruthy();
 
       styleManager.cleanup();
-      expect(document.querySelector('#notion-highlight-styles')).toBeNull();
+      expect(document.querySelector(styleManager.styleSelector)).toBeNull();
     });
 
     test('should delete highlights from CSS.highlights', () => {
@@ -241,7 +243,7 @@ describe('core/StyleManager', () => {
       styleManager.cleanup();
 
       Object.keys(COLORS).forEach(color => {
-        expect(CSS.highlights.delete).toHaveBeenCalledWith(`notion-${color}`);
+        expect(CSS.highlights.delete).toHaveBeenCalledWith(styleManager.getHighlightKey(color));
       });
     });
 

--- a/tests/unit/highlighter/windowAPI.clearPageHighlights.test.js
+++ b/tests/unit/highlighter/windowAPI.clearPageHighlights.test.js
@@ -1,0 +1,92 @@
+import { mountWindowAPI } from '../../../scripts/highlighter/windowAPI.js';
+import { HighlightManager } from '../../../scripts/highlighter/core/HighlightManager.js';
+
+jest.mock('../../../scripts/highlighter/ui/Toolbar.js', () => ({
+  Toolbar: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    updateHighlightCount: jest.fn(),
+    show: jest.fn(),
+    hide: jest.fn(),
+    minimize: jest.fn(),
+    stateManager: { currentState: 'hidden' },
+  })),
+}));
+
+describe('windowAPI.clearPageHighlights — skipStorage contract', () => {
+  let manager;
+  let mockStorage;
+  let mockStyleManager;
+
+  beforeEach(() => {
+    delete globalThis.HighlighterV2;
+    delete globalThis.notionHighlighter;
+    delete globalThis.initHighlighter;
+    delete globalThis.collectHighlights;
+    delete globalThis.clearPageHighlights;
+
+    mockStyleManager = {
+      clearAllHighlights: jest.fn(),
+      getHighlightObject: jest.fn(),
+      initialize: jest.fn(),
+    };
+    mockStorage = {
+      save: jest.fn().mockResolvedValue(undefined),
+      restore: jest.fn().mockResolvedValue(undefined),
+    };
+
+    manager = new HighlightManager();
+    manager.setDependencies({
+      styleManager: mockStyleManager,
+      interaction: null,
+      storage: mockStorage,
+      migration: null,
+    });
+
+    manager.highlights.set('h1', {
+      id: 'h1',
+      range: { startOffset: 0, endOffset: 5 },
+      color: 'yellow',
+      text: 'hello',
+      timestamp: 1,
+      rangeInfo: {},
+    });
+  });
+
+  afterEach(() => {
+    delete globalThis.HighlighterV2;
+    delete globalThis.notionHighlighter;
+    delete globalThis.initHighlighter;
+    delete globalThis.collectHighlights;
+    delete globalThis.clearPageHighlights;
+  });
+
+  test('globalThis.clearPageHighlights() 應走 skipStorage 路徑、不觸發 storage.save', () => {
+    mountWindowAPI(manager, null, mockStorage);
+
+    globalThis.clearPageHighlights();
+
+    expect(manager.highlights.size).toBe(0);
+    expect(mockStyleManager.clearAllHighlights).toHaveBeenCalledTimes(1);
+    expect(mockStorage.save).not.toHaveBeenCalled();
+  });
+
+  test('notionHighlighter.clearAll() 預設行為（無參）仍會觸發 storage.save', () => {
+    mountWindowAPI(manager, null, mockStorage);
+
+    globalThis.notionHighlighter.clearAll();
+
+    expect(manager.highlights.size).toBe(0);
+    expect(mockStyleManager.clearAllHighlights).toHaveBeenCalledTimes(1);
+    expect(mockStorage.save).toHaveBeenCalledTimes(1);
+  });
+
+  test('notionHighlighter.clearAll({ skipStorage: true }) 應跳過 storage.save', () => {
+    mountWindowAPI(manager, null, mockStorage);
+
+    globalThis.notionHighlighter.clearAll({ skipStorage: true });
+
+    expect(manager.highlights.size).toBe(0);
+    expect(mockStyleManager.clearAllHighlights).toHaveBeenCalledTimes(1);
+    expect(mockStorage.save).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### 摘要
修正高亮清除時的遞迴問題，並為 StyleManager 增加命名空間以避免樣式衝突。

### 變更內容
- 更新 `clearAll` 方法以接受選項參數，支持跳過存儲功能。
- 確保在清除高亮時不會再次觸發 `CLEAR_HIGHLIGHTS`。
- 為 `StyleManager` 的 CSS.highlights 鍵值和樣式元素 ID 加上命名空間，避免多個擴展同時注入時互相覆蓋。
- 增加測試以驗證清除高亮的行為及命名空間的正確性。

### 測試方式
已新增測試以驗證高亮清除邏輯及命名空間功能。

### 潛在風險
無顯著風險。

