### PR TITLE
feat: add saturation protection mechanism for log buffer

### DIFF
--- a/.agents/.shared/knowledge/debugging_rules.json
+++ b/.agents/.shared/knowledge/debugging_rules.json
@@ -58,7 +58,16 @@
     },
     "design_decisions": {
       "no_timestamp": "單用戶場景 + Chrome DevTools 內建時間戳，FIFO LogBuffer 隱含時間順序",
-      "console_dx": "持久化層結構化，展示層人性化（控制台保留多參數展開行為，不強制 JSON.stringify）"
+      "console_dx": "持久化層結構化，展示層人性化（控制台保留多參數展開行為，不強制 JSON.stringify）",
+      "saturation_protection": {
+        "strategy": "per-fingerprint count quota over buffer-resident entries",
+        "fingerprint": "message + context.action",
+        "suppress_threshold": 10,
+        "anomaly_threshold": 30,
+        "anomaly_marker": "[ANOMALY] message looped N× in buffer: \"...\"",
+        "context_fields_added": ["repeatCount", "anomaly", "repeatedMessage", "repeatedAction"],
+        "rationale": "buffer 是 FIFO + 有界容量；以 buffer-resident count 作配額避免迴圈訊息壓垮真實使用者事件，無需引入 timestamp。閾值 10/30 對應本 extension 的圖片批次 / highlight restore 等合法批次場景，避免 false-positive ANOMALY 稀釋警告信號可信度。"
+      }
     }
   },
   "precise_test_fixing": {

--- a/scripts/utils/LogBuffer.js
+++ b/scripts/utils/LogBuffer.js
@@ -28,13 +28,17 @@ const ANOMALY_THRESHOLD = 30;
 const ANOMALY_MESSAGE_TRUNCATE = 200;
 
 /**
- * 計算 entry 指紋：`${message}::${context.action}`
+ * 計算 entry 指紋。
+ *
+ * 使用 JSON.stringify([message, action]) 序列化 message 與 context.action 組成的 tuple,
+ * 利用 JSON 的字串逸出語法消除分隔字元歧義 — 例如 message="a::" + action="b" 與
+ * message="a" + action="::b" 在拼接式 fingerprint 下會碰撞,改成 JSON tuple 後可清楚區分。
  *
  * @param {object} entry - 日誌條目
  * @returns {string} fingerprint
  */
 function generateFingerprint(entry) {
-  return `${entry.message ?? ''}::${entry.context?.action ?? ''}`;
+  return JSON.stringify([entry.message ?? '', entry.context?.action ?? '']);
 }
 
 /**
@@ -150,17 +154,12 @@ export class LogBuffer {
    * 添加一條日誌記錄。當同一 fingerprint 在 buffer 中累計達 SUPPRESS_THRESHOLD 後，
    * 後續同 fingerprint 條目改為遞增既有條目的 context.repeatCount，不再消耗新 slot。
    *
+   * 註：fingerprint 必須由最終 entryToStore（經 needsSizeCheck / _processOversizedEntry 處理後）
+   * 衍生，以避免「SUPPRESS 檢查用原始 fp、計數累積在截斷後 fp」造成的 key split。
+   *
    * @param {object} entry - 日誌對象
    */
   push(entry) {
-    const fp = generateFingerprint(entry);
-    const slotCount = this._fingerprintCounts.get(fp) ?? 0;
-
-    if (slotCount >= SUPPRESS_THRESHOLD) {
-      this._handleSuppressedPush(fp, entry);
-      return;
-    }
-
     let entryToStore = { ...entry };
 
     // [Performance Optimization] 僅在需要時執行完整序列化檢查
@@ -168,7 +167,15 @@ export class LogBuffer {
       entryToStore = this._processOversizedEntry(entry, entryToStore);
     }
 
-    this._writeRawEntry(entryToStore);
+    const fp = generateFingerprint(entryToStore);
+    const slotCount = this._fingerprintCounts.get(fp) ?? 0;
+
+    if (slotCount >= SUPPRESS_THRESHOLD) {
+      this._handleSuppressedPush(fp, entry);
+      return;
+    }
+
+    this._writeRawEntry(entryToStore, fp);
   }
 
   /**
@@ -176,9 +183,11 @@ export class LogBuffer {
    * 不執行 fingerprint 抑制檢查，供 push() happy path 與 _emitAnomaly 共用。
    *
    * @param {object} entryToStore - 已完成大小檢查的條目
+   * @param {string} [fp] - 已預算好的 fingerprint；省略時由 entryToStore 重新計算
+   *   （anomaly 路徑沒有預算 fp）
    * @private
    */
-  _writeRawEntry(entryToStore) {
+  _writeRawEntry(entryToStore, fp) {
     const writeIndex = (this.head + this.size) % this.capacity;
     const isFull = this.size === this.capacity;
 
@@ -196,7 +205,7 @@ export class LogBuffer {
       this.head = (this.head + 1) % this.capacity;
     }
 
-    const newFp = generateFingerprint(entryToStore);
+    const newFp = fp ?? generateFingerprint(entryToStore);
     this._fingerprintCounts.set(newFp, (this._fingerprintCounts.get(newFp) ?? 0) + 1);
     this._lastIndexByFingerprint.set(newFp, writeIndex);
   }

--- a/scripts/utils/LogBuffer.js
+++ b/scripts/utils/LogBuffer.js
@@ -20,6 +20,23 @@ const FALLBACK_STRUCTURE_OVERHEAD = 350;
 // 標準欄位列表
 const STANDARD_FIELDS = new Set(['level', 'message', 'source', 'context']);
 
+// [Saturation Protection - issue #533]
+// 同 fingerprint 的 buffer-resident 條目達 SUPPRESS_THRESHOLD 後改為更新既有條目 repeatCount。
+// 達 ANOMALY_THRESHOLD 時 emit 一次 [ANOMALY] warn 條目；FIFO 驅逐到無同 fingerprint 條目時重置。
+const SUPPRESS_THRESHOLD = 10;
+const ANOMALY_THRESHOLD = 30;
+const ANOMALY_MESSAGE_TRUNCATE = 200;
+
+/**
+ * 計算 entry 指紋：`${message}::${context.action}`
+ *
+ * @param {object} entry - 日誌條目
+ * @returns {string} fingerprint
+ */
+function generateFingerprint(entry) {
+  return `${entry.message ?? ''}::${entry.context?.action ?? ''}`;
+}
+
 /**
  * 截斷訊息至指定長度
  *
@@ -122,14 +139,28 @@ export class LogBuffer {
     this.buffer = Array.from({ length: this.capacity });
     this.head = 0; // 指向最舊記錄的索引
     this.size = 0; // 當前記錄數量
+
+    // [Saturation Protection] fingerprint 追蹤狀態（issue #533）
+    this._fingerprintCounts = new Map(); // fp -> 當前實際 slot 數
+    this._lastIndexByFingerprint = new Map(); // fp -> 最後寫入該 fp 的 buffer index
+    this._anomalyEmitted = new Set(); // 已 emit 過 anomaly 的 fp
   }
 
   /**
-   * 添加一條日誌記錄
+   * 添加一條日誌記錄。當同一 fingerprint 在 buffer 中累計達 SUPPRESS_THRESHOLD 後，
+   * 後續同 fingerprint 條目改為遞增既有條目的 context.repeatCount，不再消耗新 slot。
    *
    * @param {object} entry - 日誌對象
    */
   push(entry) {
+    const fp = generateFingerprint(entry);
+    const slotCount = this._fingerprintCounts.get(fp) ?? 0;
+
+    if (slotCount >= SUPPRESS_THRESHOLD) {
+      this._handleSuppressedPush(fp, entry);
+      return;
+    }
+
     let entryToStore = { ...entry };
 
     // [Performance Optimization] 僅在需要時執行完整序列化檢查
@@ -137,8 +168,25 @@ export class LogBuffer {
       entryToStore = this._processOversizedEntry(entry, entryToStore);
     }
 
-    // 計算寫入位置：(head + size) % capacity
+    this._writeRawEntry(entryToStore);
+  }
+
+  /**
+   * 將 entry 寫入 buffer slot 並維護 FIFO + fingerprint 計數。
+   * 不執行 fingerprint 抑制檢查，供 push() happy path 與 _emitAnomaly 共用。
+   *
+   * @param {object} entryToStore - 已完成大小檢查的條目
+   * @private
+   */
+  _writeRawEntry(entryToStore) {
     const writeIndex = (this.head + this.size) % this.capacity;
+    const isFull = this.size === this.capacity;
+
+    if (isFull) {
+      const evictedFp = generateFingerprint(this.buffer[writeIndex]);
+      this._handleEviction(evictedFp);
+    }
+
     this.buffer[writeIndex] = entryToStore;
 
     if (this.size < this.capacity) {
@@ -147,6 +195,84 @@ export class LogBuffer {
       // 緩衝區已滿，覆蓋了最舊的，head 往前移
       this.head = (this.head + 1) % this.capacity;
     }
+
+    const newFp = generateFingerprint(entryToStore);
+    this._fingerprintCounts.set(newFp, (this._fingerprintCounts.get(newFp) ?? 0) + 1);
+    this._lastIndexByFingerprint.set(newFp, writeIndex);
+  }
+
+  /**
+   * 抑制路徑：fingerprint 已達 SUPPRESS_THRESHOLD 時，更新最後一條同 fp 條目的 repeatCount，
+   * 不寫入新 slot。當 repeatCount 首次達 ANOMALY_THRESHOLD 時 emit 一條 [ANOMALY] warn。
+   *
+   * @param {string} fp - 指紋
+   * @param {object} originalEntry - 原始日誌對象（用於 anomaly 引用）
+   * @private
+   */
+  _handleSuppressedPush(fp, originalEntry) {
+    const lastIdx = this._lastIndexByFingerprint.get(fp);
+    const lastEntry = this.buffer[lastIdx];
+    const slotCount = this._fingerprintCounts.get(fp);
+    const currentRepeat = lastEntry.context?.repeatCount ?? slotCount;
+    const newRepeat = currentRepeat + 1;
+
+    lastEntry.context = {
+      ...lastEntry.context,
+      repeatCount: newRepeat,
+    };
+
+    if (newRepeat === ANOMALY_THRESHOLD && !this._anomalyEmitted.has(fp)) {
+      this._anomalyEmitted.add(fp);
+      this._emitAnomaly(originalEntry, newRepeat);
+    }
+  }
+
+  /**
+   * Emit 一條 [ANOMALY] warn 條目記錄迴圈訊息。透過 _writeRawEntry 寫入，
+   * 不經 push() 的 fingerprint 抑制路徑（anomaly 自身的 fp 與被觀察 fp 不同）。
+   *
+   * @param {object} originalEntry - 觸發 anomaly 的原始條目
+   * @param {number} count - 已累計的 repeatCount
+   * @private
+   */
+  _emitAnomaly(originalEntry, count) {
+    const truncated = truncateMessage(
+      String(originalEntry?.message ?? ''),
+      ANOMALY_MESSAGE_TRUNCATE
+    );
+    this._writeRawEntry({
+      level: 'warn',
+      source: originalEntry?.source ?? 'unknown',
+      message: `[ANOMALY] message looped ${count}× in buffer: "${truncated}"`,
+      context: {
+        anomaly: true,
+        repeatedMessage: originalEntry?.message,
+        repeatedAction: originalEntry?.context?.action,
+        repeatCount: count,
+      },
+    });
+  }
+
+  /**
+   * 處理 FIFO 驅逐：遞減 evictedFp 的計數。
+   * 若 evictedFp 在 buffer 中已無任何 slot，清理對應 anomaly state，允許未來重新觸發 anomaly。
+   *
+   * 不變式：lastIndexByFingerprint 永遠指向最新 slot，FIFO eviction 永遠發生在最舊 slot
+   * （= head）。同 fp 的最後一個 slot 必為最舊一個，因此 lastIndex 被驅逐時 count 必同時降為 0
+   * 走 early-cleanup 分支；不需要修補 lastIndex。
+   *
+   * @param {string} evictedFp - 被驅逐條目的指紋
+   * @private
+   */
+  _handleEviction(evictedFp) {
+    const newCount = this._fingerprintCounts.get(evictedFp) - 1;
+    if (newCount <= 0) {
+      this._fingerprintCounts.delete(evictedFp);
+      this._lastIndexByFingerprint.delete(evictedFp);
+      this._anomalyEmitted.delete(evictedFp);
+      return;
+    }
+    this._fingerprintCounts.set(evictedFp, newCount);
   }
 
   /**
@@ -193,6 +319,9 @@ export class LogBuffer {
     this.buffer = Array.from({ length: this.capacity });
     this.head = 0;
     this.size = 0;
+    this._fingerprintCounts.clear();
+    this._lastIndexByFingerprint.clear();
+    this._anomalyEmitted.clear();
   }
 
   /**

--- a/scripts/utils/LogBuffer.js
+++ b/scripts/utils/LogBuffer.js
@@ -231,6 +231,10 @@ export class LogBuffer {
    * Emit 一條 [ANOMALY] warn 條目記錄迴圈訊息。透過 _writeRawEntry 寫入，
    * 不經 push() 的 fingerprint 抑制路徑（anomaly 自身的 fp 與被觀察 fp 不同）。
    *
+   * [Memory Safety] _writeRawEntry 不做 size check，因此這裡 MUST 使用已截斷的
+   * `truncated` 作為 context.repeatedMessage，避免大 message 透過 anomaly entry
+   * 繞過 MAX_ENTRY_SIZE 邊界。不可改回 originalEntry?.message。
+   *
    * @param {object} originalEntry - 觸發 anomaly 的原始條目
    * @param {number} count - 已累計的 repeatCount
    * @private
@@ -246,7 +250,7 @@ export class LogBuffer {
       message: `[ANOMALY] message looped ${count}× in buffer: "${truncated}"`,
       context: {
         anomaly: true,
-        repeatedMessage: originalEntry?.message,
+        repeatedMessage: truncated,
         repeatedAction: originalEntry?.context?.action,
         repeatCount: count,
       },

--- a/tests/unit/utils/LogBuffer.test.js
+++ b/tests/unit/utils/LogBuffer.test.js
@@ -1,5 +1,20 @@
 import { LogBuffer } from '../../../scripts/utils/LogBuffer.js';
 
+function pushSame(buffer, message, action, times) {
+  for (let i = 0; i < times; i++) {
+    buffer.push({
+      level: 'log',
+      source: 'background',
+      message,
+      context: { action },
+    });
+  }
+}
+
+function getAnomalies(logs) {
+  return logs.filter(log => log.context?.anomaly === true);
+}
+
 describe('LogBuffer', () => {
   let logBuffer = null;
   const DEFAULT_CAPACITY = 5; // A small capacity for easier testing
@@ -130,6 +145,257 @@ describe('LogBuffer', () => {
       const stats = logBuffer.getStats();
       expect(stats.count).toBe(0);
       expect(stats.capacity).toBe(DEFAULT_CAPACITY);
+    });
+  });
+
+  // Saturation protection (issue #533)
+  // Plan thresholds: SUPPRESS_THRESHOLD = 10, ANOMALY_THRESHOLD = 30
+  // Fingerprint = `${message}::${context?.action ?? ''}`
+  describe('Saturation protection', () => {
+    const SAT_CAPACITY = 100;
+    let satBuf;
+
+    beforeEach(() => {
+      satBuf = new LogBuffer(SAT_CAPACITY);
+    });
+
+    describe('Suppression', () => {
+      test('suppresses pushes past SUPPRESS_THRESHOLD by mutating last entry repeatCount', () => {
+        pushSame(satBuf, 'phase-3', 'CLEAR_HIGHLIGHTS', 11);
+
+        const logs = satBuf.getAll();
+        const matches = logs.filter(
+          l => l.message === 'phase-3' && l.context?.action === 'CLEAR_HIGHLIGHTS'
+        );
+
+        expect(matches).toHaveLength(10);
+
+        for (let i = 0; i < 9; i++) {
+          expect(matches[i].context.repeatCount).toBeUndefined();
+        }
+
+        expect(matches[9].context.repeatCount).toBe(11);
+      });
+
+      test('caps both A and B at 10 normal entries under A/B alternating loop', () => {
+        const aMsg = '[Injection] Script executed successfully';
+        const bMsg = 'Phase 3: CLEAR_HIGHLIGHTS 成功';
+
+        /* eslint-disable unicorn/prefer-single-call -- LogBuffer.push is not Array.push */
+        for (let i = 0; i < 25; i++) {
+          satBuf.push({ level: 'info', source: 'background', message: aMsg, context: {} });
+          satBuf.push({
+            level: 'info',
+            source: 'background',
+            message: bMsg,
+            context: { action: 'CLEAR_HIGHLIGHTS' },
+          });
+        }
+        /* eslint-enable unicorn/prefer-single-call */
+
+        const logs = satBuf.getAll();
+        const aMatches = logs.filter(l => l.message === aMsg);
+        const bMatches = logs.filter(l => l.message === bMsg);
+
+        expect(aMatches).toHaveLength(10);
+        expect(bMatches).toHaveLength(10);
+
+        expect(aMatches.at(-1).context.repeatCount).toBe(25);
+        expect(bMatches.at(-1).context.repeatCount).toBe(25);
+      });
+
+      test('non-repeating entry between suppressed pushes does not reset fingerprint count', () => {
+        pushSame(satBuf, 'msg-A', 'action-A', 11);
+
+        /* eslint-disable unicorn/prefer-single-call -- LogBuffer.push is not Array.push */
+        satBuf.push({
+          level: 'log',
+          source: 'background',
+          message: 'msg-C',
+          context: { action: 'action-C' },
+        });
+        satBuf.push({
+          level: 'log',
+          source: 'background',
+          message: 'msg-A',
+          context: { action: 'action-A' },
+        });
+        /* eslint-enable unicorn/prefer-single-call */
+
+        const logs = satBuf.getAll();
+        const aMatches = logs.filter(
+          l => l.message === 'msg-A' && l.context?.action === 'action-A'
+        );
+        const cMatches = logs.filter(
+          l => l.message === 'msg-C' && l.context?.action === 'action-C'
+        );
+
+        expect(aMatches).toHaveLength(10);
+        expect(cMatches).toHaveLength(1);
+        expect(aMatches.at(-1).context.repeatCount).toBe(12);
+      });
+
+      test('different actions for the same message are tracked as separate fingerprints', () => {
+        /* eslint-disable unicorn/prefer-single-call -- LogBuffer.push is not Array.push */
+        for (let i = 0; i < 11; i++) {
+          satBuf.push({
+            level: 'log',
+            source: 'background',
+            message: 'shared-msg',
+            context: { action: 'action-A' },
+          });
+          satBuf.push({
+            level: 'log',
+            source: 'background',
+            message: 'shared-msg',
+            context: { action: 'action-B' },
+          });
+        }
+        /* eslint-enable unicorn/prefer-single-call */
+
+        const logs = satBuf.getAll();
+        const aMatches = logs.filter(
+          l => l.message === 'shared-msg' && l.context?.action === 'action-A'
+        );
+        const bMatches = logs.filter(
+          l => l.message === 'shared-msg' && l.context?.action === 'action-B'
+        );
+
+        expect(aMatches).toHaveLength(10);
+        expect(bMatches).toHaveLength(10);
+      });
+
+      test('same action with different unrelated context fields shares fingerprint', () => {
+        for (let i = 0; i < 11; i++) {
+          satBuf.push({
+            level: 'log',
+            source: 'background',
+            message: 'msg',
+            context: { action: 'do-thing', url: `https://example.com/${i}` },
+          });
+        }
+
+        const logs = satBuf.getAll();
+        const matches = logs.filter(l => l.message === 'msg' && l.context?.action === 'do-thing');
+
+        expect(matches).toHaveLength(10);
+        expect(matches.at(-1).context.repeatCount).toBe(11);
+      });
+    });
+
+    describe('Anomaly emission', () => {
+      test('emits exactly one [ANOMALY] entry when count first hits ANOMALY_THRESHOLD', () => {
+        pushSame(satBuf, 'msg-A', 'action-A', 30);
+
+        const logs = satBuf.getAll();
+        const anomalies = getAnomalies(logs);
+
+        expect(anomalies).toHaveLength(1);
+
+        const anomaly = anomalies[0];
+        expect(anomaly.level).toBe('warn');
+        expect(anomaly.context.anomaly).toBe(true);
+        expect(anomaly.context.repeatCount).toBe(30);
+        expect(anomaly.context.repeatedMessage).toBe('msg-A');
+        expect(anomaly.context.repeatedAction).toBe('action-A');
+        expect(anomaly.message).toMatch(/^\[ANOMALY\] message looped 30× in buffer:/);
+      });
+
+      test('does not re-emit anomaly within the same episode (60 pushes -> 1 ANOMALY)', () => {
+        pushSame(satBuf, 'msg-A', 'action-A', 60);
+
+        const anomalies = getAnomalies(satBuf.getAll());
+        expect(anomalies).toHaveLength(1);
+      });
+
+      test('does not emit anomaly below threshold (29 pushes -> 0 ANOMALY)', () => {
+        pushSame(satBuf, 'msg-A', 'action-A', 29);
+
+        const logs = satBuf.getAll();
+        const anomalies = getAnomalies(logs);
+
+        expect(anomalies).toHaveLength(0);
+
+        const aMatches = logs.filter(
+          l => l.message === 'msg-A' && l.context?.action === 'action-A'
+        );
+        expect(aMatches).toHaveLength(10);
+        expect(aMatches.at(-1).context.repeatCount).toBe(29);
+      });
+
+      test('re-emits anomaly after fingerprint state is reset via FIFO eviction', () => {
+        const smallBuf = new LogBuffer(40);
+
+        pushSame(smallBuf, 'msg-A', 'action-A', 30);
+        expect(getAnomalies(smallBuf.getAll())).toHaveLength(1);
+
+        // Push 40 unique entries to evict all A entries AND the ANOMALY entry
+        for (let i = 0; i < 40; i++) {
+          smallBuf.push({
+            level: 'log',
+            source: 'background',
+            message: `unique-${i}`,
+            context: { action: `unique-${i}` },
+          });
+        }
+
+        const afterEviction = smallBuf.getAll();
+        expect(afterEviction.filter(l => l.message === 'msg-A')).toHaveLength(0);
+        expect(getAnomalies(afterEviction)).toHaveLength(0);
+
+        pushSame(smallBuf, 'msg-A', 'action-A', 30);
+
+        const final = smallBuf.getAll();
+        expect(getAnomalies(final)).toHaveLength(1);
+        expect(
+          final.filter(l => l.message === 'msg-A' && l.context?.action === 'action-A')
+        ).toHaveLength(10);
+      });
+    });
+
+    describe('Issue #533 end-to-end scenario', () => {
+      test('preserves real user events when A/B loop runs 250 alternating pairs', () => {
+        for (let i = 0; i < 30; i++) {
+          satBuf.push({
+            level: 'info',
+            source: 'background',
+            message: `user-event-${i}`,
+            context: { action: `event-${i}` },
+          });
+        }
+
+        const aMsg = '[Injection] Script executed successfully';
+        const bMsg = 'Phase 3: CLEAR_HIGHLIGHTS 成功';
+
+        /* eslint-disable unicorn/prefer-single-call -- LogBuffer.push is not Array.push */
+        for (let i = 0; i < 250; i++) {
+          satBuf.push({ level: 'info', source: 'background', message: aMsg, context: {} });
+          satBuf.push({
+            level: 'info',
+            source: 'background',
+            message: bMsg,
+            context: { action: 'CLEAR_HIGHLIGHTS' },
+          });
+        }
+        /* eslint-enable unicorn/prefer-single-call */
+
+        const logs = satBuf.getAll();
+
+        const userEvents = logs.filter(l => l.message?.startsWith('user-event-'));
+        expect(userEvents.length).toBeGreaterThanOrEqual(25);
+
+        const aMatches = logs.filter(l => l.message === aMsg);
+        const bMatches = logs.filter(l => l.message === bMsg);
+
+        expect(aMatches).toHaveLength(10);
+        expect(bMatches).toHaveLength(10);
+
+        expect(aMatches.at(-1).context.repeatCount).toBe(250);
+        expect(bMatches.at(-1).context.repeatCount).toBe(250);
+
+        const anomalies = getAnomalies(logs);
+        expect(anomalies).toHaveLength(2);
+      });
     });
   });
 });

--- a/tests/unit/utils/LogBuffer.test.js
+++ b/tests/unit/utils/LogBuffer.test.js
@@ -281,6 +281,60 @@ describe('LogBuffer', () => {
         expect(matches).toHaveLength(10);
         expect(matches.at(-1).context.repeatCount).toBe(11);
       });
+
+      // Regression: oversized entries trigger _processOversizedEntry which rewrites
+      // message/context. The pre-fix code computed the suppression fingerprint from
+      // the original entry but accumulated _fingerprintCounts under the truncated
+      // entry's fingerprint, so suppression never engaged for the oversized path.
+      test('suppresses oversized entries past SUPPRESS_THRESHOLD using a consistent fingerprint', () => {
+        const huge = 'x'.repeat(30_000);
+        for (let i = 0; i < 11; i++) {
+          satBuf.push({
+            level: 'info',
+            source: 'background',
+            message: 'oversized-spam',
+            data: huge,
+            context: { action: 'big-spam' },
+          });
+        }
+
+        const truncatedMatches = satBuf.getAll().filter(l => l.context?.truncated === true);
+
+        expect(truncatedMatches).toHaveLength(10);
+        expect(truncatedMatches.at(-1).context.repeatCount).toBe(11);
+      });
+
+      // Regression: the pre-fix fingerprint joined message and action with a
+      // literal "::" delimiter, so values containing "::" caused collisions.
+      // Pair A: message="hello::", action="world"  → "hello::::world"
+      // Pair B: message="hello",   action="::world" → "hello::::world"
+      test('does not collide fingerprints when message or action contain the "::" delimiter', () => {
+        /* eslint-disable unicorn/prefer-single-call -- LogBuffer.push is not Array.push */
+        for (let i = 0; i < 11; i++) {
+          satBuf.push({
+            level: 'log',
+            source: 'background',
+            message: 'hello::',
+            context: { action: 'world' },
+          });
+          satBuf.push({
+            level: 'log',
+            source: 'background',
+            message: 'hello',
+            context: { action: '::world' },
+          });
+        }
+        /* eslint-enable unicorn/prefer-single-call */
+
+        const logs = satBuf.getAll();
+        const aMatches = logs.filter(l => l.message === 'hello::' && l.context?.action === 'world');
+        const bMatches = logs.filter(l => l.message === 'hello' && l.context?.action === '::world');
+
+        expect(aMatches).toHaveLength(10);
+        expect(bMatches).toHaveLength(10);
+        expect(aMatches.at(-1).context.repeatCount).toBe(11);
+        expect(bMatches.at(-1).context.repeatCount).toBe(11);
+      });
     });
 
     describe('Anomaly emission', () => {

--- a/tests/unit/utils/LogBuffer.test.js
+++ b/tests/unit/utils/LogBuffer.test.js
@@ -351,6 +351,47 @@ describe('LogBuffer', () => {
           final.filter(l => l.message === 'msg-A' && l.context?.action === 'action-A')
         ).toHaveLength(10);
       });
+
+      // Memory safety: anomaly entry must respect MAX_ENTRY_SIZE even when the
+      // triggering message is large. _emitAnomaly bypasses push()'s size check
+      // via _writeRawEntry, so repeatedMessage MUST be truncated at the source.
+      test('caps anomaly entry size when triggering message is large', () => {
+        // MAX_ENTRY_SIZE in LogBuffer.js is 25_000.
+        // Pick a length that keeps original entry under the limit (so suppression
+        // path engages normally) but pushes the anomaly entry over the limit if
+        // repeatedMessage is echoed verbatim.
+        const MAX_ENTRY_SIZE = 25_000;
+        const bigMsg = 'a'.repeat(24_800);
+
+        for (let i = 0; i < 30; i++) {
+          satBuf.push({
+            level: 'info',
+            source: 'background',
+            message: bigMsg,
+            context: { action: 'spam' },
+          });
+        }
+
+        const anomalies = getAnomalies(satBuf.getAll());
+        expect(anomalies).toHaveLength(1);
+
+        const anomaly = anomalies[0];
+
+        // Memory safety invariant: serialized anomaly entry must fit MAX_ENTRY_SIZE.
+        expect(JSON.stringify(anomaly).length).toBeLessThanOrEqual(MAX_ENTRY_SIZE);
+
+        // Structural anomaly markers must survive (not lost to a generic
+        // fallback path that overwrites context).
+        expect(anomaly.level).toBe('warn');
+        expect(anomaly.message).toMatch(/^\[ANOMALY\] message looped 30× in buffer:/);
+        expect(anomaly.context.anomaly).toBe(true);
+        expect(anomaly.context.repeatCount).toBe(30);
+        expect(anomaly.context.repeatedAction).toBe('spam');
+
+        // repeatedMessage must be bounded; ANOMALY_MESSAGE_TRUNCATE = 200,
+        // truncateMessage may append "... [截斷]" so allow a small buffer.
+        expect(anomaly.context.repeatedMessage.length).toBeLessThanOrEqual(210);
+      });
     });
 
     describe('Issue #533 end-to-end scenario', () => {


### PR DESCRIPTION
### 摘要
增加飽和保護機制以防止日誌迴圈，透過指紋計數配額來管理重複日誌條目。

### 變更內容
- 實作基於指紋的計數配額，當同一指紋的緩衝區條目達到 SUPPRESS_THRESHOLD 時，更新現有條目的 repeatCount。
- 當 repeatCount 首次達到 ANOMALY_THRESHOLD 時，發出一次 [ANOMALY] 警告條目。
- 引入新的方法來生成指紋，並在 FIFO 驅逐時重置指紋狀態，以保護真實用戶事件不被迴圈訊息壓垮。
- 測試用例涵蓋了飽和保護的各種情境，確保功能的正確性與穩定性。

### 測試方式
測試用例涵蓋了飽和保護的各種情境，確保功能的正確性與穩定性。

### 潛在風險
無顯著風險。

