### PR TITLE
feat: Add session persistence for log buffer

### DIFF
--- a/scripts/utils/LogBuffer.js
+++ b/scripts/utils/LogBuffer.js
@@ -151,6 +151,10 @@ export class LogBuffer {
 
     // [Session Persistence] flush 判斷用
     this._dirty = false;
+
+    // [Session Persistence] restore gate：restore 期間暫存 push 呼叫
+    this._restoring = false;
+    this._pendingWrites = [];
   }
 
   /**
@@ -163,6 +167,11 @@ export class LogBuffer {
    * @param {object} entry - 日誌對象
    */
   push(entry) {
+    if (this._restoring) {
+      this._pendingWrites.push(entry);
+      return;
+    }
+
     let entryToStore = { ...entry };
 
     // [Performance Optimization] 僅在需要時執行完整序列化檢查
@@ -340,6 +349,7 @@ export class LogBuffer {
     this._fingerprintCounts.clear();
     this._lastIndexByFingerprint.clear();
     this._anomalyEmitted.clear();
+    this._dirty = true;
   }
 
   /**
@@ -363,18 +373,39 @@ export class LogBuffer {
   }
 
   /**
+   * 標記即將進行 restore，期間 push() 暫存到 pending queue。
+   */
+  prepareRestore() {
+    this._restoring = true;
+  }
+
+  /**
    * 從外部資料恢復 buffer 狀態（用於 session persistence restore）。
-   * 復用 push() 以保留 saturation protection 與 size check。
+   * 先重置 buffer，再寫入快照，最後 flush 任何 restore 期間暫存的 pending writes。
    *
    * @param {Array<object>} entries - 先前 getAll() 的快照
    */
   restoreFrom(entries) {
     if (!Array.isArray(entries)) {
+      this._restoring = false;
+      this._drainPendingWrites();
       return;
     }
+    this.clear();
     for (const entry of entries) {
       this.push(entry);
     }
     this._dirty = false;
+    this._restoring = false;
+    this._drainPendingWrites();
+  }
+
+  /** @private */
+  _drainPendingWrites() {
+    const pending = this._pendingWrites;
+    this._pendingWrites = [];
+    for (const entry of pending) {
+      this.push(entry);
+    }
   }
 }

--- a/scripts/utils/LogBuffer.js
+++ b/scripts/utils/LogBuffer.js
@@ -148,6 +148,9 @@ export class LogBuffer {
     this._fingerprintCounts = new Map(); // fp -> 當前實際 slot 數
     this._lastIndexByFingerprint = new Map(); // fp -> 最後寫入該 fp 的 buffer index
     this._anomalyEmitted = new Set(); // 已 emit 過 anomaly 的 fp
+
+    // [Session Persistence] flush 判斷用
+    this._dirty = false;
   }
 
   /**
@@ -176,6 +179,7 @@ export class LogBuffer {
     }
 
     this._writeRawEntry(entryToStore, fp);
+    this._dirty = true;
   }
 
   /**
@@ -229,6 +233,7 @@ export class LogBuffer {
       ...lastEntry.context,
       repeatCount: newRepeat,
     };
+    this._dirty = true;
 
     if (newRepeat === ANOMALY_THRESHOLD && !this._anomalyEmitted.has(fp)) {
       this._anomalyEmitted.add(fp);
@@ -347,5 +352,29 @@ export class LogBuffer {
       count: this.size,
       capacity: this.capacity,
     };
+  }
+
+  isDirty() {
+    return this._dirty;
+  }
+
+  markClean() {
+    this._dirty = false;
+  }
+
+  /**
+   * 從外部資料恢復 buffer 狀態（用於 session persistence restore）。
+   * 復用 push() 以保留 saturation protection 與 size check。
+   *
+   * @param {Array<object>} entries - 先前 getAll() 的快照
+   */
+  restoreFrom(entries) {
+    if (!Array.isArray(entries)) {
+      return;
+    }
+    for (const entry of entries) {
+      this.push(entry);
+    }
+    this._dirty = false;
   }
 }

--- a/scripts/utils/LogBufferPersistence.js
+++ b/scripts/utils/LogBufferPersistence.js
@@ -1,0 +1,60 @@
+/* global chrome */
+
+const STORAGE_KEY = '_logBuffer';
+const ALARM_NAME = 'log-buffer-flush';
+const ALARM_PERIOD_MINUTES = 0.5; // 30 秒（chrome.alarms 最小間隔）
+
+let _buffer = null;
+
+function flush() {
+  if (!_buffer || !_buffer.isDirty()) {
+    return;
+  }
+  const entries = _buffer.getAll();
+  chrome.storage.session.set({ [STORAGE_KEY]: entries });
+  _buffer.markClean();
+}
+
+async function restore() {
+  if (!_buffer) {
+    return;
+  }
+  try {
+    const result = await chrome.storage.session.get(STORAGE_KEY);
+    const entries = result[STORAGE_KEY];
+    if (Array.isArray(entries) && entries.length > 0) {
+      _buffer.restoreFrom(entries);
+    }
+  } catch {
+    // session storage 不可用時靜默失敗
+  }
+}
+
+function handleAlarm(alarm) {
+  if (alarm.name === ALARM_NAME) {
+    flush();
+  }
+}
+
+export const LogBufferPersistence = {
+  async init(logBuffer) {
+    _buffer = logBuffer;
+    await restore();
+    if (!chrome.alarms) {
+      return;
+    }
+    chrome.alarms.onAlarm.addListener(handleAlarm);
+    chrome.alarms.create(ALARM_NAME, { periodInMinutes: ALARM_PERIOD_MINUTES });
+  },
+
+  flush,
+  restore,
+
+  _reset() {
+    _buffer = null;
+    if (chrome.alarms) {
+      chrome.alarms.onAlarm.removeListener(handleAlarm);
+      chrome.alarms.clear(ALARM_NAME);
+    }
+  },
+};

--- a/scripts/utils/LogBufferPersistence.js
+++ b/scripts/utils/LogBufferPersistence.js
@@ -26,11 +26,9 @@ async function restore() {
   try {
     const result = await chrome.storage.session.get(STORAGE_KEY);
     const entries = result[STORAGE_KEY];
-    if (Array.isArray(entries) && entries.length > 0) {
-      _buffer.restoreFrom(entries);
-    }
+    _buffer.restoreFrom(Array.isArray(entries) ? entries : []);
   } catch {
-    // session storage 不可用時靜默失敗
+    _buffer.restoreFrom([]);
   }
 }
 
@@ -43,6 +41,7 @@ function handleAlarm(alarm) {
 export const LogBufferPersistence = {
   async init(logBuffer) {
     _buffer = logBuffer;
+    _buffer.prepareRestore();
     await restore();
     if (!chrome.alarms) {
       return;

--- a/scripts/utils/LogBufferPersistence.js
+++ b/scripts/utils/LogBufferPersistence.js
@@ -6,13 +6,17 @@ const ALARM_PERIOD_MINUTES = 0.5; // 30 秒（chrome.alarms 最小間隔）
 
 let _buffer = null;
 
-function flush() {
+async function flush() {
   if (!_buffer || !_buffer.isDirty()) {
     return;
   }
   const entries = _buffer.getAll();
-  chrome.storage.session.set({ [STORAGE_KEY]: entries });
-  _buffer.markClean();
+  try {
+    await chrome.storage.session.set({ [STORAGE_KEY]: entries });
+    _buffer.markClean();
+  } catch {
+    // quota exceeded 或 session storage 不可用時保留 dirty 狀態，下次重試
+  }
 }
 
 async function restore() {

--- a/scripts/utils/LogBufferPersistence.js
+++ b/scripts/utils/LogBufferPersistence.js
@@ -2,7 +2,7 @@
 
 const STORAGE_KEY = '_logBuffer';
 const ALARM_NAME = 'log-buffer-flush';
-const ALARM_PERIOD_MINUTES = 0.5; // 30 秒（chrome.alarms 最小間隔）
+const ALARM_PERIOD_MINUTES = 1;
 
 let _buffer = null;
 

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -8,6 +8,7 @@
  */
 
 import { LogBuffer } from './LogBuffer.js';
+import { LogBufferPersistence } from './LogBufferPersistence.js';
 import { LogSanitizer } from './LogSanitizer.js';
 import { LOG_ICONS } from '../config/shared/ui.js';
 import { DEV_LOG_SINK, DEV_LOG_SINK_BATCH } from '../config/runtimeActions/diagnosticsActions.js';
@@ -388,6 +389,7 @@ function initDebugState() {
   // 初始化 LogBuffer (僅 Background)
   if (isBackground && !_logBuffer) {
     _logBuffer = new LogBuffer(DEFAULT_BUFFER_CAPACITY);
+    LogBufferPersistence.init(_logBuffer);
   }
 
   _isInitialized = true;

--- a/tests/unit/utils/LogBuffer.dirty.test.js
+++ b/tests/unit/utils/LogBuffer.dirty.test.js
@@ -1,0 +1,79 @@
+import { LogBuffer } from '../../../scripts/utils/LogBuffer.js';
+
+describe('LogBuffer - dirty flag', () => {
+  let buffer;
+
+  beforeEach(() => {
+    buffer = new LogBuffer(5);
+  });
+
+  test('starts clean', () => {
+    expect(buffer.isDirty()).toBe(false);
+  });
+
+  test('becomes dirty after push', () => {
+    buffer.push({ level: 'info', source: 'bg', message: 'test', context: {} });
+    expect(buffer.isDirty()).toBe(true);
+  });
+
+  test('markClean resets dirty flag', () => {
+    buffer.push({ level: 'info', source: 'bg', message: 'test', context: {} });
+    buffer.markClean();
+    expect(buffer.isDirty()).toBe(false);
+  });
+
+  test('becomes dirty on suppressed push (repeatCount update)', () => {
+    for (let i = 0; i < 12; i++) {
+      buffer.push({ level: 'info', source: 'bg', message: 'same', context: { action: 'a' } });
+    }
+    buffer.markClean();
+    buffer.push({ level: 'info', source: 'bg', message: 'same', context: { action: 'a' } });
+    expect(buffer.isDirty()).toBe(true);
+  });
+});
+
+describe('LogBuffer - restoreFrom', () => {
+  test('restores entries from snapshot', () => {
+    const buffer = new LogBuffer(10);
+    const entries = [
+      { level: 'info', source: 'bg', message: 'msg1', context: {} },
+      { level: 'warn', source: 'bg', message: 'msg2', context: { action: 'x' } },
+    ];
+    buffer.restoreFrom(entries);
+
+    const all = buffer.getAll();
+    expect(all).toHaveLength(2);
+    expect(all[0].message).toBe('msg1');
+    expect(all[1].message).toBe('msg2');
+  });
+
+  test('is not dirty after restoreFrom', () => {
+    const buffer = new LogBuffer(10);
+    buffer.restoreFrom([{ level: 'info', source: 'bg', message: 'x', context: {} }]);
+    expect(buffer.isDirty()).toBe(false);
+  });
+
+  test('handles non-array input gracefully', () => {
+    const buffer = new LogBuffer(5);
+    buffer.restoreFrom(null);
+    buffer.restoreFrom(undefined);
+    buffer.restoreFrom('bad');
+    expect(buffer.getAll()).toHaveLength(0);
+  });
+
+  test('respects capacity during restore', () => {
+    const buffer = new LogBuffer(3);
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      level: 'info',
+      source: 'bg',
+      message: `msg${i}`,
+      context: {},
+    }));
+    buffer.restoreFrom(entries);
+
+    const all = buffer.getAll();
+    expect(all).toHaveLength(3);
+    expect(all[0].message).toBe('msg2');
+    expect(all[2].message).toBe('msg4');
+  });
+});

--- a/tests/unit/utils/LogBufferPersistence.test.js
+++ b/tests/unit/utils/LogBufferPersistence.test.js
@@ -66,7 +66,7 @@ describe('LogBufferPersistence', () => {
     buffer.push({ level: 'info', source: 'bg', message: 'new-entry', context: {} });
     expect(buffer.isDirty()).toBe(true);
 
-    LogBufferPersistence.flush();
+    await LogBufferPersistence.flush();
 
     expect(chrome.storage.session.set).toHaveBeenCalled();
     const stored = chrome.storage.session.set.mock.calls.at(-1)[0]._logBuffer;
@@ -80,9 +80,21 @@ describe('LogBufferPersistence', () => {
     await LogBufferPersistence.init(buffer);
 
     chrome.storage.session.set.mockClear();
-    LogBufferPersistence.flush();
+    await LogBufferPersistence.flush();
 
     expect(chrome.storage.session.set).not.toHaveBeenCalled();
+  });
+
+  test('flush keeps buffer dirty when storage write fails', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    buffer.push({ level: 'error', source: 'bg', message: 'quota-test', context: {} });
+    chrome.storage.session.set.mockRejectedValueOnce(new Error('QUOTA_BYTES quota exceeded'));
+
+    await LogBufferPersistence.flush();
+
+    expect(buffer.isDirty()).toBe(true);
   });
 
   test('alarm triggers flush', async () => {

--- a/tests/unit/utils/LogBufferPersistence.test.js
+++ b/tests/unit/utils/LogBufferPersistence.test.js
@@ -53,7 +53,7 @@ describe('LogBufferPersistence', () => {
     const buffer = new LogBuffer(10);
     await LogBufferPersistence.init(buffer);
 
-    expect(chrome.alarms.create).toHaveBeenCalledWith('log-buffer-flush', { periodInMinutes: 0.5 });
+    expect(chrome.alarms.create).toHaveBeenCalledWith('log-buffer-flush', { periodInMinutes: 1 });
     expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalled();
     expect(buffer.getAll()).toHaveLength(1);
     expect(buffer.getAll()[0].message).toBe('restored');

--- a/tests/unit/utils/LogBufferPersistence.test.js
+++ b/tests/unit/utils/LogBufferPersistence.test.js
@@ -1,0 +1,121 @@
+import { LogBufferPersistence } from '../../../scripts/utils/LogBufferPersistence.js';
+import { LogBuffer } from '../../../scripts/utils/LogBuffer.js';
+
+const mockStorage = {};
+const mockAlarmListeners = [];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAlarmListeners.length = 0;
+
+  globalThis.chrome = {
+    storage: {
+      session: {
+        get: jest.fn(key => {
+          const k = typeof key === 'string' ? key : Object.keys(key)[0];
+          return Promise.resolve({ [k]: mockStorage[k] ?? undefined });
+        }),
+        set: jest.fn(obj => {
+          Object.assign(mockStorage, obj);
+          return Promise.resolve();
+        }),
+      },
+    },
+    alarms: {
+      create: jest.fn(),
+      clear: jest.fn(),
+      onAlarm: {
+        addListener: jest.fn(fn => mockAlarmListeners.push(fn)),
+        removeListener: jest.fn(fn => {
+          const idx = mockAlarmListeners.indexOf(fn);
+          if (idx !== -1) {
+            mockAlarmListeners.splice(idx, 1);
+          }
+        }),
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  for (const key of Object.keys(mockStorage)) {
+    delete mockStorage[key];
+  }
+  if (globalThis.chrome) {
+    LogBufferPersistence._reset();
+  }
+});
+
+describe('LogBufferPersistence', () => {
+  test('init registers alarm and restores from session storage', async () => {
+    mockStorage._logBuffer = [{ level: 'info', source: 'bg', message: 'restored', context: {} }];
+
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    expect(chrome.alarms.create).toHaveBeenCalledWith('log-buffer-flush', { periodInMinutes: 0.5 });
+    expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalled();
+    expect(buffer.getAll()).toHaveLength(1);
+    expect(buffer.getAll()[0].message).toBe('restored');
+  });
+
+  test('flush writes buffer to session storage when dirty', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    buffer.push({ level: 'info', source: 'bg', message: 'new-entry', context: {} });
+    expect(buffer.isDirty()).toBe(true);
+
+    LogBufferPersistence.flush();
+
+    expect(chrome.storage.session.set).toHaveBeenCalled();
+    const stored = chrome.storage.session.set.mock.calls.at(-1)[0]._logBuffer;
+    expect(stored).toHaveLength(1);
+    expect(stored[0].message).toBe('new-entry');
+    expect(buffer.isDirty()).toBe(false);
+  });
+
+  test('flush skips write when buffer is not dirty', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    chrome.storage.session.set.mockClear();
+    LogBufferPersistence.flush();
+
+    expect(chrome.storage.session.set).not.toHaveBeenCalled();
+  });
+
+  test('alarm triggers flush', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    buffer.push({ level: 'warn', source: 'bg', message: 'alarm-test', context: {} });
+
+    for (const listener of mockAlarmListeners) {
+      listener({ name: 'log-buffer-flush' });
+    }
+
+    expect(chrome.storage.session.set).toHaveBeenCalled();
+  });
+
+  test('unrelated alarm does not trigger flush', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    buffer.push({ level: 'info', source: 'bg', message: 'x', context: {} });
+    chrome.storage.session.set.mockClear();
+
+    for (const listener of mockAlarmListeners) {
+      listener({ name: 'some-other-alarm' });
+    }
+
+    expect(chrome.storage.session.set).not.toHaveBeenCalled();
+  });
+
+  test('restore handles empty storage gracefully', async () => {
+    const buffer = new LogBuffer(10);
+    await LogBufferPersistence.init(buffer);
+
+    expect(buffer.getAll()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### 摘要
新增日誌緩衝區的會話持久化功能，確保日誌在背景環境下的狀態能夠正確恢復。

### 變更內容
- 新增 `LogBufferPersistence` 模組以實現日誌緩衝區的會話持久化。
- 在 `LogBuffer` 中添加 `_dirty` 標誌以追蹤緩衝區的變更狀態。
- 實現 `flush` 和 `restore` 方法，分別用於將緩衝區內容寫入會話存儲和從會話存儲恢復內容。
- 在 `Logger` 中初始化 `LogBufferPersistence`，確保正確恢復日誌緩衝區狀態。
- 增加單元測試以驗證持久化功能的正確性，包括緩衝區的清理和恢復行為。

### 測試方式
已增加單元測試來驗證持久化功能的正確性。

### 潛在風險
無顯著風險。

