### PR TITLE
feat: refactor inline styles and add CSS variables for options page

### DIFF
--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1464,6 +1464,30 @@ h4 .icon-svg {
   margin-top: 12px;
 }
 
+.fw-medium {
+  font-weight: 500;
+}
+
+.shrink-0 {
+  flex-shrink: 0;
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.mb-14 {
+  margin-bottom: 14px;
+}
+
+.mb-16 {
+  margin-bottom: 16px;
+}
+
+.mt-10 {
+  margin-top: 10px;
+}
+
 /* --- Advanced Features Profile --- */
 .profile-layout {
   display: flex;

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1460,6 +1460,14 @@ h4 .icon-svg {
 }
 
 /* Margin Utilities */
+.auth-actions {
+  margin-top: 16px;
+}
+
+.locked-message {
+  color: var(--text-muted);
+}
+
 .text-secondary {
   color: var(--text-secondary);
 }

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1578,6 +1578,124 @@ h4 .icon-svg {
   margin: 8px 0 0;
 }
 
+/* Cloud Sync Card — header */
+.cloud-sync-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Cloud Sync Card — connected account info */
+.drive-account-info {
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Cloud Sync Card — sync summary text */
+.drive-sync-summary {
+  margin-bottom: 12px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* Cloud Sync Card — frequency selector row */
+.drive-frequency-row {
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.drive-frequency-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.drive-frequency-select {
+  flex: 1;
+  max-width: 140px;
+  font-size: 0.8rem;
+}
+
+/* Cloud Sync Card — auto-sync status output */
+.drive-auto-sync-status {
+  margin-bottom: 12px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Cloud Sync Card — conflict banner */
+.drive-conflict-banner {
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.drive-conflict-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  color: var(--color-warning-strong);
+}
+
+.drive-conflict-title {
+  color: var(--color-warning-strong);
+  font-size: 0.875rem;
+}
+
+/* Cloud Sync Card — error banner content */
+.drive-error-content {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--color-danger);
+}
+
+.drive-error-code {
+  color: var(--color-danger-light);
+  font-weight: 500;
+}
+
+/* Cloud Sync Card — loading state */
+.drive-loading-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.drive-loading-overlay {
+  margin-top: 12px;
+  text-align: center;
+}
+
+.drive-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-color, #334155);
+  border-top-color: #4ade80;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 
 /* ============================================
    關於作者

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1127,7 +1127,7 @@ select:focus {
 
 .faq-answer {
   color: var(--text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.875rem;
   line-height: 1.6;
 }
 

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1492,6 +1492,10 @@ h4 .icon-svg {
   margin-left: auto;
 }
 
+.mb-10 {
+  margin-bottom: 10px;
+}
+
 .mb-14 {
   margin-bottom: 14px;
 }
@@ -1702,7 +1706,7 @@ h4 .icon-svg {
   width: 16px;
   height: 16px;
   border: 2px solid var(--border-color, #334155);
-  border-top-color: #4ade80;
+  border-top-color: var(--color-success);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1460,6 +1460,14 @@ h4 .icon-svg {
 }
 
 /* Margin Utilities */
+.text-secondary {
+  color: var(--text-secondary);
+}
+
+.text-muted {
+  color: var(--text-muted);
+}
+
 .mt-12 {
   margin-top: 12px;
 }

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -555,10 +555,9 @@
 
             <p
               id="account-status"
-              class="status-message"
+              class="status-message mt-8"
               aria-live="polite"
               aria-atomic="true"
-              class="mt-8"
             ></p>
           </div>
 
@@ -740,7 +739,7 @@
                 <svg
                   width="16"
                   height="16"
-                  class="icon-svg"
+                  class="icon-svg shrink-0"
                   aria-hidden="true"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -750,7 +749,6 @@
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   style="margin-top: 1px"
-                  class="shrink-0"
                 >
                   <circle cx="12" cy="12" r="10" />
                   <line x1="12" y1="8" x2="12" y2="12" />
@@ -785,10 +783,9 @@
             <!-- 通用狀態訊息 -->
             <p
               id="drive-sync-status"
-              class="status-message"
+              class="status-message mt-10"
               aria-live="polite"
               aria-atomic="true"
-              class="mt-10"
             ></p>
           </div>
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -558,20 +558,20 @@
               class="status-message"
               aria-live="polite"
               aria-atomic="true"
-              style="margin-top: 8px"
+              class="mt-8"
             ></p>
           </div>
 
           <!-- Cloud Sync Card — Phase A 正式 UI -->
           <div id="cloud-sync-card" class="card" style="display: none">
-            <h3 style="display: flex; align-items: center; gap: 8px">
+            <h3 class="cloud-sync-header">
               <svg
                 width="20"
                 height="20"
                 viewBox="0 0 48 48"
                 aria-hidden="true"
                 focusable="false"
-                style="flex-shrink: 0"
+                class="shrink-0"
               >
                 <polygon points="16,40 0,12 16,12" fill="#4285F4" />
                 <polygon points="16,40 32,40 48,12 32,12" fill="#34A853" />
@@ -582,7 +582,7 @@
 
             <!-- 狀態零：未登入帳號 -->
             <div id="drive-state-logged-out" style="display: none">
-              <p class="section-desc" style="margin-bottom: 12px">
+              <p class="section-desc mb-12">
                 登入帳號後，可連接 Google Drive 以備份和同步你的本地資料到雲端。
               </p>
               <div class="auth-actions">
@@ -594,7 +594,7 @@
 
             <!-- 狀態一：已登入但未連接 Google Drive -->
             <div id="drive-state-disconnected" style="display: none">
-              <p class="section-desc" style="margin-bottom: 12px">
+              <p class="section-desc mb-12">
                 連接 Google Drive 後，可備份和同步你的本地資料到雲端。
               </p>
               <div class="auth-actions">
@@ -611,47 +611,27 @@
 
             <!-- 狀態二：已連接，可正常操作 -->
             <div id="drive-state-connected" style="display: none">
-              <div
-                class="drive-account-info"
-                style="
-                  margin-bottom: 16px;
-                  padding: 10px 12px;
-                  background: rgba(255, 255, 255, 0.04);
-                  border-radius: 8px;
-                  display: flex;
-                  align-items: center;
-                  gap: 10px;
-                "
-              >
+              <div class="drive-account-info">
                 <div>
                   <div class="text-sm" style="color: var(--text-secondary)">已連接帳號</div>
-                  <div id="drive-connected-email" class="text-sm" style="font-weight: 500"></div>
+                  <div id="drive-connected-email" class="text-sm fw-medium"></div>
                 </div>
               </div>
               <!-- 帳號隔離警示 -->
               <p id="drive-source-warning" class="drive-source-warning hidden"></p>
               <!-- 同步狀態摘要 -->
 
-              <div
-                id="drive-sync-summary"
-                style="margin-bottom: 12px; font-size: 0.8rem; color: var(--text-muted)"
-              >
+              <div id="drive-sync-summary" class="drive-sync-summary">
                 <span id="drive-last-upload-text">尚未上載</span>
               </div>
               <!-- Phase B: 自動同步頻率選擇器 -->
-              <div
-                id="drive-frequency-row"
-                style="margin-bottom: 14px; display: flex; align-items: center; gap: 10px"
-              >
-                <label
-                  for="drive-frequency-select"
-                  style="font-size: 0.8rem; color: var(--text-secondary); white-space: nowrap"
+              <div id="drive-frequency-row" class="drive-frequency-row">
+                <label for="drive-frequency-select" class="drive-frequency-label"
                   >自動備份頻率 <span class="badge-beta">測試版</span></label
                 >
                 <select
                   id="drive-frequency-select"
-                  class="form-select-enhanced"
-                  style="flex: 1; max-width: 140px; font-size: 0.8rem"
+                  class="form-select-enhanced drive-frequency-select"
                 >
                   <option value="off">關閉（僅手動）</option>
                   <option value="daily">每日</option>
@@ -661,19 +641,13 @@
               </div>
               <!-- Phase B: 自動同步狀態 -->
               <output
-                id="drive-auto-sync-status"
-                aria-live="polite"
-                style="
-                  margin-bottom: 12px;
-                  font-size: 0.75rem;
-                  color: var(--text-muted);
-                  display: none;
-                "
+                class="drive-auto-sync-status"
+                style="display: none"
               >
                 <span id="drive-auto-sync-status-text"></span>
               </output>
               <!-- 操作按鈕 -->
-              <div class="button-group" style="gap: 8px; flex-wrap: wrap">
+              <div class="button-group">
                 <button id="drive-upload-button" type="button" class="btn-secondary">
                   <svg aria-hidden="true" focusable="false" width="16" height="16" class="icon-svg">
                     <use href="#icon-upload" />
@@ -689,8 +663,7 @@
                 <button
                   id="drive-disconnect-button"
                   type="button"
-                  class="btn-danger"
-                  style="margin-left: auto"
+                  class="btn-danger ml-auto"
                 >
                   <svg aria-hidden="true" focusable="false" width="16" height="16" class="icon-svg">
                     <use href="#icon-unlink" />

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -675,16 +675,8 @@
 
             <!-- 狀態三：衝突 — 遠端較新，需人工處理 -->
             <div id="drive-state-conflict" style="display: none">
-              <div
-                style="
-                  background: rgba(234, 179, 8, 0.12);
-                  border: 1px solid rgba(234, 179, 8, 0.3);
-                  border-radius: 8px;
-                  padding: 12px 14px;
-                  margin-bottom: 14px;
-                "
-              >
-                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px">
+              <div class="drive-conflict-banner">
+                <div class="drive-conflict-header">
                   <svg
                     width="16"
                     height="16"
@@ -693,7 +685,7 @@
                     focusable="false"
                     viewBox="0 0 24 24"
                     fill="none"
-                    stroke="#eab308"
+                    stroke="currentColor"
                     stroke-width="2"
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -704,18 +696,16 @@
                     <line x1="12" y1="9" x2="12" y2="13" />
                     <line x1="12" y1="17" x2="12.01" y2="17" />
                   </svg>
-                  <strong style="color: #eab308; font-size: 0.875rem">雲端資料較新</strong>
+                  <strong class="drive-conflict-title">雲端資料較新</strong>
                 </div>
-                <p class="text-sm" style="color: var(--text-secondary); margin-bottom: 10px">
+                <p class="text-sm text-secondary mb-10">
                   雲端快照
                   比本地資料新，上載可能覆蓋較新的雲端資料。建議先下載雲端版本，或確認後強制上載。
                 </p>
                 <p
-                  id="drive-conflict-remote-time"
-                  class="text-sm"
-                  style="color: var(--text-muted); margin-bottom: 12px"
+                  class="text-sm text-muted mb-12"
                 ></p>
-                <div style="display: flex; gap: 8px; flex-wrap: wrap">
+                <div class="button-group">
                   <button id="drive-conflict-download-button" type="button" class="btn-primary">
                     <svg
                       aria-hidden="true"

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -613,7 +613,7 @@
             <div id="drive-state-connected" style="display: none">
               <div class="drive-account-info">
                 <div>
-                  <div class="text-sm" style="color: var(--text-secondary)">已連接帳號</div>
+                  <div class="text-sm text-secondary">已連接帳號</div>
                   <div id="drive-connected-email" class="text-sm fw-medium"></div>
                 </div>
               </div>
@@ -749,7 +749,7 @@
                   stroke-width="2"
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                  style="flex-shrink: 0; margin-top: 1px"
+                  style="margin-top: 1px"
                   class="shrink-0"
                 >
                   <circle cx="12" cy="12" r="10" />
@@ -788,7 +788,6 @@
               class="status-message"
               aria-live="polite"
               aria-atomic="true"
-              style="margin-top: 10px"
               class="mt-10"
             ></p>
           </div>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -477,7 +477,7 @@
 
             <!-- 未登入狀態 -->
             <div id="account-logged-out">
-              <p class="section-desc" style="margin-bottom: 12px">
+              <p class="section-desc mb-12">
                 使用 Google 帳號登入，享受同步與進階功能。
               </p>
               <div class="auth-actions">
@@ -527,7 +527,7 @@
                   <div id="profile-email" class="profile-email text-sm"></div>
                 </div>
               </div>
-              <div class="auth-actions" style="margin-top: 16px">
+              <div class="auth-actions">
                 <button id="account-logout-button" type="button" class="btn-danger">
                   <span class="icon">
                     <svg
@@ -735,18 +735,8 @@
             </div>
 
             <!-- 錯誤提示（顯示在各狀態下方） -->
-            <div id="drive-error-banner" style="display: none; margin-top: 10px">
-              <div
-                style="
-                  background: rgba(239, 68, 68, 0.1);
-                  border: 1px solid rgba(239, 68, 68, 0.3);
-                  border-radius: 8px;
-                  padding: 10px 14px;
-                  display: flex;
-                  align-items: flex-start;
-                  gap: 8px;
-                "
-              >
+            <div id="drive-error-banner" class="mt-10" style="display: none">
+              <div class="drive-error-content">
                 <svg
                   width="16"
                   height="16"
@@ -760,6 +750,7 @@
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   style="flex-shrink: 0; margin-top: 1px"
+                  class="shrink-0"
                 >
                   <circle cx="12" cy="12" r="10" />
                   <line x1="12" y1="8" x2="12" y2="12" />
@@ -767,13 +758,12 @@
                 </svg>
                 <div>
                   <div
-                    class="text-sm"
-                    style="color: #fca5a5; font-weight: 500"
+                    class="text-sm drive-error-code"
                     id="drive-error-code"
                   ></div>
                   <div
-                    class="text-sm"
-                    style="color: var(--text-muted); margin-top: 2px"
+                    class="text-sm text-muted"
+                    style="margin-top: 2px"
                     id="drive-error-time"
                   ></div>
                 </div>
@@ -783,27 +773,11 @@
             <!-- 操作進行中（spinner） -->
             <div
               id="drive-loading-overlay"
-              style="display: none; margin-top: 12px; text-align: center"
+              class="drive-loading-overlay"
+              style="display: none"
             >
-              <div
-                style="
-                  display: inline-flex;
-                  align-items: center;
-                  gap: 8px;
-                  color: var(--text-muted);
-                  font-size: 0.875rem;
-                "
-              >
-                <div
-                  style="
-                    width: 16px;
-                    height: 16px;
-                    border: 2px solid var(--border-color, #334155);
-                    border-top-color: #4ade80;
-                    border-radius: 50%;
-                    animation: spin 0.8s linear infinite;
-                  "
-                ></div>
+              <div class="drive-loading-wrapper">
+                <div class="drive-spinner"></div>
                 <span id="drive-loading-text">處理中...</span>
               </div>
             </div>
@@ -815,6 +789,7 @@
               aria-live="polite"
               aria-atomic="true"
               style="margin-top: 10px"
+              class="mt-10"
             ></p>
           </div>
 
@@ -824,18 +799,17 @@
               <svg
                 width="20"
                 height="20"
-                class="icon-svg"
+                class="icon-svg icon-inline-hint"
                 aria-hidden="true"
                 focusable="false"
-                style="vertical-align: middle; margin-right: 4px"
               >
                 <use href="#icon-star" />
               </svg>
               AI 智能摘要與助手
             </h3>
-            <p class="section-desc" style="margin-bottom: 12px">
+            <p class="section-desc mb-12">
               透過先進 AI 幫助您快速整理網頁重點。<br />
-              <span class="locked-message" style="color: var(--text-muted)"
+              <span class="locked-message"
                 >需先登入 Google 帳號。</span
               >
             </p>

--- a/styles/ui-tokens.css
+++ b/styles/ui-tokens.css
@@ -27,6 +27,8 @@
   /* === Color: Status === */
   --color-success: #10b981;
   --color-warning: #f59e0b;
+  --color-warning-strong: #eab308;
+  --color-danger-light: #fca5a5;
 
   /* === Color: Text === */
   --color-text: #1e293b;


### PR DESCRIPTION
### 摘要
本次更新重構了 options 頁面的內聯樣式，並引入了新的 CSS 變數以提升可維護性和一致性。

### 變更內容
- 新增 `--color-warning-strong` 和 `--color-danger-light` 色彩 token。
- 新增多個 utility class，包括 `fw-medium`、`shrink-0`、`ml-auto`、`mb-14/16` 和 `mt-10`。
- 為 Cloud Sync Card 區塊新增了 component class，並將相關的內聯樣式抽取至 CSS。
- 清理了 Cloud Sync Card 的不同狀態（連接、衝突、錯誤、加載）的內聯樣式，並對齊設計變數。
- 調整 FAQ 答案的字體大小以改善可讀性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

