### PR TITLE
refactor: migrate visibility toggles to .hidden class

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -71,7 +71,7 @@
         <p class="status-text" id="status-text">正在驗證登入資訊...</p>
       </output>
 
-      <p class="close-hint" id="close-hint" style="display: none">此頁面將自動關閉</p>
+      <p class="close-hint hidden" id="close-hint">此頁面將自動關閉</p>
     </div>
 
     <!-- auth.js 處理所有 callback bridge 邏輯 -->

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -32,7 +32,6 @@ export class AuthManager {
   // 將常數綁定到類別上供實例使用
   static CLASS_AUTH_SUCCESS = 'auth-status success';
   static CLASS_AUTH_STATUS = 'auth-status';
-  static STYLE_INLINE_FLEX = 'inline-flex';
 
   /**
    * @param {import('./UIManager.js').UIManager} uiManager
@@ -248,10 +247,10 @@ export class AuthManager {
 
     // OAuth 按鈕切換為已連接狀態
     if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.style.display = 'none';
+      this.elements.oauthConnectButton.classList.add('hidden');
     }
     if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.style.display = AuthManager.STYLE_INLINE_FLEX;
+      this.elements.oauthDisconnectButton.classList.remove('hidden');
     }
 
     // 手動模式區域顯示提示（OAuth 已連接）
@@ -317,7 +316,7 @@ export class AuthManager {
       UI_MESSAGES.AUTH.ACTION_RECONNECT
     );
     if (this.elements.disconnectButton) {
-      this.elements.disconnectButton.style.display = AuthManager.STYLE_INLINE_FLEX;
+      this.elements.disconnectButton.classList.remove('hidden');
     }
 
     if (this.elements.apiKeyInput) {
@@ -344,10 +343,10 @@ export class AuthManager {
       this.elements.oauthStatus.className = AuthManager.CLASS_AUTH_STATUS;
     }
     if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.style.display = AuthManager.STYLE_INLINE_FLEX;
+      this.elements.oauthConnectButton.classList.remove('hidden');
     }
     if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.style.display = 'none';
+      this.elements.oauthDisconnectButton.classList.add('hidden');
     }
 
     // 載入資料來源列表
@@ -415,7 +414,7 @@ export class AuthManager {
       UI_MESSAGES.AUTH.ACTION_CONNECT
     );
     if (this.elements.disconnectButton) {
-      this.elements.disconnectButton.style.display = 'none';
+      this.elements.disconnectButton.classList.add('hidden');
     }
 
     // OAuth 區域也顯示未連接
@@ -424,10 +423,10 @@ export class AuthManager {
       this.elements.oauthStatus.className = AuthManager.CLASS_AUTH_STATUS;
     }
     if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.style.display = AuthManager.STYLE_INLINE_FLEX;
+      this.elements.oauthConnectButton.classList.remove('hidden');
     }
     if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.style.display = 'none';
+      this.elements.oauthDisconnectButton.classList.add('hidden');
     }
 
     this.ui.hideDataSourceUpgradeNotice();

--- a/pages/options/DriveCloudSyncController.js
+++ b/pages/options/DriveCloudSyncController.js
@@ -493,19 +493,11 @@ function _updateAutoSyncStatus(metadata) {
     return;
   }
 
-  if (metadata.frequency === 'off' || !metadata.frequency) {
-    statusDiv.classList.add('hidden');
-    statusText.textContent = '';
-    return;
-  }
+  const isFrequencyActive = Boolean(metadata.frequency) && metadata.frequency !== 'off';
+  const shouldShowReview = isFrequencyActive && Boolean(metadata.needsManualReview);
 
-  if (metadata.needsManualReview) {
-    statusDiv.classList.remove('hidden');
-    statusText.textContent = UI_MESSAGES.CLOUD_SYNC.AUTO_SYNC_NEEDS_REVIEW;
-  } else {
-    statusDiv.classList.add('hidden');
-    statusText.textContent = '';
-  }
+  statusDiv.classList.toggle('hidden', !shouldShowReview);
+  statusText.textContent = shouldShowReview ? UI_MESSAGES.CLOUD_SYNC.AUTO_SYNC_NEEDS_REVIEW : '';
 }
 
 /**

--- a/pages/options/DriveCloudSyncController.js
+++ b/pages/options/DriveCloudSyncController.js
@@ -309,7 +309,7 @@ function installReturnSyncListeners() {
 export function setCloudSyncCardVisibility(isLoggedIn) {
   const card = el(DOM.CARD);
   if (card) {
-    card.style.display = isLoggedIn ? '' : 'none';
+    card.classList.toggle('hidden', !isLoggedIn);
   }
 }
 
@@ -340,7 +340,7 @@ function showLoading(message) {
   const overlay = el(DOM.LOADING_OVERLAY);
   const text = el(DOM.LOADING_TEXT);
   if (overlay) {
-    overlay.style.display = '';
+    overlay.classList.remove('hidden');
   }
   if (text) {
     text.textContent = message;
@@ -354,7 +354,7 @@ function showLoading(message) {
 function hideLoading() {
   const overlay = el(DOM.LOADING_OVERLAY);
   if (overlay) {
-    overlay.style.display = 'none';
+    overlay.classList.add('hidden');
   }
   _setActionButtonsDisabled(false);
 }
@@ -399,16 +399,16 @@ function _updateStatePanels(state) {
   const stateConflict = el(DOM.STATE_CONFLICT);
 
   if (stateLoggedOut) {
-    stateLoggedOut.style.display = state === 'logged_out' ? '' : 'none';
+    stateLoggedOut.classList.toggle('hidden', state !== 'logged_out');
   }
   if (stateDisconnected) {
-    stateDisconnected.style.display = state === 'disconnected' ? '' : 'none';
+    stateDisconnected.classList.toggle('hidden', state !== 'disconnected');
   }
   if (stateConnected) {
-    stateConnected.style.display = state === 'connected' ? '' : 'none';
+    stateConnected.classList.toggle('hidden', state !== 'connected');
   }
   if (stateConflict) {
-    stateConflict.style.display = state === 'conflict' ? '' : 'none';
+    stateConflict.classList.toggle('hidden', state !== 'conflict');
   }
 }
 
@@ -454,7 +454,7 @@ function _updateErrorBanner(metadata) {
   const errorBanner = el(DOM.ERROR_BANNER);
 
   if (errorBanner) {
-    errorBanner.style.display = hasError ? '' : 'none';
+    errorBanner.classList.toggle('hidden', !hasError);
   }
   if (!hasError) {
     return;
@@ -494,16 +494,16 @@ function _updateAutoSyncStatus(metadata) {
   }
 
   if (metadata.frequency === 'off' || !metadata.frequency) {
-    statusDiv.style.display = 'none';
+    statusDiv.classList.add('hidden');
     statusText.textContent = '';
     return;
   }
 
   if (metadata.needsManualReview) {
-    statusDiv.style.display = '';
+    statusDiv.classList.remove('hidden');
     statusText.textContent = UI_MESSAGES.CLOUD_SYNC.AUTO_SYNC_NEEDS_REVIEW;
   } else {
-    statusDiv.style.display = 'none';
+    statusDiv.classList.add('hidden');
     statusText.textContent = '';
   }
 }
@@ -597,7 +597,7 @@ function renderLoggedOutCloudSyncCard() {
 
   const errorBanner = el(DOM.ERROR_BANNER);
   if (errorBanner) {
-    errorBanner.style.display = 'none';
+    errorBanner.classList.add('hidden');
   }
 
   const errorCodeEl = el(DOM.ERROR_CODE);

--- a/pages/options/StorageManager.js
+++ b/pages/options/StorageManager.js
@@ -586,7 +586,7 @@ export class StorageManager {
 
     if (totalKeys <= 0) {
       if (btn) {
-        btn.style.display = 'none';
+        btn.classList.add('hidden');
       }
       return;
     }
@@ -613,7 +613,7 @@ export class StorageManager {
     el.append(summaryEl);
 
     if (btn) {
-      btn.style.display = 'inline-block';
+      btn.classList.remove('hidden');
     }
   }
 

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1581,6 +1581,11 @@ h4 .icon-svg {
   object-fit: cover;
 }
 
+/* Fallback display for class-toggled avatar fallback (was JS-set 'flex') */
+#profile-avatar-fallback {
+  display: flex;
+}
+
 .profile-details {
   display: flex;
   flex-direction: column;

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1270,8 +1270,9 @@ h4 .icon-svg {
 }
 
 /* Utility Classes for Refactoring Inline Styles */
+/* `!important` 對齊 Tailwind/Bootstrap utility 慣例，確保 .hidden 為無條件隱藏 */
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .sr-only {

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -1581,8 +1581,10 @@ h4 .icon-svg {
   object-fit: cover;
 }
 
-/* Fallback display for class-toggled avatar fallback (was JS-set 'flex') */
-#profile-avatar-fallback {
+/* Fallback display for class-toggled avatar fallback (was JS-set 'flex').
+   Scoped with :not(.hidden) so the .hidden utility (specificity 0,0,1,0)
+   isn't overridden by the ID selector (0,1,0,0). */
+#profile-avatar-fallback:not(.hidden) {
   display: flex;
 }
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -986,7 +986,7 @@
             ></output>
 
             <!-- 執行清理按鈕（僅在有可清理項目時顯示） -->
-            <button id="execute-cleanup-button" class="btn-danger" style="display: none">
+            <button id="execute-cleanup-button" class="btn-danger hidden">
               <svg width="16" height="16" class="icon-svg" aria-hidden="true" focusable="false">
                 <use href="#icon-trash" />
               </svg>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -986,7 +986,7 @@
             ></output>
 
             <!-- 執行清理按鈕（僅在有可清理項目時顯示） -->
-            <button id="execute-cleanup-button" class="btn-danger hidden">
+            <button id="execute-cleanup-button" type="button" class="btn-danger hidden">
               <svg width="16" height="16" class="icon-svg" aria-hidden="true" focusable="false">
                 <use href="#icon-trash" />
               </svg>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -472,7 +472,7 @@
           </header>
 
           <!-- Account Card -->
-          <div id="account-card" class="card" style="display: none">
+          <div id="account-card" class="card hidden">
             <h3>帳號登入</h3>
 
             <!-- 未登入狀態 -->
@@ -507,11 +507,11 @@
             </div>
 
             <!-- 已登入狀態 -->
-            <div id="account-logged-in" style="display: none">
+            <div id="account-logged-in" class="hidden">
               <div class="profile-layout">
                 <div class="profile-avatar">
-                  <img id="profile-avatar-img" alt="使用者頭像" style="display: none" />
-                  <div id="profile-avatar-fallback" style="display: none"></div>
+                  <img id="profile-avatar-img" class="hidden" alt="使用者頭像" />
+                  <div id="profile-avatar-fallback" class="hidden"></div>
                 </div>
                 <div class="profile-details">
                   <div class="profile-name-row">

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -566,7 +566,7 @@
           </div>
 
           <!-- Cloud Sync Card — Phase A 正式 UI -->
-          <div id="cloud-sync-card" class="card" style="display: none">
+          <div id="cloud-sync-card" class="card hidden">
             <h3 class="cloud-sync-header">
               <svg
                 width="20"
@@ -584,7 +584,7 @@
             </h3>
 
             <!-- 狀態零：未登入帳號 -->
-            <div id="drive-state-logged-out" style="display: none">
+            <div id="drive-state-logged-out" class="hidden">
               <p class="section-desc mb-12">
                 登入帳號後，可連接 Google Drive 以備份和同步你的本地資料到雲端。
               </p>
@@ -596,7 +596,7 @@
             </div>
 
             <!-- 狀態一：已登入但未連接 Google Drive -->
-            <div id="drive-state-disconnected" style="display: none">
+            <div id="drive-state-disconnected" class="hidden">
               <p class="section-desc mb-12">
                 連接 Google Drive 後，可備份和同步你的本地資料到雲端。
               </p>
@@ -619,7 +619,7 @@
             </div>
 
             <!-- 狀態二：已連接，可正常操作 -->
-            <div id="drive-state-connected" style="display: none">
+            <div id="drive-state-connected" class="hidden">
               <div class="drive-account-info">
                 <div>
                   <div class="text-sm text-secondary">已連接帳號</div>
@@ -649,7 +649,7 @@
                 </select>
               </div>
               <!-- Phase B: 自動同步狀態 -->
-              <output class="drive-auto-sync-status" style="display: none">
+              <output class="drive-auto-sync-status hidden">
                 <span id="drive-auto-sync-status-text"></span>
               </output>
               <!-- 操作按鈕 -->
@@ -676,7 +676,7 @@
             </div>
 
             <!-- 狀態三：衝突 — 遠端較新，需人工處理 -->
-            <div id="drive-state-conflict" style="display: none">
+            <div id="drive-state-conflict" class="hidden">
               <div class="drive-conflict-banner">
                 <div class="drive-conflict-header">
                   <svg
@@ -735,7 +735,7 @@
             </div>
 
             <!-- 錯誤提示（顯示在各狀態下方） -->
-            <div id="drive-error-banner" class="mt-10" style="display: none">
+            <div id="drive-error-banner" class="mt-10 hidden">
               <div class="drive-error-content">
                 <svg
                   width="16"
@@ -767,7 +767,7 @@
             </div>
 
             <!-- 操作進行中（spinner） -->
-            <div id="drive-loading-overlay" class="drive-loading-overlay" style="display: none">
+            <div id="drive-loading-overlay" class="drive-loading-overlay hidden">
               <div class="drive-loading-wrapper">
                 <div class="drive-spinner"></div>
                 <span id="drive-loading-text">處理中...</span>

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -200,10 +200,10 @@ export function initOptions() {
     const oauthConnectBtn = document.querySelector('#oauth-connect-button');
     const oauthDisconnectBtn = document.querySelector('#oauth-disconnect-button');
     if (oauthConnectBtn) {
-      oauthConnectBtn.style.display = 'none';
+      oauthConnectBtn.classList.add('hidden');
     }
     if (oauthDisconnectBtn) {
-      oauthDisconnectBtn.style.display = 'none';
+      oauthDisconnectBtn.classList.add('hidden');
     }
   }
 
@@ -628,19 +628,19 @@ function updateProfileDOM(profile) {
     if (avatarImgEl) {
       avatarImgEl.src = profile.avatarUrl;
       avatarImgEl.alt = UI_MESSAGES.ACCOUNT.AVATAR_ALT;
-      avatarImgEl.style.display = '';
+      avatarImgEl.classList.remove('hidden');
     }
     if (avatarFallbackEl) {
-      avatarFallbackEl.style.display = 'none';
+      avatarFallbackEl.classList.add('hidden');
     }
   } else {
     if (avatarImgEl) {
       avatarImgEl.removeAttribute('src');
-      avatarImgEl.style.display = 'none';
+      avatarImgEl.classList.add('hidden');
     }
     if (avatarFallbackEl) {
       avatarFallbackEl.textContent = avatarFallbackInitial;
-      avatarFallbackEl.style.display = 'flex';
+      avatarFallbackEl.classList.remove('hidden');
     }
   }
 }
@@ -680,10 +680,10 @@ function updateAccountLoginState(isActive, profile) {
 
   if (isActive) {
     if (loggedOutEl) {
-      loggedOutEl.style.display = 'none';
+      loggedOutEl.classList.add('hidden');
     }
     if (loggedInEl) {
-      loggedInEl.style.display = '';
+      loggedInEl.classList.remove('hidden');
     }
 
     if (profile) {
@@ -693,10 +693,10 @@ function updateAccountLoginState(isActive, profile) {
   } else {
     // 未登入狀態
     if (loggedOutEl) {
-      loggedOutEl.style.display = '';
+      loggedOutEl.classList.remove('hidden');
     }
     if (loggedInEl) {
-      loggedInEl.style.display = 'none';
+      loggedInEl.classList.add('hidden');
     }
 
     updateLockedFeatures(true);
@@ -771,18 +771,18 @@ function initAccountUI() {
 
   // feature flag 檢查
   if (!BUILD_ENV.ENABLE_ACCOUNT) {
-    accountCard.style.display = 'none';
+    accountCard.classList.add('hidden');
     if (advancedTab) {
-      advancedTab.style.display = 'none';
+      advancedTab.classList.add('hidden');
     }
     if (advancedSection) {
-      advancedSection.style.display = 'none';
+      advancedSection.classList.add('hidden');
     }
     return;
   }
 
   // 顯示 account card
-  accountCard.style.display = '';
+  accountCard.classList.remove('hidden');
 
   // 登入按鈕：開新 tab 到 /v1/account/google/start?ext_id=<chrome.runtime.id>
   const loginBtn = document.querySelector('#account-login-button');

--- a/scripts/auth/callbackStatusView.js
+++ b/scripts/auth/callbackStatusView.js
@@ -29,7 +29,6 @@ export function showLoading(message) {
     spinner.id = DOM_IDS.SPINNER.slice(1);
     spinner.className = 'spinner';
     spinner.setAttribute(ATTR_ARIA_HIDDEN, 'true');
-    spinner.style.display = '';
 
     const statusText = document.createElement('p');
     statusText.id = DOM_IDS.STATUS_TEXT.slice(1);
@@ -40,7 +39,7 @@ export function showLoading(message) {
     statusArea.replaceChildren(spinner, statusText);
   }
   if (closeHint) {
-    closeHint.style.display = 'none';
+    closeHint.classList.add('hidden');
   }
 }
 
@@ -76,7 +75,7 @@ export function showSuccess(message) {
     statusArea.replaceChildren(iconCircle, statusText);
   }
   if (closeHint) {
-    closeHint.style.display = '';
+    closeHint.classList.remove('hidden');
   }
 }
 
@@ -131,6 +130,6 @@ export function showError(message, detail) {
     statusArea.replaceChildren(...children);
   }
   if (closeHint) {
-    closeHint.style.display = 'none';
+    closeHint.classList.add('hidden');
   }
 }

--- a/styles/callback-bridge.css
+++ b/styles/callback-bridge.css
@@ -15,8 +15,9 @@
 }
 
 /* === Visibility Utility === */
+/* `!important` 對齊 Tailwind/Bootstrap utility 慣例，確保 .hidden 為無條件隱藏 */
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .status-area {

--- a/styles/callback-bridge.css
+++ b/styles/callback-bridge.css
@@ -14,6 +14,11 @@
   --callback-hint-text: #475569;
 }
 
+/* === Visibility Utility === */
+.hidden {
+  display: none;
+}
+
 .status-area {
   min-height: 64px;
   display: flex;

--- a/tests/unit/auth/callbackStatusView.test.js
+++ b/tests/unit/auth/callbackStatusView.test.js
@@ -11,7 +11,7 @@ function buildDom() {
         <div class="spinner" id="spinner" aria-hidden="true"></div>
         <p class="status-text" id="status-text">初始訊息</p>
       </output>
-      <p id="close-hint" style="display: none">此頁面將自動關閉</p>
+      <p id="close-hint" class="hidden">此頁面將自動關閉</p>
     </main>
   `;
 }
@@ -35,7 +35,7 @@ describe('callbackStatusView', () => {
     expect(spinner.className).toBe('spinner');
     expect(statusText).not.toBeNull();
     expect(statusText.textContent).toBe('重新載入中');
-    expect(closeHint.style.display).toBe('none');
+    expect(closeHint.classList.contains('hidden')).toBe(true);
   });
 
   it('showLoading 在 error 後應重建 loading UI', () => {
@@ -57,7 +57,7 @@ describe('callbackStatusView', () => {
     expect(successIcon).not.toBeNull();
 
     const closeHint = document.querySelector('#close-hint');
-    expect(closeHint.style.display).toBe('');
+    expect(closeHint.classList.contains('hidden')).toBe(false);
   });
 
   it('showError 應標記 status-error className、插入 error-detail 並隱藏關閉提示', () => {
@@ -71,6 +71,6 @@ describe('callbackStatusView', () => {
     expect(errorDetail.textContent).toBe('詳細錯誤訊息');
 
     const closeHint = document.querySelector('#close-hint');
-    expect(closeHint.style.display).toBe('none');
+    expect(closeHint.classList.contains('hidden')).toBe(true);
   });
 });

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -425,8 +425,12 @@ describe('AuthManager Extended', () => {
       expect(document.querySelector('#oauth-status').textContent).toContain(
         '已連接 — My Workspace'
       );
-      expect(document.querySelector('#oauth-connect-button').style.display).toBe('none');
-      expect(document.querySelector('#oauth-disconnect-button').style.display).toBe('inline-flex');
+      expect(document.querySelector('#oauth-connect-button').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#oauth-disconnect-button').classList.contains('hidden')).toBe(
+        false
+      );
       expect(mockLoadDatabases).toHaveBeenCalledWith('oauth_token_123');
       expect(document.querySelector('#database-id').value).toBe('ds_local_123');
       expect(document.querySelector('#title-template').value).toBe('{title} - custom');

--- a/tests/unit/options/DriveCloudSyncController.test.js
+++ b/tests/unit/options/DriveCloudSyncController.test.js
@@ -163,12 +163,12 @@ describe('DriveCloudSyncController', () => {
   describe('setCloudSyncCardVisibility', () => {
     it('shows card if logged in', () => {
       setCloudSyncCardVisibility(true);
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
     });
 
     it('hides card if logged out', () => {
       setCloudSyncCardVisibility(false);
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('none');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(true);
     });
   });
 
@@ -176,12 +176,22 @@ describe('DriveCloudSyncController', () => {
     it('未登入時應顯示提示狀態而不是隱藏整張卡片', async () => {
       await initCloudSyncController(false);
 
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-state-logged-out').style.display).toBe('');
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('none');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
       expect(document.querySelector('#drive-login-prompt-button').disabled).toBe(true);
     });
   });
@@ -189,10 +199,16 @@ describe('DriveCloudSyncController', () => {
   describe('renderCloudSyncCard', () => {
     it('renders disconnected state correctly', () => {
       renderCloudSyncCard({ connectionEmail: null });
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('none');
-      expect(document.querySelector('#drive-error-banner').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-error-banner').classList.contains('hidden')).toBe(true);
     });
 
     it('renders connected state correctly without conflict', () => {
@@ -201,9 +217,15 @@ describe('DriveCloudSyncController', () => {
         lastSuccessfulUploadAt: '2023-01-01T00:00:00Z',
         needsManualReview: false,
       });
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('');
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        true
+      );
 
       expect(document.querySelector('#drive-connected-email').textContent).toBe('test@notion.so');
       expect(document.querySelector('#drive-last-upload-text').textContent).toContain(
@@ -224,8 +246,12 @@ describe('DriveCloudSyncController', () => {
         }
       );
 
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
       expect(document.querySelector('#drive-sync-status').textContent).toContain('臨時登入失效');
       expect(document.querySelector('#drive-sync-status').textContent).toContain('重新登入');
       expect(document.querySelector('#drive-sync-status').className).toContain('error');
@@ -242,12 +268,18 @@ describe('DriveCloudSyncController', () => {
         needsManualReview: true,
         lastErrorCode: DRIVE_SYNC_ERROR_CODES.REMOTE_SNAPSHOT_NEWER,
       });
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        false
+      );
 
       // Error banner is hidden because REMOTE_SNAPSHOT_NEWER is considered conflict, not generic error
-      expect(document.querySelector('#drive-error-banner').style.display).toBe('none');
+      expect(document.querySelector('#drive-error-banner').classList.contains('hidden')).toBe(true);
     });
 
     it('renders other generic errors correctly', () => {
@@ -256,7 +288,9 @@ describe('DriveCloudSyncController', () => {
         lastErrorCode: DRIVE_SYNC_ERROR_CODES.UPLOAD_FAILED,
         lastErrorAt: '2023-01-02T00:00:00Z',
       });
-      expect(document.querySelector('#drive-error-banner').style.display).toBe('');
+      expect(document.querySelector('#drive-error-banner').classList.contains('hidden')).toBe(
+        false
+      );
       expect(document.querySelector('#drive-error-code').textContent).toContain(
         DRIVE_SYNC_ERROR_CODES.UPLOAD_FAILED
       );
@@ -338,7 +372,9 @@ describe('DriveCloudSyncController', () => {
         needsManualReview: true,
       });
       expect(document.querySelector('#drive-frequency-select').value).toBe('daily');
-      expect(document.querySelector('#drive-auto-sync-status').style.display).toBe('');
+      expect(document.querySelector('#drive-auto-sync-status').classList.contains('hidden')).toBe(
+        false
+      );
       expect(document.querySelector('#drive-auto-sync-status-text').textContent).toBe(
         UI_MESSAGES.CLOUD_SYNC.AUTO_SYNC_NEEDS_REVIEW
       );
@@ -348,7 +384,9 @@ describe('DriveCloudSyncController', () => {
         connectionEmail: 'test@notion.so',
         frequency: 'off',
       });
-      expect(document.querySelector('#drive-auto-sync-status').style.display).toBe('none');
+      expect(document.querySelector('#drive-auto-sync-status').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('hides auto sync status container when frequency is active but no review is needed', () => {
@@ -358,7 +396,9 @@ describe('DriveCloudSyncController', () => {
         frequency: 'weekly',
         needsManualReview: true,
       });
-      expect(document.querySelector('#drive-auto-sync-status').style.display).toBe('');
+      expect(document.querySelector('#drive-auto-sync-status').classList.contains('hidden')).toBe(
+        false
+      );
 
       // 再切換到 needsManualReview=false：container 必須被隱藏，避免 margin-bottom 佔用空白
       renderCloudSyncCard({
@@ -366,7 +406,9 @@ describe('DriveCloudSyncController', () => {
         frequency: 'weekly',
         needsManualReview: false,
       });
-      expect(document.querySelector('#drive-auto-sync-status').style.display).toBe('none');
+      expect(document.querySelector('#drive-auto-sync-status').classList.contains('hidden')).toBe(
+        true
+      );
       expect(document.querySelector('#drive-auto-sync-status-text').textContent).toBe('');
     });
   });
@@ -504,7 +546,9 @@ describe('DriveCloudSyncController', () => {
       document.querySelector('#drive-download-button').click();
       await flushAsyncWork();
 
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        false
+      );
       expect(document.querySelector('#drive-loading-text').textContent).toBe(
         UI_MESSAGES.CLOUD_SYNC.LOADING_STATUS_SYNC
       );
@@ -611,7 +655,7 @@ describe('DriveCloudSyncController', () => {
       document.querySelector('#drive-upload-button').click();
       await flushAsyncWork();
 
-      expect(document.querySelector('#drive-error-banner').style.display).toBe('none');
+      expect(document.querySelector('#drive-error-banner').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#drive-sync-status').textContent).toBe('');
       expect(document.querySelector('#drive-sync-status').className).toBe('status-message');
     });
@@ -632,7 +676,9 @@ describe('DriveCloudSyncController', () => {
         `${UI_MESSAGES.CLOUD_SYNC.UPLOAD_FAILED_PREFIX}${ErrorHandler.formatUserMessage(safeMessage)}`
       );
       expect(document.querySelector('#drive-sync-status').className).toContain('error');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('sanitizes upload errors before logging', async () => {
@@ -671,7 +717,9 @@ describe('DriveCloudSyncController', () => {
         `${UI_MESSAGES.CLOUD_SYNC.DOWNLOAD_FAILED_PREFIX}發生未知錯誤，請稍後再試`
       );
       expect(document.querySelector('#drive-sync-status').className).toContain('error');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('sanitizes download errors before logging', async () => {
@@ -701,7 +749,9 @@ describe('DriveCloudSyncController', () => {
       expect(mockSendMessage).not.toHaveBeenCalledWith({
         action: RUNTIME_ACTIONS.DRIVE_SYNC_MANUAL_DOWNLOAD,
       });
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
       expect(document.querySelector('#drive-download-button').disabled).toBe(false);
     });
 
@@ -723,8 +773,12 @@ describe('DriveCloudSyncController', () => {
       expect(driveClient.disconnectDrive).toHaveBeenCalled();
       expect(driveClient.clearDriveSyncMetadata).toHaveBeenCalled();
       expect(mockSendMessage).not.toHaveBeenCalled();
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('disconnect 成功後應顯示成功狀態並收起 loading overlay', async () => {
@@ -743,7 +797,9 @@ describe('DriveCloudSyncController', () => {
         UI_MESSAGES.CLOUD_SYNC.DISCONNECT_SUCCESS
       );
       expect(document.querySelector('#drive-sync-status').className).toContain('success');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('shows an error when disconnect fails', async () => {
@@ -761,7 +817,9 @@ describe('DriveCloudSyncController', () => {
         UI_MESSAGES.CLOUD_SYNC.DISCONNECT_FAILED
       );
       expect(document.querySelector('#drive-sync-status').className).toContain('error');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('skips disconnect when user cancels confirmation', async () => {
@@ -777,8 +835,10 @@ describe('DriveCloudSyncController', () => {
 
     it('bypasses interaction if not logged in', async () => {
       await initCloudSyncController(false);
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-state-logged-out').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
       // Handlers not attached if not logged in initially (in actual implementation)
     });
 
@@ -793,7 +853,9 @@ describe('DriveCloudSyncController', () => {
       const initPromise = initCloudSyncController(true);
 
       // Loading overlay should be displayed immediately
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        false
+      );
       expect(document.querySelector('#drive-loading-text').textContent).toBe(
         UI_MESSAGES.CLOUD_SYNC.LOADING_STATUS_SYNC
       );
@@ -812,7 +874,9 @@ describe('DriveCloudSyncController', () => {
       await initPromise;
 
       // Loading overlay should be hidden after initialization completes
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('none');
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        true
+      );
       expect(document.querySelector('#drive-connect-button').disabled).toBe(false);
       expect(document.querySelector('#drive-upload-button').disabled).toBe(false);
     });
@@ -980,7 +1044,9 @@ describe('DriveCloudSyncController', () => {
         'warn-path@test.dev'
       );
       // 未 throw
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('');
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        false
+      );
     });
 
     it('falls back to disconnected state when remote sync fails', async () => {
@@ -993,9 +1059,15 @@ describe('DriveCloudSyncController', () => {
         action: 'syncRemoteDriveConnection',
         error: sanitizeApiError(new Error('TOKEN_EXPIRED'), 'drive_connection_sync'),
       });
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('initCloudSyncController 傳入 transientAuthError=true 時不應誤顯示已連線狀態', async () => {
@@ -1011,8 +1083,12 @@ describe('DriveCloudSyncController', () => {
 
       await initCloudSyncController(true, { transientAuthError: true });
 
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
       expect(document.querySelector('#drive-sync-status').textContent).toContain('臨時登入失效');
       expect(driveClient.fetchDriveConnectionStatus).not.toHaveBeenCalled();
     });
@@ -1123,8 +1199,12 @@ describe('DriveCloudSyncController', () => {
       expect(storedMetadata.lastErrorCode).toBe(DRIVE_SYNC_ERROR_CODES.REMOTE_SNAPSHOT_NEWER);
       expect(storedMetadata.connectedAt).toBe('2026-04-19T11:00:00Z');
 
-      expect(document.querySelector('#drive-state-conflict').style.display).toBe('');
-      expect(document.querySelector('#drive-state-connected').style.display).toBe('none');
+      expect(document.querySelector('#drive-state-conflict').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#drive-state-connected').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('focus 首次連線且本地缺少 connectedAt 時才 fallback 為目前時間', async () => {
@@ -1257,7 +1337,9 @@ describe('DriveCloudSyncController', () => {
       await refreshCloudSyncCard({ syncRemote: true });
 
       expect(driveClient.clearDriveSyncMetadata).toHaveBeenCalled();
-      expect(document.querySelector('#drive-state-disconnected').style.display).toBe('');
+      expect(document.querySelector('#drive-state-disconnected').classList.contains('hidden')).toBe(
+        false
+      );
     });
 
     it('syncRemote:true 時同時查詢 snapshot status 並恢復雲端備份顯示', async () => {
@@ -1463,7 +1545,7 @@ describe('DriveCloudSyncController', () => {
       let isOverlayVisibleDuringConfirm = null;
       globalThis.confirm.mockImplementationOnce(() => {
         isDisabledDuringConfirm = uploadBtn.disabled;
-        isOverlayVisibleDuringConfirm = overlay.style.display === '';
+        isOverlayVisibleDuringConfirm = !overlay.classList.contains('hidden');
         return false;
       });
 
@@ -1476,7 +1558,7 @@ describe('DriveCloudSyncController', () => {
       expect(isDisabledDuringConfirm).toBe(true);
       expect(isOverlayVisibleDuringConfirm).toBe(true);
       expect(uploadBtn.disabled).toBe(false);
-      expect(overlay.style.display).toBe('none');
+      expect(overlay.classList.contains('hidden')).toBe(true);
     });
 
     it('偵測跨安裝且使用者確認時，應送出 DRIVE_SYNC_MANUAL_UPLOAD', async () => {

--- a/tests/unit/options/StorageManager.test.js
+++ b/tests/unit/options/StorageManager.test.js
@@ -73,7 +73,7 @@ function buildTestDom() {
     <div id="highlights-count"></div>
     <div id="config-count"></div>
     <output id="health-status"></output>
-    <button id="execute-cleanup-button" style="display:none"></button>
+    <button id="execute-cleanup-button" class="hidden"></button>
     <div id="cleanup-status" class="status-message mt-8"></div>
   `;
 }
@@ -850,14 +850,14 @@ describe('StorageManager — 使用量與健康狀態', () => {
       storageManager.updateHealthDisplay(report);
 
       const btn = storageManager.elements.executeCleanupButton;
-      expect(btn.style.display).toBe('inline-block');
+      expect(btn.classList.contains('hidden')).toBe(false);
       expect(storageManager.elements.healthStatus.textContent).toContain('可清理：1 個空記錄');
     });
 
     test('無可清理項目時應隱藏「執行清理」按鈕', () => {
       storageManager.updateHealthDisplay(baseReport());
       const btn = storageManager.elements.executeCleanupButton;
-      expect(btn.style.display).toBe('none');
+      expect(btn.classList.contains('hidden')).toBe(true);
     });
 
     test('healthStatus 元素不存在時應安全返回', () => {

--- a/tests/unit/options/options.test.js
+++ b/tests/unit/options/options.test.js
@@ -876,8 +876,12 @@ describe('options.js', () => {
 
       initOptions();
 
-      expect(document.querySelector('#oauth-connect-button').style.display).toBe('none');
-      expect(document.querySelector('#oauth-disconnect-button').style.display).toBe('none');
+      expect(document.querySelector('#oauth-connect-button').classList.contains('hidden')).toBe(
+        true
+      );
+      expect(document.querySelector('#oauth-disconnect-button').classList.contains('hidden')).toBe(
+        true
+      );
     });
 
     it('應監聽 storageUsageUpdate 事件並更新儲存使用量', () => {
@@ -1959,9 +1963,9 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       BUILD_ENV.ENABLE_ACCOUNT = false;
       getAccountProfile.mockResolvedValue(null);
       initOptions();
-      expect(document.querySelector('#account-card').style.display).toBe('none');
-      expect(document.querySelector('#tab-advanced').style.display).toBe('none');
-      expect(document.querySelector('#section-advanced').style.display).toBe('none');
+      expect(document.querySelector('#account-card').classList.contains('hidden')).toBe(true);
+      expect(document.querySelector('#tab-advanced').classList.contains('hidden')).toBe(true);
+      expect(document.querySelector('#section-advanced').classList.contains('hidden')).toBe(true);
     });
 
     it('ENABLE_ACCOUNT=true 時應顯示 account card', async () => {
@@ -1969,7 +1973,7 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       initOptions();
       // renderAccountUI 是 async，等待 microtask
       await Promise.resolve();
-      expect(document.querySelector('#account-card').style.display).not.toBe('none');
+      expect(document.querySelector('#account-card').classList.contains('hidden')).toBe(false);
     });
   });
 
@@ -1979,8 +1983,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       initOptions();
       await flushAsyncClick();
 
-      expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-in').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
       expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
         false
@@ -2015,12 +2021,12 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       initOptions();
       await flushAsyncClick();
 
-      expect(document.querySelector('#account-logged-in').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-out').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#profile-display-name').textContent).toBe('Test User');
 
       const avatarImg = document.querySelector('#profile-avatar-img');
-      expect(avatarImg.style.display).not.toBe('none');
+      expect(avatarImg.classList.contains('hidden')).toBe(false);
       expect(avatarImg.src).toContain('avatar.png');
 
       expect(
@@ -2043,7 +2049,7 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
         'user@example.com'
       );
       const fallback = document.querySelector('#profile-avatar-fallback');
-      expect(fallback.style.display).not.toBe('none');
+      expect(fallback.classList.contains('hidden')).toBe(false);
       expect(fallback.textContent).toBe('U');
     });
 
@@ -2061,7 +2067,7 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       expect(document.querySelector('#profile-display-name').textContent).toBe('user@example.com');
 
       const fallback = document.querySelector('#profile-avatar-fallback');
-      expect(fallback.style.display).not.toBe('none');
+      expect(fallback.classList.contains('hidden')).toBe(false);
       expect(fallback.textContent).toBe('U');
     });
 
@@ -2081,7 +2087,7 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       expect(document.querySelector('#profile-email').textContent).toBe('');
 
       const fallback = document.querySelector('#profile-avatar-fallback');
-      expect(fallback.style.display).toBe('flex');
+      expect(fallback.classList.contains('hidden')).toBe(false);
       expect(fallback.textContent).toBe('?');
     });
 
@@ -2097,8 +2103,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-in').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
       expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
         false
@@ -2248,8 +2256,8 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       listener({ action: 'account_session_updated' });
       await flushAsyncClick();
 
-      expect(document.querySelector('#account-logged-in').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-out').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#profile-display-name').textContent).toBe('New');
       expect(document.querySelector('#profile-email').textContent).toBe('new@example.com');
     });
@@ -2272,8 +2280,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       listener({ action: 'account_session_cleared' });
       await flushAsyncClick();
 
-      expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-in').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
       expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
         false
@@ -2321,8 +2331,8 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       await flushAsyncClick();
 
       // token 過期但 refresh 成功，應顯示已登入狀態
-      expect(document.querySelector('#account-logged-in').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-out').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(true);
     });
 
     it('token 過期且 getAccountAccessToken 回 null（terminal failure 或無 refresh token），UI 應切回未登入', async () => {
@@ -2339,8 +2349,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       await flushAsyncClick();
 
       // terminal failure / 無 refresh token，應回到未登入
-      expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-in').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(true);
     });
 
     it('token 取得發生 transient rejection 時，有 profile 應保留 logged-in UI、顯示可重試提示，且 Cloud Sync 不應卡在 loading', async () => {
@@ -2356,8 +2368,8 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       await flushAsyncClick();
 
       // regression guard：有 profile + transient rejection 時保留 logged-in，讓使用者可重試
-      expect(document.querySelector('#account-logged-in').style.display).not.toBe('none');
-      expect(document.querySelector('#account-logged-out').style.display).toBe('none');
+      expect(document.querySelector('#account-logged-in').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#account-logged-out').classList.contains('hidden')).toBe(true);
       expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
       expect(document.querySelector('#account-status').textContent).toContain('無法更新登入狀態');
     });

--- a/tests/unit/options/options.test.js
+++ b/tests/unit/options/options.test.js
@@ -1981,8 +1981,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
 
       expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
       expect(document.querySelector('#account-logged-in').style.display).toBe('none');
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-state-logged-out').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
       expect(
         document.querySelector('#ai-assistant-card').classList.contains('locked-feature')
       ).toBe(true);
@@ -1994,8 +1996,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
 
       initOptions();
 
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-loading-overlay').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-loading-overlay').classList.contains('hidden')).toBe(
+        false
+      );
     });
   });
 
@@ -2095,8 +2099,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
 
       expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
       expect(document.querySelector('#account-logged-in').style.display).toBe('none');
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-state-logged-out').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
     });
   });
 
@@ -2268,8 +2274,10 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
 
       expect(document.querySelector('#account-logged-out').style.display).not.toBe('none');
       expect(document.querySelector('#account-logged-in').style.display).toBe('none');
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
-      expect(document.querySelector('#drive-state-logged-out').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
+      expect(document.querySelector('#drive-state-logged-out').classList.contains('hidden')).toBe(
+        false
+      );
     });
   });
 
@@ -2350,7 +2358,7 @@ describe('Account UI (initAccountUI / renderAccountUI)', () => {
       // regression guard：有 profile + transient rejection 時保留 logged-in，讓使用者可重試
       expect(document.querySelector('#account-logged-in').style.display).not.toBe('none');
       expect(document.querySelector('#account-logged-out').style.display).toBe('none');
-      expect(document.querySelector('#cloud-sync-card').style.display).toBe('');
+      expect(document.querySelector('#cloud-sync-card').classList.contains('hidden')).toBe(false);
       expect(document.querySelector('#account-status').textContent).toContain('無法更新登入狀態');
     });
 


### PR DESCRIPTION
### 摘要
重構多個元件的可見性切換，統一使用 `.hidden` 類別來控制顯示與隱藏。

### 變更內容
- 將多個元件的顯示邏輯從內聯樣式改為使用 `.hidden` 類別。
- 更新相關的 CSS 規則以支持新的顯示邏輯。
- 確保所有涉及的元件在狀態變更時正確添加或移除 `.hidden` 類別。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

