### PR TITLE
refactor: restructure composite handlers into a registry mapping table

### DIFF
--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -71,6 +71,51 @@ function resolveUiMessage(path) {
   return typeof value === 'string' ? value : '';
 }
 
+const COMPOSITE_HANDLERS = {
+  'destination-target-help': element => {
+    const link = element.querySelector('a');
+    if (!link) {
+      return;
+    }
+    element.replaceChildren(
+      document.createTextNode(UI_MESSAGES.OPTIONS.DESTINATION.HELP_PREFIX),
+      link,
+      document.createTextNode(UI_MESSAGES.OPTIONS.DESTINATION.HELP_SUFFIX)
+    );
+    link.textContent = UI_MESSAGES.OPTIONS.DESTINATION.HELP_LINK_TEXT;
+  },
+
+  'guide-shortcut-desc': element => {
+    const codes = element.querySelectorAll('code.kbd');
+    if (codes.length !== 2) {
+      return;
+    }
+    const [ctrlCode, cmdCode] = codes;
+    ctrlCode.textContent = UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CTRL_KEY;
+    cmdCode.textContent = UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CMD_KEY;
+    element.replaceChildren(
+      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_PREFIX),
+      ctrlCode,
+      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_MIDDLE),
+      cmdCode,
+      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_SUFFIX)
+    );
+  },
+
+  'guide-faq-token-answer': element => {
+    const code = element.querySelector('code.inline-code');
+    if (!code) {
+      return;
+    }
+    code.textContent = UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_CODE;
+    element.replaceChildren(
+      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_PREFIX),
+      code,
+      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_SUFFIX)
+    );
+  },
+};
+
 export function applyStaticOptionMessages(root = document) {
   root.querySelectorAll('[data-ui-message]').forEach(element => {
     element.textContent = resolveUiMessage(element.dataset.uiMessage);
@@ -88,44 +133,12 @@ export function applyStaticOptionMessages(root = document) {
     element.setAttribute('aria-label', resolveUiMessage(element.dataset.uiAriaLabel));
   });
 
-  const destinationHelp = root.querySelector('[data-ui-composite="destination-target-help"]');
-  const destinationHelpLink = destinationHelp?.querySelector('a');
-  if (destinationHelp && destinationHelpLink) {
-    destinationHelp.replaceChildren(
-      document.createTextNode(UI_MESSAGES.OPTIONS.DESTINATION.HELP_PREFIX),
-      destinationHelpLink,
-      document.createTextNode(UI_MESSAGES.OPTIONS.DESTINATION.HELP_SUFFIX)
-    );
-    destinationHelpLink.textContent = UI_MESSAGES.OPTIONS.DESTINATION.HELP_LINK_TEXT;
-  }
-
-  const shortcutDesc = root.querySelector('[data-ui-composite="guide-shortcut-desc"]');
-  if (shortcutDesc) {
-    const codes = shortcutDesc.querySelectorAll('code.kbd');
-    if (codes.length === 2) {
-      const [ctrlCode, cmdCode] = codes;
-      ctrlCode.textContent = UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CTRL_KEY;
-      cmdCode.textContent = UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CMD_KEY;
-      shortcutDesc.replaceChildren(
-        document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_PREFIX),
-        ctrlCode,
-        document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_MIDDLE),
-        cmdCode,
-        document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_SUFFIX)
-      );
+  root.querySelectorAll('[data-ui-composite]').forEach(element => {
+    const handler = COMPOSITE_HANDLERS[element.dataset.uiComposite];
+    if (handler) {
+      handler(element);
     }
-  }
-
-  const tokenAnswer = root.querySelector('[data-ui-composite="guide-faq-token-answer"]');
-  const tokenAnswerCode = tokenAnswer?.querySelector('code.inline-code');
-  if (tokenAnswer && tokenAnswerCode) {
-    tokenAnswerCode.textContent = UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_CODE;
-    tokenAnswer.replaceChildren(
-      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_PREFIX),
-      tokenAnswerCode,
-      document.createTextNode(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_SUFFIX)
-    );
-  }
+  });
 }
 
 function normalizeDestinationProfileName(value) {

--- a/tests/unit/options/options.test.js
+++ b/tests/unit/options/options.test.js
@@ -230,6 +230,7 @@ describe('options.js', () => {
       const helpText = document.querySelector('.destination-target-help');
       const helpLink = helpText.querySelector('a');
       expect(helpText.textContent).toContain(UI_MESSAGES.OPTIONS.DESTINATION.HELP_PREFIX);
+      expect(helpText.textContent).toContain(UI_MESSAGES.OPTIONS.DESTINATION.HELP_SUFFIX);
       expect(helpLink.textContent).toBe(UI_MESSAGES.OPTIONS.DESTINATION.HELP_LINK_TEXT);
       expect(helpLink.getAttribute('href')).toBe('https://example.test');
     });
@@ -349,6 +350,41 @@ describe('options.js', () => {
       expect(document.querySelector('[data-ui-composite="never-registered-key"]').textContent).toBe(
         '原始內容'
       );
+    });
+
+    // Composite handler 直接用 identifier access UI_MESSAGES（不走 resolveUiMessage），
+    // 若 messages.js 改名而 handler 漏改，DOM 會印出字串 "undefined"。
+    // per-handler 測試會 catch（textContent 比對失敗），但失敗訊息指向 textContent 不符，
+    // 不會直接點出哪個 path 失效。這個 reflective test 把 path 契約攤開：
+    // 失敗時直接告訴你是哪個 key 不見了。
+    // 注意：path 列表 hand-maintained；新增 handler 時需同步更新此列表。
+    it('composite handler 引用的 UI_MESSAGES path 皆為非空字串', () => {
+      const compositePaths = [
+        'OPTIONS.DESTINATION.HELP_PREFIX',
+        'OPTIONS.DESTINATION.HELP_SUFFIX',
+        'OPTIONS.DESTINATION.HELP_LINK_TEXT',
+        'OPTIONS.GUIDE.FEATURES_SHORTCUT_CTRL_KEY',
+        'OPTIONS.GUIDE.FEATURES_SHORTCUT_CMD_KEY',
+        'OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_PREFIX',
+        'OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_MIDDLE',
+        'OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_SUFFIX',
+        'OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_CODE',
+        'OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_PREFIX',
+        'OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_SUFFIX',
+      ];
+
+      compositePaths.forEach(path => {
+        let value = UI_MESSAGES;
+        for (const key of path.split('.')) {
+          value = value?.[key];
+        }
+        // 把 path 包進 actual object，失敗訊息會直接點名是哪個 key 失效。
+        expect({
+          path,
+          type: typeof value,
+          nonEmpty: typeof value === 'string' && value.length > 0,
+        }).toEqual({ path, type: 'string', nonEmpty: true });
+      });
     });
   });
 

--- a/tests/unit/options/options.test.js
+++ b/tests/unit/options/options.test.js
@@ -285,6 +285,71 @@ describe('options.js', () => {
       // 防呆：若有人意外把 binding 全部刪掉，這個下限會立刻失敗。
       expect(totalBindings).toBeGreaterThan(20);
     });
+
+    it('應重組 guide-shortcut-desc 的 Ctrl/Cmd 快捷鍵描述', () => {
+      document.body.innerHTML = `
+        <div data-ui-composite="guide-shortcut-desc">
+          舊文字 <code class="kbd">OLD-CTRL</code> 中間舊文字 <code class="kbd">OLD-CMD</code> 舊尾
+        </div>
+      `;
+
+      applyStaticOptionMessages();
+
+      const container = document.querySelector('[data-ui-composite="guide-shortcut-desc"]');
+      const codes = container.querySelectorAll('code.kbd');
+      expect(codes).toHaveLength(2);
+      expect(codes[0].textContent).toBe(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CTRL_KEY);
+      expect(codes[1].textContent).toBe(UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_CMD_KEY);
+      expect(container.textContent).toContain(
+        UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_PREFIX
+      );
+      expect(container.textContent).toContain(
+        UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_MIDDLE
+      );
+      expect(container.textContent).toContain(
+        UI_MESSAGES.OPTIONS.GUIDE.FEATURES_SHORTCUT_DESC_SUFFIX
+      );
+    });
+
+    it('當 guide-shortcut-desc 缺少預期的 code 元素時應安靜跳過', () => {
+      document.body.innerHTML = `
+        <div data-ui-composite="guide-shortcut-desc">只有一個 <code class="kbd">X</code></div>
+      `;
+
+      expect(() => applyStaticOptionMessages()).not.toThrow();
+
+      // 既有 code 文字應保留（handler 偵測到 length !== 2 直接跳過）
+      const code = document.querySelector('[data-ui-composite="guide-shortcut-desc"] code.kbd');
+      expect(code.textContent).toBe('X');
+    });
+
+    it('應重組 guide-faq-token-answer 的 token 格式說明', () => {
+      document.body.innerHTML = `
+        <div data-ui-composite="guide-faq-token-answer">
+          舊文字 <code class="inline-code">old_</code> 舊尾
+        </div>
+      `;
+
+      applyStaticOptionMessages();
+
+      const container = document.querySelector('[data-ui-composite="guide-faq-token-answer"]');
+      const code = container.querySelector('code.inline-code');
+      expect(code).not.toBeNull();
+      expect(code.textContent).toBe(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_CODE);
+      expect(container.textContent).toContain(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_PREFIX);
+      expect(container.textContent).toContain(UI_MESSAGES.OPTIONS.GUIDE.FAQ_TOKEN_ANSWER_SUFFIX);
+    });
+
+    it('未知的 data-ui-composite key 不應拋錯', () => {
+      document.body.innerHTML = `
+        <div data-ui-composite="never-registered-key">原始內容</div>
+      `;
+
+      expect(() => applyStaticOptionMessages()).not.toThrow();
+      expect(document.querySelector('[data-ui-composite="never-registered-key"]').textContent).toBe(
+        '原始內容'
+      );
+    });
   });
 
   describe('saveSettings', () => {


### PR DESCRIPTION
### 摘要
重構 `applyStaticOptionMessages` 函數，將複合處理器重構為註冊表映射表，以提升可讀性與擴充性。

### 變更內容
- 在 `pages/options/options.js` 中新增私有的 `COMPOSITE_HANDLERS` 映射表，將三個複合處理器（`destination-target-help`、`guide-shortcut-desc`、`guide-faq-token-answer`）從內聯的條件分支抽出為獨立的處理函數。
- 簡化 `applyStaticOptionMessages` 函數為「遍歷 + 分發」模式，與現有的 `data-ui-*` 屬性綁定迴圈風格一致。
- 新增四個單元測試：`guide-shortcut-desc` 重組、`guide-shortcut-desc` fallback、`guide-faq-token-answer` 重組、未知 composite key 防禦測試。

### 測試方式
已新增單元測試以驗證重構後的行為，確保各個處理器的功能正常。

### 潛在風險
無顯著風險。

