### PR TITLE
fix: 🔒 sanitize MarkdownExtractor cleanDOM to prevent XSS via innerHTML

### DIFF
--- a/scripts/content/extractors/MarkdownExtractor.js
+++ b/scripts/content/extractors/MarkdownExtractor.js
@@ -131,7 +131,7 @@ export const MarkdownExtractor = {
       clone.querySelectorAll(selector).forEach(el => el.remove());
     });
 
-    // 縱深防禦 (Defense-in-Depth)：移除潛在的 XSS 屬性 (如 on* 事件、危險 URL 協議與 formaction)
+    // 縱深防禦 (Defense-in-Depth)：移除潛在的 XSS 屬性 (如 on* 事件、危險 URL 協議、formaction、form action)
     const DANGEROUS_URL_RE = /^\s*(?:javascript:|data:text\/html)/i;
     const allElements = clone.querySelectorAll('*');
     allElements.forEach(el => {
@@ -160,6 +160,12 @@ export const MarkdownExtractor = {
       const formaction = el.getAttribute('formaction');
       if (formaction && DANGEROUS_URL_RE.test(formaction)) {
         el.removeAttribute('formaction');
+      }
+
+      // 清理 <form> 的 action 危險 URL（與 formaction 同質的提交目標攻擊向量）
+      const action = el.getAttribute('action');
+      if (action && DANGEROUS_URL_RE.test(action)) {
+        el.removeAttribute('action');
       }
     });
 

--- a/scripts/content/extractors/MarkdownExtractor.js
+++ b/scripts/content/extractors/MarkdownExtractor.js
@@ -83,6 +83,7 @@ export const MarkdownExtractor = {
       'style',
       'meta',
       'link',
+      'base',
 
       // Copy Buttons & Toolbars
       '.clipboard-button',
@@ -130,7 +131,8 @@ export const MarkdownExtractor = {
       clone.querySelectorAll(selector).forEach(el => el.remove());
     });
 
-    // 縱深防禦 (Defense-in-Depth)：移除潛在的 XSS 屬性 (如 on* 事件與 javascript: 協議)
+    // 縱深防禦 (Defense-in-Depth)：移除潛在的 XSS 屬性 (如 on* 事件、危險 URL 協議與 formaction)
+    const DANGEROUS_URL_RE = /^\s*(?:javascript:|data:text\/html)/i;
     const allElements = clone.querySelectorAll('*');
     allElements.forEach(el => {
       const attributes = Array.from(el.attributes);
@@ -140,17 +142,24 @@ export const MarkdownExtractor = {
         }
       });
 
-      // 清理 javascript: URLs
-      if (el.tagName === 'A') {
+      // 清理 <a> 的 href 危險 URL（javascript: / data:text/html）
+      if (el.tagName?.toUpperCase() === 'A') {
         const href = el.getAttribute('href');
-        if (href && href.trim().toLowerCase().startsWith('javascript:')) {
+        if (href && DANGEROUS_URL_RE.test(href)) {
           el.removeAttribute('href');
         }
       }
 
+      // 清理任意元素的 src 危險 URL
       const src = el.getAttribute('src');
-      if (src && src.trim().toLowerCase().startsWith('javascript:')) {
+      if (src && DANGEROUS_URL_RE.test(src)) {
         el.removeAttribute('src');
+      }
+
+      // 清理 <button> / <input> 的 formaction 危險 URL
+      const formaction = el.getAttribute('formaction');
+      if (formaction && DANGEROUS_URL_RE.test(formaction)) {
+        el.removeAttribute('formaction');
       }
     });
 

--- a/scripts/content/extractors/MarkdownExtractor.js
+++ b/scripts/content/extractors/MarkdownExtractor.js
@@ -72,8 +72,18 @@ export const MarkdownExtractor = {
   cleanDOM(element) {
     const clone = element.cloneNode(true);
 
-    // 定義需要移除的雜訊選擇器
+    // 定義需要移除的雜訊選擇器與潛在的 XSS 風險標籤
     const noiseSelectors = [
+      // XSS & Security Risks
+      'script',
+      'iframe',
+      'object',
+      'embed',
+      'noscript',
+      'style',
+      'meta',
+      'link',
+
       // Copy Buttons & Toolbars
       '.clipboard-button',
       '.copy-button',
@@ -118,6 +128,30 @@ export const MarkdownExtractor = {
     const labelSelectors = ['.language-label', '.lang-label', 'span[data-code-text]'];
     labelSelectors.forEach(selector => {
       clone.querySelectorAll(selector).forEach(el => el.remove());
+    });
+
+    // 縱深防禦 (Defense-in-Depth)：移除潛在的 XSS 屬性 (如 on* 事件與 javascript: 協議)
+    const allElements = clone.querySelectorAll('*');
+    allElements.forEach(el => {
+      const attributes = Array.from(el.attributes);
+      attributes.forEach(attr => {
+        if (attr.name.toLowerCase().startsWith('on')) {
+          el.removeAttribute(attr.name);
+        }
+      });
+
+      // 清理 javascript: URLs
+      if (el.tagName === 'A') {
+        const href = el.getAttribute('href');
+        if (href && href.trim().toLowerCase().startsWith('javascript:')) {
+          el.removeAttribute('href');
+        }
+      }
+
+      const src = el.getAttribute('src');
+      if (src && src.trim().toLowerCase().startsWith('javascript:')) {
+        el.removeAttribute('src');
+      }
     });
 
     // 清洗完成

--- a/tests/unit/content/extractors/MarkdownExtractor.test.js
+++ b/tests/unit/content/extractors/MarkdownExtractor.test.js
@@ -121,6 +121,23 @@ describe('MarkdownExtractor', () => {
       expect(inputs[0].hasAttribute('formaction')).toBe(false);
     });
 
+    it('should remove form action attribute when it carries a dangerous URL', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <form action="javascript:alert(1)"><button type="submit">Bad</button></form>
+        <form action=" Data:Text/HTML,<script>alert(2)</script>"><button type="submit">Bad data</button></form>
+        <form action="https://safe.example.com/submit"><button type="submit">Safe</button></form>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      const forms = cleaned.querySelectorAll('form');
+      expect(forms[0].hasAttribute('action')).toBe(false);
+      expect(forms[1].hasAttribute('action')).toBe(false);
+      expect(forms[2].getAttribute('action')).toBe('https://safe.example.com/submit');
+    });
+
     it('should remove data:text/html URLs from href and src', () => {
       const container = doc.createElement('div');
       container.innerHTML = `

--- a/tests/unit/content/extractors/MarkdownExtractor.test.js
+++ b/tests/unit/content/extractors/MarkdownExtractor.test.js
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { MarkdownExtractor } from '../../../../scripts/content/extractors/MarkdownExtractor.js';
+
+describe('MarkdownExtractor', () => {
+  let doc;
+
+  beforeEach(() => {
+    doc = document.implementation.createHTMLDocument('Test Document');
+  });
+
+  describe('cleanDOM - Security Sanitization', () => {
+    it('should remove dangerous tags (script, iframe, style, etc.)', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <p>Safe content</p>
+        <script>alert("XSS")</script>
+        <iframe src="http://evil.com"></iframe>
+        <style>body { display: none; }</style>
+        <object data="evil.swf"></object>
+        <embed src="evil.swf"></embed>
+        <noscript>Cannot execute</noscript>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      expect(cleaned.innerHTML).not.toContain('<script');
+      expect(cleaned.innerHTML).not.toContain('<iframe');
+      expect(cleaned.innerHTML).not.toContain('<style');
+      expect(cleaned.innerHTML).not.toContain('<object');
+      expect(cleaned.innerHTML).not.toContain('<embed');
+      expect(cleaned.innerHTML).not.toContain('<noscript');
+      expect(cleaned.innerHTML).toContain('Safe content');
+    });
+
+    it('should remove inline event handlers (on*)', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <div onclick="alert(1)" onmouseover="alert(2)" data-safe="true">
+          Hover me
+          <img src="test.jpg" onerror="alert(3)" onload="alert(4)" />
+        </div>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      const div = cleaned.querySelector('div');
+      expect(div.hasAttribute('onclick')).toBe(false);
+      expect(div.hasAttribute('onmouseover')).toBe(false);
+      expect(Object.hasOwn(div.dataset, 'safe')).toBe(true);
+
+      const img = cleaned.querySelector('img');
+      expect(img.hasAttribute('onerror')).toBe(false);
+      expect(img.hasAttribute('onload')).toBe(false);
+      expect(img.getAttribute('src')).toBe('test.jpg');
+    });
+
+    it('should remove javascript: URLs from href and src', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <a href="javascript:alert(1)">Click me</a>
+        <a href=" javascript: alert(2) ">Click me 2</a>
+        <a href="JavaScript:alert(3)">Click me 3</a>
+        <a href="https://safe.com">Safe Link</a>
+        <img src="javascript:alert(4)" />
+        <img src="image.jpg" />
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      const links = cleaned.querySelectorAll('a');
+      expect(links[0].hasAttribute('href')).toBe(false);
+      expect(links[1].hasAttribute('href')).toBe(false);
+      expect(links[2].hasAttribute('href')).toBe(false);
+      expect(links[3].getAttribute('href')).toBe('https://safe.com');
+
+      const imgs = cleaned.querySelectorAll('img');
+      expect(imgs[0].hasAttribute('src')).toBe(false);
+      expect(imgs[1].getAttribute('src')).toBe('image.jpg');
+    });
+  });
+});

--- a/tests/unit/content/extractors/MarkdownExtractor.test.js
+++ b/tests/unit/content/extractors/MarkdownExtractor.test.js
@@ -83,5 +83,81 @@ describe('MarkdownExtractor', () => {
       expect(imgs[0].hasAttribute('src')).toBe(false);
       expect(imgs[1].getAttribute('src')).toBe('image.jpg');
     });
+
+    it('should remove <base> tag to prevent relative URL hijacking', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <base href="https://evil.example.com/" />
+        <p>Article body</p>
+        <a href="/login">Sign in</a>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      expect(cleaned.querySelector('base')).toBeNull();
+      expect(cleaned.innerHTML).toContain('Article body');
+      expect(cleaned.querySelector('a[href="/login"]')).not.toBeNull();
+    });
+
+    it('should remove formaction attribute when it carries a dangerous URL', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <form>
+          <button type="submit" formaction="javascript:alert(1)">Bad</button>
+          <input type="submit" formaction=" JavaScript: alert(2) " value="Bad input" />
+          <button type="submit" formaction="https://safe.example.com/submit">Safe</button>
+        </form>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      const buttons = cleaned.querySelectorAll('button');
+      expect(buttons[0].hasAttribute('formaction')).toBe(false);
+      expect(buttons[1].getAttribute('formaction')).toBe('https://safe.example.com/submit');
+
+      const inputs = cleaned.querySelectorAll('input');
+      expect(inputs[0].hasAttribute('formaction')).toBe(false);
+    });
+
+    it('should remove data:text/html URLs from href and src', () => {
+      const container = doc.createElement('div');
+      container.innerHTML = `
+        <a href="data:text/html,<script>alert(1)</script>">Click</a>
+        <a href=" Data:Text/HTML;base64,PHNjcmlwdD4=">Click 2</a>
+        <a href="https://safe.com">Safe Link</a>
+        <img src="data:text/html,<svg/onload=alert(2)>" />
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      const links = cleaned.querySelectorAll('a');
+      expect(links[0].hasAttribute('href')).toBe(false);
+      expect(links[1].hasAttribute('href')).toBe(false);
+      expect(links[2].getAttribute('href')).toBe('https://safe.com');
+
+      const img = cleaned.querySelector('img');
+      expect(img.hasAttribute('src')).toBe(false);
+    });
+
+    it('should preserve safe data: URIs (e.g., data:image/png) — regression guard', () => {
+      const container = doc.createElement('div');
+      const safeSrc =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+      container.innerHTML = `
+        <img src="${safeSrc}" alt="dot" />
+        <a href="data:application/pdf;base64,JVBERi0=">Download</a>
+      `;
+      doc.body.append(container);
+
+      const cleaned = MarkdownExtractor.cleanDOM(container);
+
+      expect(cleaned.querySelector('img').getAttribute('src')).toBe(safeSrc);
+      expect(cleaned.querySelector('a').getAttribute('href')).toBe(
+        'data:application/pdf;base64,JVBERi0='
+      );
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** An XSS vulnerability existed in `MarkdownExtractor.js` where the `.innerHTML` of a cloned container was returned without sufficient security sanitization, allowing potentially malicious scripts or event handlers to propagate.

⚠️ **Risk:** If the extracted HTML containing dangerous payloads (like `<script>`, `<iframe>`, or inline `on*` events) was rendered or parsed downstream without further security checks, it could lead to Cross-Site Scripting (XSS).

🛡️ **Solution:** Enhanced the `cleanDOM` method in `MarkdownExtractor.js` to perform deep sanitization on the cloned DOM element before accessing its `innerHTML`. This includes:
  - Removing known dangerous tags (`script`, `iframe`, `object`, `embed`, `noscript`, `style`, `meta`, `link`).
  - Iterating over all cloned elements to remove any inline event handlers (attributes starting with `on`).
  - Stripping `javascript:` URIs from `href` and `src` attributes.
  - Added robust Jest tests to ensure dangerous elements and attributes are effectively removed while preserving safe content.

---
*PR created automatically by Jules for task [4213980492021405411](https://jules.google.com/task/4213980492021405411) started by @cowcfj*