### PR TITLE
test: 🧪 Fix sanitizeApiError mock to use actual implementation

### DIFF
--- a/tests/unit/background/handlers/highlightHandlers.test.js
+++ b/tests/unit/background/handlers/highlightHandlers.test.js
@@ -39,9 +39,10 @@ describe('highlightHandlers', () => {
     ErrorHandler.formatUserMessage.mockImplementation(msg => msg);
 
     // Fix sanitizeApiError mock
-    sanitizeApiError.mockImplementation(err =>
-      typeof err === 'string' ? err : err.message || 'unknown_error'
+    const { sanitizeApiError: actualSanitizeApiError } = jest.requireActual(
+      '../../../../scripts/utils/securityUtils.js'
     );
+    sanitizeApiError.mockImplementation(actualSanitizeApiError);
 
     mockServices = {
       notionService: {
@@ -162,13 +163,11 @@ describe('highlightHandlers', () => {
       const sendResponse = jest.fn();
       const sender = { id: 'test-id', tab: { id: 1, url: 'https://example.com' } };
       const request = { highlights: [{ text: 'test' }] };
-      const { ErrorHandler: ActualErrorHandler } = jest.requireActual(
+
+      const { ErrorHandler: ActualErrorHandlerLocal } = jest.requireActual(
         '../../../../scripts/utils/ErrorHandler.js'
       );
-
-      ErrorHandler.formatUserMessage.mockImplementation(error =>
-        ActualErrorHandler.formatUserMessage(error)
-      );
+      ErrorHandler.formatUserMessage.mockImplementation(ActualErrorHandlerLocal.formatUserMessage);
 
       mockServices.storageService.getConfig.mockResolvedValue({ notionApiKey: 'key1' });
       mockServices.storageService.getSavedPageData.mockResolvedValue({ notionPageId: 'page1' });
@@ -553,7 +552,7 @@ describe('highlightHandlers', () => {
       expect(sendResponse).toHaveBeenCalledWith(
         expect.objectContaining({
           success: false,
-          error: expect.stringContaining('Collection failed'),
+          error: 'Unknown Error',
         })
       );
     });


### PR DESCRIPTION
**What:**
Fixed the hardcoded mock implementations of `sanitizeApiError` and `ErrorHandler` in `tests/unit/background/handlers/highlightHandlers.test.js` to use `jest.requireActual`.

**Coverage:**
- Tests `highlight section retryable failure 應返回可重試的友善訊息` and `should handle collection failure in updateHighlights` were updated to assert against the actual format logic of these utilities, instead of asserting against simplified pass-through mocks.
- Ensured all other assertions depending on these mocks are updated and passing.

**Result:**
Improved test suite accuracy by ensuring that the tests evaluate behavior identical to the production environment, reducing the chance of masking issues caused by overly simplistic mock assumptions.

---
*PR created automatically by Jules for task [7023004083985766611](https://jules.google.com/task/7023004083985766611) started by @cowcfj*