### PR TITLE
feat: Refactor batch delete logic and improve test coverage

### DIFF
--- a/scripts/background/handlers/migrationHandlers.js
+++ b/scripts/background/handlers/migrationHandlers.js
@@ -255,7 +255,7 @@ export function createMigrationHandlers(services) {
         }
 
         const details = urls.map((_, i) => allResultsMap.get(i));
-        const successCount = details.filter(d => d.status === 'success').length;
+        const successCount = details.filter(detail => detail.status === 'success').length;
 
         const results = {
           success: successCount,
@@ -317,7 +317,28 @@ export function createMigrationHandlers(services) {
         Logger.log('開始批量刪除', { action: 'migration_batch_delete', pageCount: urls.length });
 
         // 使用 StorageService.clearLegacyKeys 安全刪除（同時清理 highlights_ + saved_）
-        await Promise.all(urls.map(urlItem => clearLegacyKeysWithStable(storageService, urlItem)));
+        const MAX_CONCURRENCY = 5;
+        const cleanupResults = await pMap(
+          urls,
+          async urlItem => {
+            try {
+              await clearLegacyKeysWithStable(storageService, urlItem);
+              return { status: 'fulfilled' };
+            } catch (error) {
+              return { status: 'rejected', reason: error };
+            }
+          },
+          { concurrency: MAX_CONCURRENCY }
+        );
+
+        const failures = cleanupResults.filter(result => result.status === 'rejected');
+        if (failures.length > 0) {
+          const error = new Error(
+            `Failed to delete ${failures.length} of ${urls.length} migration items`
+          );
+          error.cause = failures[0].reason;
+          throw error;
+        }
 
         Logger.log('批量刪除完成', { action: 'migration_batch_delete', pageCount: urls.length });
         sendResponse({

--- a/scripts/background/handlers/migrationHandlers.js
+++ b/scripts/background/handlers/migrationHandlers.js
@@ -333,9 +333,7 @@ export function createMigrationHandlers(services) {
 
         const failures = cleanupResults.filter(result => result.status === 'rejected');
         if (failures.length > 0) {
-          const error = new Error(
-            `Failed to delete ${failures.length} of ${urls.length} migration items`
-          );
+          const error = new Error(ERROR_MESSAGES.TECHNICAL.MIGRATION_BATCH_DELETE_PARTIAL_FAILURE);
           error.cause = failures[0].reason;
           throw error;
         }

--- a/scripts/config/shared/messages.js
+++ b/scripts/config/shared/messages.js
@@ -468,6 +468,7 @@ const TECHNICAL = {
   INVALID_PAGE_URL: 'Invalid pageUrl: must be a non-empty string',
   LOG_INVALID_URL: '無效的 URL 參數',
   CLEAR_NOTION_STATE_FAILED: '清除本地 Notion 狀態失敗',
+  MIGRATION_BATCH_DELETE_PARTIAL_FAILURE: 'MIGRATION_BATCH_DELETE_PARTIAL_FAILURE',
 };
 
 export const LOG_LEVELS = deepFreeze({
@@ -558,6 +559,7 @@ const PATTERNS = {
   VALIDATION_ERROR: USER_MESSAGES.API_VALIDATION_FAILED,
   IMAGE_VALIDATION_ERROR: '圖片驗證失敗 (Notion API 拒絕)。如有需要，請導出偵錯日誌以查看詳情。',
   HIGHLIGHT_SECTION_DELETE_INCOMPLETE: '標註同步未完成，請稍後再試',
+  MIGRATION_BATCH_DELETE_PARTIAL_FAILURE: '部分標註數據刪除失敗，請稍後再試',
   NOTIONHQ_CLIENT_RESPONSE_ERROR: 'Notion API 請求失敗，請稍後再試',
 
   RATE_LIMITED: '請求過於頻繁，請稍後再試',

--- a/tests/unit/background/handlers/migrationHandlers.test.js
+++ b/tests/unit/background/handlers/migrationHandlers.test.js
@@ -11,6 +11,7 @@
  */
 
 import { createMigrationHandlers } from '../../../../scripts/background/handlers/migrationHandlers.js';
+import { ERROR_MESSAGES } from '../../../../scripts/config/shared/messages.js';
 import { computeStableUrl } from '../../../../scripts/utils/urlUtils.js';
 
 jest.mock('../../../../scripts/utils/urlUtils.js', () => ({
@@ -655,6 +656,26 @@ describe('migrationHandlers', () => {
         expect.objectContaining({
           success: false,
           error: expect.any(String),
+        })
+      );
+    });
+
+    test('單一 URL 清理失敗時應回傳 centralized migration batch delete 錯誤訊息', async () => {
+      const urls = ['https://cleanup.example.com/one', 'https://cleanup.example.com/two'];
+      const sendResponse = jest.fn();
+
+      mockStorageService.clearLegacyKeys.mockImplementation(async url => {
+        if (url === urls[1]) {
+          throw new Error('cleanup failed');
+        }
+      });
+
+      await handlers.migration_batch_delete({ urls }, defaultSender, sendResponse);
+
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: ERROR_MESSAGES.PATTERNS.MIGRATION_BATCH_DELETE_PARTIAL_FAILURE,
         })
       );
     });

--- a/tests/unit/background/handlers/migrationHandlers.test.js
+++ b/tests/unit/background/handlers/migrationHandlers.test.js
@@ -294,7 +294,7 @@ describe('migrationHandlers', () => {
 
       // If validation fails, there won't be results. Check for error.
       if (!response.results) {
-        throw new Error(`No results in response: ${  JSON.stringify(response)}`);
+        throw new Error(`No results in response: ${JSON.stringify(response)}`);
       }
 
       const details = response.results.details;
@@ -628,6 +628,58 @@ describe('migrationHandlers', () => {
 
       expect(sendResponse).toHaveBeenCalledWith(
         expect.objectContaining({ success: true, count: 1 })
+      );
+    });
+
+    test('單一 URL 清理失敗時仍應嘗試其他 URL 並回傳失敗', async () => {
+      const urls = [
+        'https://cleanup.example.com/one',
+        'https://cleanup.example.com/two',
+        'https://cleanup.example.com/three',
+      ];
+      const sendResponse = jest.fn();
+
+      mockStorageService.clearLegacyKeys.mockImplementation(async url => {
+        if (url === urls[1]) {
+          throw new Error('cleanup failed');
+        }
+      });
+
+      await handlers.migration_batch_delete({ urls }, defaultSender, sendResponse);
+
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(urls[0]);
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(urls[1]);
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(urls[2]);
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledTimes(3);
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.any(String),
+        })
+      );
+    });
+
+    test('批量刪除時同時執行的 cleanup 不應超過 5 個', async () => {
+      const urls = Array.from(
+        { length: 6 },
+        (_, index) => `https://cleanup.example.com/page-${index}`
+      );
+      const sendResponse = jest.fn();
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      mockStorageService.clearLegacyKeys.mockImplementation(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        inFlight -= 1;
+      });
+
+      await handlers.migration_batch_delete({ urls }, defaultSender, sendResponse);
+
+      expect(maxInFlight).toBeLessThanOrEqual(5);
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, count: urls.length })
       );
     });
   });


### PR DESCRIPTION
### 摘要
重構批量刪除邏輯，提升效能並增加測試覆蓋率。

### 變更內容
- 使用 pMap 實現批量刪除，限制同時執行的清理請求數量為 5。
- 增加對單一 URL 清理失敗時的處理，確保其他 URL 仍然被嘗試清理。
- 增加測試用例以驗證批量刪除的行為，確保在清理失敗時能正確回傳錯誤信息。

### 測試方式
已增加測試用例以驗證批量刪除的行為。

### 潛在風險
無顯著風險.

