### PR TITLE
chore: Remove help.html from documentation impact matrix

### DIFF
--- a/.agents/.shared/knowledge/doc_impact_matrix.json
+++ b/.agents/.shared/knowledge/doc_impact_matrix.json
@@ -5,14 +5,14 @@
   "lite_plan_policy": "Lite plan tasks may skip document impact checks entirely when they do not affect user-visible behavior, API contracts, storage/message bus, auth/security, or workflow policy.",
   "change_types": {
     "feature": {
-      "must_check": ["docs/specs/*", "USER_GUIDE.md", "help.html", "relevant docs/guides/*"],
+      "must_check": ["docs/specs/*", "USER_GUIDE.md", "relevant docs/guides/*"],
       "notes": "Use when a change introduces new capability, new workflow, visible UI/state, new message action, storage key, or user-facing limitation."
     },
     "bug_fix": {
       "must_check": [
         "relevant docs/specs/*",
         "relevant docs/guides/*",
-        "USER_GUIDE.md or help.html when user-visible behavior or wording changes"
+        "USER_GUIDE.md when user-visible behavior or wording changes"
       ],
       "notes": "Pure internal fixes may skip user-facing docs, but the final report must state why."
     },


### PR DESCRIPTION
### 摘要
移除不再需要的 help.html 參考，以提高清晰度和準確性。

### 變更內容
- 從 "must_check" 列表中移除 "help.html"。
- 確保 "must_check" 列表僅包含相關的文檔。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

