### PR TITLE
fix: allow release-assets job to run on workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,10 @@ jobs:
     permissions:
       contents: write
     needs: release-please
-    # Run if release was just created OR if manually triggered
-    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
+    # Run if release was just created OR if manually triggered.
+    # `always()` is required so this job can run when the upstream `release-please`
+    # job is skipped on workflow_dispatch (its `if:` excludes non-push events).
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### 摘要
修正 release-assets 工作在 workflow_dispatch 事件下無法執行的問題。

### 變更內容
- 更新 release-assets 工作的條件判斷，確保在 upstream 的 release-please 工作被跳過時，仍能執行。
- 調整 release_created 的比較邏輯，確保其為 'true' 時才執行。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

