### PR TITLE
chore: reduce Complex Conditional weight for NextJsExtractor.js

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,17 @@
+{
+  "usage": "Persist this file inside your repository as .codescene/code-health-rules.json. Keep only the rules and thresholds you want to override. See docs/adr/0010-codescene-complex-conditional-weight.md for the rationale behind each entry.",
+  "rule_sets": [
+    {
+      "matching_content_path": "scripts/content/extractors/NextJsExtractor.js",
+      "matching_content_path_doc": "Specify a glob pattern relative to the repository root.",
+      "rules": [
+        {
+          "name": "Complex Conditional",
+          "weight": 0.5
+        }
+      ],
+      "thresholds": [],
+      "thresholds_doc": "The thresholds let you redefine the details of selected code health issues."
+    }
+  ]
+}


### PR DESCRIPTION
### 摘要
調整 `NextJsExtractor.js` 中的 Complex Conditional 規則權重，以降低其對代碼健康評分的影響。

### 變更內容
- 將 `NextJsExtractor.js` 中的 Complex Conditional 規則權重減少至 0.5。
- 更新 `.codescene/code-health-rules.json` 文件以反映新的權重設定。
- 參考文檔更新，包含 ADR 0010 和計劃文檔的鏈接。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

