### PR TITLE
refactor: abstract BBC and StoryAtoms conversion logic into modules

### DIFF
--- a/scripts/content/extractors/NextJsExtractor.js
+++ b/scripts/content/extractors/NextJsExtractor.js
@@ -9,13 +9,11 @@
  */
 
 import Logger from '../../utils/Logger.js';
-import {
-  BBC_DEFAULT_IMAGE_WIDTH,
-  BBC_IMAGE_BASE_URL,
-  NEXTJS_CONFIG,
-} from '../../config/shared/content.js';
+import { NEXTJS_CONFIG } from '../../config/shared/content.js';
 import { isTitleConsistent } from '../../utils/contentUtils.js';
 import { sanitizeUrlForLogging } from '../../utils/LogSanitizer.js';
+import * as BbcBlockConverter from './blocks/BbcBlockConverter.js';
+import * as StoryAtomsConverter from './blocks/StoryAtomsConverter.js';
 
 const PAGES_ROUTER = 'pages-router';
 const APP_ROUTER = 'app-router';
@@ -1332,26 +1330,10 @@ export const NextJsExtractor = {
    * @returns {Array}
    */
   _convertStoryAtoms(atoms) {
-    if (!Array.isArray(atoms)) {
-      return [];
-    }
-
-    const blocks = [];
-
-    for (const atom of atoms) {
-      if (atom.type === 'text') {
-        const block = this._createBlockFromTextAtom(atom);
-        if (block) {
-          blocks.push(block);
-        }
-      } else if (atom.type === 'image') {
-        const block = this._createBlockFromImageAtom(atom);
-        if (block) {
-          blocks.push(block);
-        }
-      }
-    }
-    return blocks;
+    return StoryAtomsConverter.convertStoryAtoms(atoms, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+      stripHtml: this._stripHtml.bind(this),
+    });
   },
 
   /**
@@ -1438,305 +1420,59 @@ export const NextJsExtractor = {
    * @returns {object|null}
    */
   _createBlockFromTextAtom(atom) {
-    if (!atom.content) {
-      return null;
-    }
-
-    const text = this._stripHtml(atom.content).trim();
-    if (!text) {
-      return null;
-    }
-
-    let type = 'paragraph';
-    const tagName = (atom.tagName || 'p').toLowerCase();
-
-    switch (tagName) {
-      case 'h1': {
-        type = 'heading_1';
-        break;
-      }
-      case 'h2': {
-        type = 'heading_2';
-        break;
-      }
-      case 'h3': {
-        type = 'heading_3';
-        break;
-      }
-      case 'blockquote': {
-        type = 'quote';
-        break;
-      }
-    }
-
-    return {
-      object: 'block',
-      type,
-      [type]: {
-        rich_text: this._createRichTextChunks(text),
-      },
-    };
+    return StoryAtomsConverter.createBlockFromTextAtom(atom, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+      stripHtml: this._stripHtml.bind(this),
+    });
   },
 
   _createBlockFromImageAtom(atom) {
-    // Yahoo 格式: atom.size.resized.url 或 atom.size.original.url
-    // 通用格式: atom.url
-    const imageUrl =
-      atom.url || atom.size?.resized?.url || atom.size?.original?.url || atom.size?.lightbox?.url;
-
-    if (!imageUrl) {
-      Logger.debug('NextJsExtractor._createBlockFromImageAtom: 無法找到圖片 URL', {
-        atomKeys: Object.keys(atom),
-        // eslint-disable-next-line unicorn/explicit-length-check
-        hasSize: Boolean(atom.size && Object.keys(atom.size).length > 0),
-      });
-      return null;
-    }
-
-    return {
-      object: 'block',
-      type: 'image',
-      image: {
-        type: 'external',
-        external: {
-          url: imageUrl,
-        },
-        caption: this._createRichTextChunks(atom.caption),
-      },
-    };
+    return StoryAtomsConverter.createBlockFromImageAtom(atom, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 偵測是否為 BBC {type, model} 格式
-   * BBC blocks 使用 `type` + `model`，而非 `blockType` + `text`
-   *
-   * @param {Array} blocks
-   * @returns {boolean}
-   */
   _isBbcFormat(blocks) {
-    return blocks.some(
-      block =>
-        block != null &&
-        typeof block === 'object' &&
-        typeof block.type === 'string' &&
-        block.model != null &&
-        typeof block.model === 'object' &&
-        !block.blockType
-    );
+    return BbcBlockConverter.isBbcFormat(blocks);
   },
 
-  /**
-   * 轉換 BBC {type, model} 巢狀 blocks 為 Notion Blocks
-   *
-   * BBC block 類型映射:
-   * - headline/subheadline → heading_1/heading_2
-   * - text → paragraph(s)
-   * - image → image (使用 BBC CDN URL)
-   * - byline/relatedContent/wsoj → 跳過
-   *
-   * @param {Array} blocks - BBC 頂層 blocks 陣列
-   * @returns {Array} Notion blocks
-   */
   _convertBbcBlocks(blocks) {
-    const result = [];
-    for (const block of blocks) {
-      this._processSingleBbcBlock(block, result);
-    }
-    return result;
+    return BbcBlockConverter.convertBbcBlocks(blocks, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 處理單一 BBC Block，將轉碼結果附加到 result 陣列中
-   *
-   * @param {object} block - 單一 block 物件
-   * @param {Array} result - 收集區塊結果的陣列
-   */
   _processSingleBbcBlock(block, result) {
-    if (!block || typeof block !== 'object') {
-      return;
-    }
-
-    const { type, model } = block;
-
-    if (!type || !model) {
-      return;
-    }
-
-    switch (type) {
-      case 'headline': {
-        const h1Block = this._buildBbcHeadingBlock(model, false);
-        if (h1Block) {
-          result.push(h1Block);
-        }
-        break;
-      }
-
-      case 'subheadline': {
-        const h2Block = this._buildBbcHeadingBlock(model, true);
-        if (h2Block) {
-          result.push(h2Block);
-        }
-        break;
-      }
-
-      case 'text': {
-        result.push(...this._buildBbcTextBlocks(model));
-        break;
-      }
-
-      case 'image': {
-        const imgBlock = this._buildBbcImageBlock(model);
-        if (imgBlock) {
-          result.push(imgBlock);
-        }
-        break;
-      }
-
-      // 跳過頁面雜訊 block 類型
-      case 'byline':
-      case 'relatedContent':
-      case 'wsoj':
-      case 'include':
-      case 'social-embed': {
-        break;
-      }
-
-      default: {
-        // 嘗試通用文字提取（作為安全網）
-        const fallbackBlock = this._buildBbcFallbackBlock(model);
-        if (fallbackBlock) {
-          result.push(fallbackBlock);
-        }
-        break;
-      }
-    }
+    return BbcBlockConverter.processSingleBbcBlock(block, result, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 遞歸提取 BBC model 中的純文字
-   *
-   * BBC 文字結構: model → blocks → paragraph/fragment → model.text
-   * 支援多層 model.blocks 巢狀
-   *
-   * @param {object} model - BBC model 物件
-   * @returns {string} 合併後的純文字
-   */
   _extractBbcText(model) {
-    if (!model || typeof model !== 'object') {
-      return '';
-    }
-
-    // 直接有 text 屬性（fragment 層級）
-    if (typeof model.text === 'string' && model.text.trim()) {
-      return model.text.trim();
-    }
-
-    // 遞歸遍歷子 blocks
-    if (Array.isArray(model.blocks)) {
-      return model.blocks
-        .map(child =>
-          child && typeof child === 'object' ? this._extractBbcText(child.model || child) : ''
-        )
-        .filter(Boolean)
-        .join('');
-    }
-
-    return '';
+    return BbcBlockConverter.extractBbcText(model);
   },
 
-  /**
-   * 建立 BBC Heading (H1 / H2) Block
-   *
-   * @param {object} model
-   * @param {boolean} isSubheading
-   * @returns {object|null}
-   */
   _buildBbcHeadingBlock(model, isSubheading) {
-    const text = this._extractBbcText(model);
-    if (!text) {
-      return null;
-    }
-    const blockType = isSubheading ? 'heading_2' : 'heading_1';
-    return {
-      object: 'block',
-      type: blockType,
-      [blockType]: { rich_text: this._createRichTextChunks(text) },
-    };
+    return BbcBlockConverter.buildBbcHeadingBlock(model, isSubheading, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 建立 BBC Text Blocks (可能有多個 Paragraphs)
-   *
-   * @param {object} model
-   * @returns {Array}
-   */
   _buildBbcTextBlocks(model) {
-    const result = [];
-    const paragraphs = Array.isArray(model.blocks) ? model.blocks : [];
-    for (const para of paragraphs) {
-      if (!para || typeof para !== 'object') {
-        continue;
-      }
-      if (para.type === 'paragraph' || para.type === 'introduction') {
-        const paraText = this._extractBbcText(para.model || {});
-        if (paraText) {
-          result.push({
-            object: 'block',
-            type: 'paragraph',
-            paragraph: { rich_text: this._createRichTextChunks(paraText) },
-          });
-        }
-      }
-    }
-    return result;
+    return BbcBlockConverter.buildBbcTextBlocks(model, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 建立 BBC Image Block
-   *
-   * @param {object} model
-   * @returns {object|null}
-   */
   _buildBbcImageBlock(model) {
-    const subBlocks = Array.isArray(model.blocks) ? model.blocks : [];
-    const rawImage = subBlocks.find(blk => blk.type === 'rawImage');
-    const captionBlock = subBlocks.find(blk => blk.type === 'caption');
-
-    if (rawImage?.model?.locator && rawImage?.model?.originCode) {
-      const { locator, originCode } = rawImage.model;
-      const imageUrl = `${BBC_IMAGE_BASE_URL}/${BBC_DEFAULT_IMAGE_WIDTH}/${originCode}/${locator}.webp`;
-      const captionText = captionBlock ? this._extractBbcText(captionBlock.model || {}) : '';
-
-      return {
-        object: 'block',
-        type: 'image',
-        image: {
-          type: 'external',
-          external: { url: imageUrl },
-          caption: captionText ? this._createRichTextChunks(captionText) : [],
-        },
-      };
-    }
-    return null;
+    return BbcBlockConverter.buildBbcImageBlock(model, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 
-  /**
-   * 建立 BBC 通用 Fallback Text Block
-   *
-   * @param {object} model
-   * @returns {object|null}
-   */
   _buildBbcFallbackBlock(model) {
-    if (model.blocks || model.text) {
-      const fallbackText = this._extractBbcText(model);
-      if (fallbackText) {
-        return {
-          object: 'block',
-          type: 'paragraph',
-          paragraph: { rich_text: this._createRichTextChunks(fallbackText) },
-        };
-      }
-    }
-    return null;
+    return BbcBlockConverter.buildBbcFallbackBlock(model, {
+      richTextChunkBuilder: this._createRichTextChunks.bind(this),
+    });
   },
 };

--- a/scripts/content/extractors/blocks/BbcBlockConverter.js
+++ b/scripts/content/extractors/blocks/BbcBlockConverter.js
@@ -1,0 +1,244 @@
+/**
+ * BbcBlockConverter.js
+ * 專門負責 BBC blocks 格式轉換為 Notion 區塊的 pure functions 模組
+ */
+
+import { BBC_DEFAULT_IMAGE_WIDTH, BBC_IMAGE_BASE_URL } from '../../../config/shared/content.js';
+
+/**
+ * 偵測是否為 BBC {type, model} 格式
+ * BBC blocks 使用 `type` + `model`，而非 `blockType` + `text`
+ *
+ * @param {Array} blocks
+ * @returns {boolean}
+ */
+export function isBbcFormat(blocks) {
+  if (!Array.isArray(blocks)) {
+    return false;
+  }
+  return blocks.some(
+    block =>
+      block != null &&
+      typeof block === 'object' &&
+      typeof block.type === 'string' &&
+      block.model != null &&
+      typeof block.model === 'object' &&
+      !block.blockType
+  );
+}
+
+/**
+ * 轉換 BBC {type, model} 巢狀 blocks 為 Notion Blocks
+ *
+ * @param {Array} blocks - BBC 頂層 blocks 陣列
+ * @param {object} deps - 外部依賴
+ * @param {Function} deps.richTextChunkBuilder - 建立富文本 chunks 的函式
+ * @returns {Array} Notion blocks
+ */
+export function convertBbcBlocks(blocks, deps) {
+  if (!Array.isArray(blocks)) {
+    return [];
+  }
+  const result = [];
+  for (const block of blocks) {
+    processSingleBbcBlock(block, result, deps);
+  }
+  return result;
+}
+
+/**
+ * 處理單一 BBC Block，將轉碼結果附加到 result 陣列中
+ *
+ * @param {object} block - 單一 block 物件
+ * @param {Array} result - 收集區塊結果的陣列
+ * @param {object} deps - 外部依賴
+ */
+export function processSingleBbcBlock(block, result, deps) {
+  if (!block || typeof block !== 'object') {
+    return;
+  }
+
+  const { type, model } = block;
+
+  if (!type || !model) {
+    return;
+  }
+
+  switch (type) {
+    case 'headline': {
+      const h1Block = buildBbcHeadingBlock(model, false, deps);
+      if (h1Block) {
+        result.push(h1Block);
+      }
+      break;
+    }
+
+    case 'subheadline': {
+      const h2Block = buildBbcHeadingBlock(model, true, deps);
+      if (h2Block) {
+        result.push(h2Block);
+      }
+      break;
+    }
+
+    case 'text': {
+      result.push(...buildBbcTextBlocks(model, deps));
+      break;
+    }
+
+    case 'image': {
+      const imgBlock = buildBbcImageBlock(model, deps);
+      if (imgBlock) {
+        result.push(imgBlock);
+      }
+      break;
+    }
+
+    // 跳過頁面雜訊 block 類型
+    case 'byline':
+    case 'relatedContent':
+    case 'wsoj':
+    case 'include':
+    case 'social-embed': {
+      break;
+    }
+
+    default: {
+      // 嘗試通用文字提取（作為安全網）
+      const fallbackBlock = buildBbcFallbackBlock(model, deps);
+      if (fallbackBlock) {
+        result.push(fallbackBlock);
+      }
+      break;
+    }
+  }
+}
+
+/**
+ * 遞歸提取 BBC model 中的純文字
+ *
+ * @param {object} model - BBC model 物件
+ * @returns {string} 合併後的純文字
+ */
+export function extractBbcText(model) {
+  if (!model || typeof model !== 'object') {
+    return '';
+  }
+
+  // 直接有 text 屬性（fragment 層級）
+  if (typeof model.text === 'string' && model.text.trim()) {
+    return model.text.trim();
+  }
+
+  // 遞歸遍歷子 blocks
+  if (Array.isArray(model.blocks)) {
+    return model.blocks
+      .map(child =>
+        child && typeof child === 'object' ? extractBbcText(child.model || child) : ''
+      )
+      .filter(Boolean)
+      .join('');
+  }
+
+  return '';
+}
+
+/**
+ * 建立 BBC Heading (H1 / H2) Block
+ *
+ * @param {object} model
+ * @param {boolean} isSubheading
+ * @param {object} deps
+ * @returns {object|null}
+ */
+export function buildBbcHeadingBlock(model, isSubheading, deps) {
+  const text = extractBbcText(model);
+  if (!text) {
+    return null;
+  }
+  const blockType = isSubheading ? 'heading_2' : 'heading_1';
+  return {
+    object: 'block',
+    type: blockType,
+    [blockType]: { rich_text: deps.richTextChunkBuilder(text) },
+  };
+}
+
+/**
+ * 建立 BBC Text Blocks (可能有多個 Paragraphs)
+ *
+ * @param {object} model
+ * @param {object} deps
+ * @returns {Array}
+ */
+export function buildBbcTextBlocks(model, deps) {
+  const result = [];
+  const paragraphs = Array.isArray(model.blocks) ? model.blocks : [];
+  for (const para of paragraphs) {
+    if (!para || typeof para !== 'object') {
+      continue;
+    }
+    if (para.type === 'paragraph' || para.type === 'introduction') {
+      const paraText = extractBbcText(para.model || {});
+      if (paraText) {
+        result.push({
+          object: 'block',
+          type: 'paragraph',
+          paragraph: { rich_text: deps.richTextChunkBuilder(paraText) },
+        });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * 建立 BBC Image Block
+ *
+ * @param {object} model
+ * @param {object} deps
+ * @returns {object|null}
+ */
+export function buildBbcImageBlock(model, deps) {
+  const subBlocks = Array.isArray(model.blocks) ? model.blocks : [];
+  const rawImage = subBlocks.find(blk => blk.type === 'rawImage');
+  const captionBlock = subBlocks.find(blk => blk.type === 'caption');
+
+  if (rawImage?.model?.locator && rawImage?.model?.originCode) {
+    const { locator, originCode } = rawImage.model;
+    const imageUrl = `${BBC_IMAGE_BASE_URL}/${BBC_DEFAULT_IMAGE_WIDTH}/${originCode}/${locator}.webp`;
+    const captionText = captionBlock ? extractBbcText(captionBlock.model || {}) : '';
+
+    return {
+      object: 'block',
+      type: 'image',
+      image: {
+        type: 'external',
+        external: { url: imageUrl },
+        caption: captionText ? deps.richTextChunkBuilder(captionText) : [],
+      },
+    };
+  }
+  return null;
+}
+
+/**
+ * 建立 BBC 通用 Fallback Text Block
+ *
+ * @param {object} model
+ * @param {object} deps
+ * @returns {object|null}
+ */
+export function buildBbcFallbackBlock(model, deps) {
+  if (model.blocks || model.text) {
+    const fallbackText = extractBbcText(model);
+    if (fallbackText) {
+      return {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { rich_text: deps.richTextChunkBuilder(fallbackText) },
+      };
+    }
+  }
+  return null;
+}

--- a/scripts/content/extractors/blocks/BbcBlockConverter.js
+++ b/scripts/content/extractors/blocks/BbcBlockConverter.js
@@ -5,6 +5,29 @@
 
 import { BBC_DEFAULT_IMAGE_WIDTH, BBC_IMAGE_BASE_URL } from '../../../config/shared/content.js';
 
+const SKIPPED_BBC_BLOCK_TYPES = new Set([
+  'byline',
+  'relatedContent',
+  'wsoj',
+  'include',
+  'social-embed',
+]);
+
+function wrapSingleBlock(block) {
+  return block ? [block] : [];
+}
+
+const BBC_BLOCK_HANDLERS = {
+  headline: (model, deps) => wrapSingleBlock(buildBbcHeadingBlock(model, false, deps)),
+  subheadline: (model, deps) => wrapSingleBlock(buildBbcHeadingBlock(model, true, deps)),
+  text: (model, deps) => buildBbcTextBlocks(model, deps),
+  image: (model, deps) => wrapSingleBlock(buildBbcImageBlock(model, deps)),
+};
+
+function defaultBbcHandler(model, deps) {
+  return wrapSingleBlock(buildBbcFallbackBlock(model, deps));
+}
+
 /**
  * 偵測是否為 BBC {type, model} 格式
  * BBC blocks 使用 `type` + `model`，而非 `blockType` + `text`
@@ -59,59 +82,16 @@ export function processSingleBbcBlock(block, result, deps) {
   }
 
   const { type, model } = block;
-
   if (!type || !model) {
     return;
   }
 
-  switch (type) {
-    case 'headline': {
-      const h1Block = buildBbcHeadingBlock(model, false, deps);
-      if (h1Block) {
-        result.push(h1Block);
-      }
-      break;
-    }
-
-    case 'subheadline': {
-      const h2Block = buildBbcHeadingBlock(model, true, deps);
-      if (h2Block) {
-        result.push(h2Block);
-      }
-      break;
-    }
-
-    case 'text': {
-      result.push(...buildBbcTextBlocks(model, deps));
-      break;
-    }
-
-    case 'image': {
-      const imgBlock = buildBbcImageBlock(model, deps);
-      if (imgBlock) {
-        result.push(imgBlock);
-      }
-      break;
-    }
-
-    // 跳過頁面雜訊 block 類型
-    case 'byline':
-    case 'relatedContent':
-    case 'wsoj':
-    case 'include':
-    case 'social-embed': {
-      break;
-    }
-
-    default: {
-      // 嘗試通用文字提取（作為安全網）
-      const fallbackBlock = buildBbcFallbackBlock(model, deps);
-      if (fallbackBlock) {
-        result.push(fallbackBlock);
-      }
-      break;
-    }
+  if (SKIPPED_BBC_BLOCK_TYPES.has(type)) {
+    return;
   }
+
+  const handler = BBC_BLOCK_HANDLERS[type] || defaultBbcHandler;
+  result.push(...handler(model, deps));
 }
 
 /**
@@ -125,22 +105,30 @@ export function extractBbcText(model) {
     return '';
   }
 
-  // 直接有 text 屬性（fragment 層級）
-  if (typeof model.text === 'string' && model.text.trim()) {
-    return model.text.trim();
+  const direct = getDirectBbcText(model);
+  if (direct) {
+    return direct;
   }
 
-  // 遞歸遍歷子 blocks
   if (Array.isArray(model.blocks)) {
-    return model.blocks
-      .map(child =>
-        child && typeof child === 'object' ? extractBbcText(child.model || child) : ''
-      )
-      .filter(Boolean)
-      .join('');
+    return joinBbcChildText(model.blocks);
   }
 
   return '';
+}
+
+function getDirectBbcText(model) {
+  if (typeof model.text !== 'string') {
+    return '';
+  }
+  return model.text.trim();
+}
+
+function joinBbcChildText(blocks) {
+  return blocks
+    .map(child => (child && typeof child === 'object' ? extractBbcText(child.model || child) : ''))
+    .filter(Boolean)
+    .join('');
 }
 
 /**
@@ -172,24 +160,32 @@ export function buildBbcHeadingBlock(model, isSubheading, deps) {
  * @returns {Array}
  */
 export function buildBbcTextBlocks(model, deps) {
-  const result = [];
   const paragraphs = Array.isArray(model.blocks) ? model.blocks : [];
-  for (const para of paragraphs) {
-    if (!para || typeof para !== 'object') {
-      continue;
-    }
-    if (para.type === 'paragraph' || para.type === 'introduction') {
-      const paraText = extractBbcText(para.model || {});
-      if (paraText) {
-        result.push({
-          object: 'block',
-          type: 'paragraph',
-          paragraph: { rich_text: deps.richTextChunkBuilder(paraText) },
-        });
-      }
-    }
+  return paragraphs.map(para => buildBbcParagraphBlock(para, deps)).filter(Boolean);
+}
+
+const BBC_PARAGRAPH_TYPES = new Set(['paragraph', 'introduction']);
+
+function buildBbcParagraphBlock(para, deps) {
+  if (!isBbcParagraphLike(para)) {
+    return null;
   }
-  return result;
+  const paraText = extractBbcText(para.model || {});
+  if (!paraText) {
+    return null;
+  }
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: { rich_text: deps.richTextChunkBuilder(paraText) },
+  };
+}
+
+function isBbcParagraphLike(para) {
+  if (!para || typeof para !== 'object') {
+    return false;
+  }
+  return BBC_PARAGRAPH_TYPES.has(para.type);
 }
 
 /**
@@ -201,25 +197,35 @@ export function buildBbcTextBlocks(model, deps) {
  */
 export function buildBbcImageBlock(model, deps) {
   const subBlocks = Array.isArray(model.blocks) ? model.blocks : [];
-  const rawImage = subBlocks.find(blk => blk.type === 'rawImage');
-  const captionBlock = subBlocks.find(blk => blk.type === 'caption');
-
-  if (rawImage?.model?.locator && rawImage?.model?.originCode) {
-    const { locator, originCode } = rawImage.model;
-    const imageUrl = `${BBC_IMAGE_BASE_URL}/${BBC_DEFAULT_IMAGE_WIDTH}/${originCode}/${locator}.webp`;
-    const captionText = captionBlock ? extractBbcText(captionBlock.model || {}) : '';
-
-    return {
-      object: 'block',
-      type: 'image',
-      image: {
-        type: 'external',
-        external: { url: imageUrl },
-        caption: captionText ? deps.richTextChunkBuilder(captionText) : [],
-      },
-    };
+  const imageUrl = extractBbcImageUrl(subBlocks);
+  if (!imageUrl) {
+    return null;
   }
-  return null;
+  const captionText = extractBbcImageCaption(subBlocks);
+  return {
+    object: 'block',
+    type: 'image',
+    image: {
+      type: 'external',
+      external: { url: imageUrl },
+      caption: captionText ? deps.richTextChunkBuilder(captionText) : [],
+    },
+  };
+}
+
+function extractBbcImageUrl(subBlocks) {
+  const rawImage = subBlocks.find(blk => blk.type === 'rawImage');
+  const locator = rawImage?.model?.locator;
+  const originCode = rawImage?.model?.originCode;
+  if (!locator || !originCode) {
+    return null;
+  }
+  return `${BBC_IMAGE_BASE_URL}/${BBC_DEFAULT_IMAGE_WIDTH}/${originCode}/${locator}.webp`;
+}
+
+function extractBbcImageCaption(subBlocks) {
+  const captionBlock = subBlocks.find(blk => blk.type === 'caption');
+  return captionBlock ? extractBbcText(captionBlock.model || {}) : '';
 }
 
 /**

--- a/scripts/content/extractors/blocks/StoryAtomsConverter.js
+++ b/scripts/content/extractors/blocks/StoryAtomsConverter.js
@@ -5,6 +5,11 @@
 
 import Logger from '../../../utils/Logger.js';
 
+const STORY_ATOM_BUILDERS = {
+  text: (atom, deps) => createBlockFromTextAtom(atom, deps),
+  image: (atom, deps) => createBlockFromImageAtom(atom, deps),
+};
+
 /**
  * 轉換 Yahoo storyAtoms 為 Notion Blocks
  *
@@ -18,23 +23,15 @@ export function convertStoryAtoms(atoms, deps) {
   if (!Array.isArray(atoms)) {
     return [];
   }
+  return atoms.map(atom => buildStoryAtomBlock(atom, deps)).filter(Boolean);
+}
 
-  const blocks = [];
-
-  for (const atom of atoms) {
-    if (atom.type === 'text') {
-      const block = createBlockFromTextAtom(atom, deps);
-      if (block) {
-        blocks.push(block);
-      }
-    } else if (atom.type === 'image') {
-      const block = createBlockFromImageAtom(atom, deps);
-      if (block) {
-        blocks.push(block);
-      }
-    }
+function buildStoryAtomBlock(atom, deps) {
+  if (!atom || typeof atom !== 'object') {
+    return null;
   }
-  return blocks;
+  const builder = STORY_ATOM_BUILDERS[atom.type];
+  return builder ? builder(atom, deps) : null;
 }
 
 /**
@@ -93,17 +90,9 @@ export function createBlockFromTextAtom(atom, deps) {
  * @returns {object|null}
  */
 export function createBlockFromImageAtom(atom, deps) {
-  // Yahoo 格式: atom.size.resized.url 或 atom.size.original.url
-  // 通用格式: atom.url
-  const imageUrl =
-    atom.url || atom.size?.resized?.url || atom.size?.original?.url || atom.size?.lightbox?.url;
-
+  const imageUrl = extractImageAtomUrl(atom);
   if (!imageUrl) {
-    Logger.debug('StoryAtomsConverter.createBlockFromImageAtom: 無法找到圖片 URL', {
-      atomKeys: Object.keys(atom),
-      // eslint-disable-next-line unicorn/explicit-length-check
-      hasSize: Boolean(atom.size && Object.keys(atom.size).length > 0),
-    });
+    logMissingImageUrl(atom);
     return null;
   }
 
@@ -118,4 +107,34 @@ export function createBlockFromImageAtom(atom, deps) {
       caption: deps.richTextChunkBuilder(atom.caption),
     },
   };
+}
+
+const IMAGE_SIZE_KEYS = ['resized', 'original', 'lightbox'];
+
+function extractImageAtomUrl(atom) {
+  // 通用格式: atom.url
+  if (atom.url) {
+    return atom.url;
+  }
+  // Yahoo 格式: atom.size.<resized|original|lightbox>.url
+  // atom.size 是物件而非 length-like 數值；停用 unicorn/explicit-length-check 的誤判
+  // eslint-disable-next-line unicorn/explicit-length-check
+  if (!atom.size || typeof atom.size !== 'object') {
+    return null;
+  }
+  for (const key of IMAGE_SIZE_KEYS) {
+    const url = atom.size[key]?.url;
+    if (url) {
+      return url;
+    }
+  }
+  return null;
+}
+
+function logMissingImageUrl(atom) {
+  Logger.debug('StoryAtomsConverter.createBlockFromImageAtom: 無法找到圖片 URL', {
+    atomKeys: Object.keys(atom),
+    // eslint-disable-next-line unicorn/explicit-length-check
+    hasSize: Boolean(atom.size && Object.keys(atom.size).length > 0),
+  });
 }

--- a/scripts/content/extractors/blocks/StoryAtomsConverter.js
+++ b/scripts/content/extractors/blocks/StoryAtomsConverter.js
@@ -133,6 +133,8 @@ function extractImageAtomUrl(atom) {
 
 function logMissingImageUrl(atom) {
   Logger.debug('StoryAtomsConverter.createBlockFromImageAtom: 無法找到圖片 URL', {
+    action: 'StoryAtomsConverter.createBlockFromImageAtom',
+    result: 'missing_image_url',
     atomKeys: Object.keys(atom),
     // eslint-disable-next-line unicorn/explicit-length-check
     hasSize: Boolean(atom.size && Object.keys(atom.size).length > 0),

--- a/scripts/content/extractors/blocks/StoryAtomsConverter.js
+++ b/scripts/content/extractors/blocks/StoryAtomsConverter.js
@@ -1,0 +1,121 @@
+/**
+ * StoryAtomsConverter.js
+ * 專門負責 Yahoo storyAtoms 格式轉換為 Notion 區塊的 pure functions 模組
+ */
+
+import Logger from '../../../utils/Logger.js';
+
+/**
+ * 轉換 Yahoo storyAtoms 為 Notion Blocks
+ *
+ * @param {Array} atoms
+ * @param {object} deps
+ * @param {Function} deps.richTextChunkBuilder
+ * @param {Function} deps.stripHtml
+ * @returns {Array}
+ */
+export function convertStoryAtoms(atoms, deps) {
+  if (!Array.isArray(atoms)) {
+    return [];
+  }
+
+  const blocks = [];
+
+  for (const atom of atoms) {
+    if (atom.type === 'text') {
+      const block = createBlockFromTextAtom(atom, deps);
+      if (block) {
+        blocks.push(block);
+      }
+    } else if (atom.type === 'image') {
+      const block = createBlockFromImageAtom(atom, deps);
+      if (block) {
+        blocks.push(block);
+      }
+    }
+  }
+  return blocks;
+}
+
+/**
+ * 根據文本 Atom 創建 Block
+ *
+ * @param {object} atom
+ * @param {object} deps
+ * @returns {object|null}
+ */
+export function createBlockFromTextAtom(atom, deps) {
+  if (!atom.content) {
+    return null;
+  }
+
+  const text = deps.stripHtml(atom.content).trim();
+  if (!text) {
+    return null;
+  }
+
+  let type = 'paragraph';
+  const tagName = (atom.tagName || 'p').toLowerCase();
+
+  switch (tagName) {
+    case 'h1': {
+      type = 'heading_1';
+      break;
+    }
+    case 'h2': {
+      type = 'heading_2';
+      break;
+    }
+    case 'h3': {
+      type = 'heading_3';
+      break;
+    }
+    case 'blockquote': {
+      type = 'quote';
+      break;
+    }
+  }
+
+  return {
+    object: 'block',
+    type,
+    [type]: {
+      rich_text: deps.richTextChunkBuilder(text),
+    },
+  };
+}
+
+/**
+ * 根據圖片 Atom 創建 Block
+ *
+ * @param {object} atom
+ * @param {object} deps
+ * @returns {object|null}
+ */
+export function createBlockFromImageAtom(atom, deps) {
+  // Yahoo 格式: atom.size.resized.url 或 atom.size.original.url
+  // 通用格式: atom.url
+  const imageUrl =
+    atom.url || atom.size?.resized?.url || atom.size?.original?.url || atom.size?.lightbox?.url;
+
+  if (!imageUrl) {
+    Logger.debug('StoryAtomsConverter.createBlockFromImageAtom: 無法找到圖片 URL', {
+      atomKeys: Object.keys(atom),
+      // eslint-disable-next-line unicorn/explicit-length-check
+      hasSize: Boolean(atom.size && Object.keys(atom.size).length > 0),
+    });
+    return null;
+  }
+
+  return {
+    object: 'block',
+    type: 'image',
+    image: {
+      type: 'external',
+      external: {
+        url: imageUrl,
+      },
+      caption: deps.richTextChunkBuilder(atom.caption),
+    },
+  };
+}

--- a/tests/unit/content/extractors/blocks/BbcBlockConverter.test.js
+++ b/tests/unit/content/extractors/blocks/BbcBlockConverter.test.js
@@ -1,0 +1,295 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  buildBbcFallbackBlock,
+  buildBbcHeadingBlock,
+  buildBbcImageBlock,
+  buildBbcTextBlocks,
+  convertBbcBlocks,
+  extractBbcText,
+  isBbcFormat,
+  processSingleBbcBlock,
+} from '../../../../../scripts/content/extractors/blocks/BbcBlockConverter.js';
+import {
+  BBC_DEFAULT_IMAGE_WIDTH,
+  BBC_IMAGE_BASE_URL,
+} from '../../../../../scripts/config/shared/content.js';
+
+function makeDeps() {
+  return {
+    richTextChunkBuilder: jest.fn(text => [{ type: 'text', text: { content: text } }]),
+  };
+}
+
+describe('BbcBlockConverter', () => {
+  describe('isBbcFormat', () => {
+    test('returns true for blocks with type+model and no blockType', () => {
+      expect(
+        isBbcFormat([
+          { type: 'headline', model: { text: 'hi' } },
+          { type: 'text', model: { blocks: [] } },
+        ])
+      ).toBe(true);
+    });
+
+    test('returns false when any block has blockType (non-BBC schema)', () => {
+      expect(isBbcFormat([{ type: 'headline', model: {}, blockType: 'something' }])).toBe(false);
+    });
+
+    test('returns false for empty / non-array / malformed inputs', () => {
+      expect(isBbcFormat([])).toBe(false);
+      expect(isBbcFormat(null)).toBe(false);
+      expect(isBbcFormat([null, 'string', { type: 'x' }])).toBe(false);
+    });
+  });
+
+  describe('extractBbcText', () => {
+    test('returns trimmed direct text', () => {
+      expect(extractBbcText({ text: '  Hello  ' })).toBe('Hello');
+    });
+
+    test('falls back to concatenating child block text without separators', () => {
+      const model = {
+        blocks: [
+          { type: 'fragment', model: { text: 'Hello' } },
+          { type: 'fragment', model: { text: 'World' } },
+        ],
+      };
+      expect(extractBbcText(model)).toBe('HelloWorld');
+    });
+
+    test('returns empty string for invalid model', () => {
+      expect(extractBbcText(null)).toBe('');
+      expect(extractBbcText('string')).toBe('');
+      expect(extractBbcText({})).toBe('');
+    });
+
+    test('skips falsy or non-object children', () => {
+      const model = {
+        blocks: [null, 'noop', { type: 'fragment', model: { text: 'A' } }],
+      };
+      expect(extractBbcText(model)).toBe('A');
+    });
+  });
+
+  describe('buildBbcHeadingBlock', () => {
+    test('returns heading_1 when isSubheading=false', () => {
+      const deps = makeDeps();
+      const block = buildBbcHeadingBlock({ text: 'Title' }, false, deps);
+      expect(block).toEqual({
+        object: 'block',
+        type: 'heading_1',
+        heading_1: { rich_text: [{ type: 'text', text: { content: 'Title' } }] },
+      });
+    });
+
+    test('returns heading_2 when isSubheading=true', () => {
+      const deps = makeDeps();
+      expect(buildBbcHeadingBlock({ text: 'Sub' }, true, deps).type).toBe('heading_2');
+    });
+
+    test('returns null when text is empty', () => {
+      const deps = makeDeps();
+      expect(buildBbcHeadingBlock({ text: '   ' }, false, deps)).toBeNull();
+      expect(deps.richTextChunkBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildBbcTextBlocks', () => {
+    test('emits a paragraph block for each paragraph / introduction child', () => {
+      const deps = makeDeps();
+      const blocks = buildBbcTextBlocks(
+        {
+          blocks: [
+            { type: 'paragraph', model: { text: 'P1' } },
+            { type: 'introduction', model: { text: 'P2' } },
+          ],
+        },
+        deps
+      );
+      expect(blocks.map(b => b.type)).toEqual(['paragraph', 'paragraph']);
+      expect(blocks[0].paragraph.rich_text[0].text.content).toBe('P1');
+    });
+
+    test('skips children whose type is not paragraph / introduction', () => {
+      const deps = makeDeps();
+      const blocks = buildBbcTextBlocks(
+        { blocks: [{ type: 'list', model: { text: 'ignored' } }] },
+        deps
+      );
+      expect(blocks).toEqual([]);
+    });
+
+    test('skips paragraphs whose extracted text is empty', () => {
+      const deps = makeDeps();
+      const blocks = buildBbcTextBlocks(
+        { blocks: [{ type: 'paragraph', model: { text: '   ' } }] },
+        deps
+      );
+      expect(blocks).toEqual([]);
+    });
+
+    test('returns [] when model.blocks is missing or non-array', () => {
+      const deps = makeDeps();
+      expect(buildBbcTextBlocks({}, deps)).toEqual([]);
+      expect(buildBbcTextBlocks({ blocks: null }, deps)).toEqual([]);
+    });
+  });
+
+  describe('buildBbcImageBlock', () => {
+    test('builds external image block with caption when locator + originCode + caption exist', () => {
+      const deps = makeDeps();
+      const block = buildBbcImageBlock(
+        {
+          blocks: [
+            { type: 'rawImage', model: { locator: 'p0abc', originCode: 'cpsprodpb' } },
+            { type: 'caption', model: { text: 'A caption' } },
+          ],
+        },
+        deps
+      );
+      expect(block).toEqual({
+        object: 'block',
+        type: 'image',
+        image: {
+          type: 'external',
+          external: {
+            url: `${BBC_IMAGE_BASE_URL}/${BBC_DEFAULT_IMAGE_WIDTH}/cpsprodpb/p0abc.webp`,
+          },
+          caption: [{ type: 'text', text: { content: 'A caption' } }],
+        },
+      });
+    });
+
+    test('returns image block with empty caption when caption block is absent', () => {
+      const deps = makeDeps();
+      const block = buildBbcImageBlock(
+        {
+          blocks: [{ type: 'rawImage', model: { locator: 'p0abc', originCode: 'cpsprodpb' } }],
+        },
+        deps
+      );
+      expect(block.image.caption).toEqual([]);
+    });
+
+    test('returns null when rawImage is missing locator or originCode', () => {
+      const deps = makeDeps();
+      expect(
+        buildBbcImageBlock({ blocks: [{ type: 'rawImage', model: { locator: 'x' } }] }, deps)
+      ).toBeNull();
+      expect(
+        buildBbcImageBlock({ blocks: [{ type: 'rawImage', model: { originCode: 'x' } }] }, deps)
+      ).toBeNull();
+    });
+
+    test('returns null when no rawImage sub-block exists', () => {
+      const deps = makeDeps();
+      expect(buildBbcImageBlock({ blocks: [{ type: 'caption', model: {} }] }, deps)).toBeNull();
+      expect(buildBbcImageBlock({}, deps)).toBeNull();
+    });
+  });
+
+  describe('buildBbcFallbackBlock', () => {
+    test('returns paragraph for model.text', () => {
+      const deps = makeDeps();
+      const block = buildBbcFallbackBlock({ text: 'Stranded' }, deps);
+      expect(block).toEqual({
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { rich_text: [{ type: 'text', text: { content: 'Stranded' } }] },
+      });
+    });
+
+    test('returns paragraph by recursing into model.blocks', () => {
+      const deps = makeDeps();
+      const block = buildBbcFallbackBlock(
+        { blocks: [{ type: 'fragment', model: { text: 'X' } }] },
+        deps
+      );
+      expect(block.paragraph.rich_text[0].text.content).toBe('X');
+    });
+
+    test('returns null when neither blocks nor text present', () => {
+      const deps = makeDeps();
+      expect(buildBbcFallbackBlock({}, deps)).toBeNull();
+    });
+
+    test('returns null when extracted text is empty', () => {
+      const deps = makeDeps();
+      expect(buildBbcFallbackBlock({ text: '   ' }, deps)).toBeNull();
+    });
+  });
+
+  describe('processSingleBbcBlock', () => {
+    test('routes known block types via handler map', () => {
+      const deps = makeDeps();
+      const result = [];
+      processSingleBbcBlock({ type: 'headline', model: { text: 'Hi' } }, result, deps);
+      expect(result).toEqual([
+        {
+          object: 'block',
+          type: 'heading_1',
+          heading_1: { rich_text: [{ type: 'text', text: { content: 'Hi' } }] },
+        },
+      ]);
+    });
+
+    test('uses fallback handler for unknown types', () => {
+      const deps = makeDeps();
+      const result = [];
+      processSingleBbcBlock({ type: 'mystery', model: { text: 'Body' } }, result, deps);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('paragraph');
+    });
+
+    test.each([['byline'], ['relatedContent'], ['wsoj'], ['include'], ['social-embed']])(
+      'skips %s blocks',
+      type => {
+        const deps = makeDeps();
+        const result = [];
+        processSingleBbcBlock({ type, model: { text: 'irrelevant' } }, result, deps);
+        expect(result).toEqual([]);
+      }
+    );
+
+    test('does nothing when block is malformed', () => {
+      const deps = makeDeps();
+      const result = [];
+      processSingleBbcBlock(null, result, deps);
+      processSingleBbcBlock({}, result, deps);
+      processSingleBbcBlock({ type: 'headline' }, result, deps);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('convertBbcBlocks', () => {
+    test('returns [] for non-array input', () => {
+      expect(convertBbcBlocks(null, makeDeps())).toEqual([]);
+    });
+
+    test('flattens output from each block in order', () => {
+      const deps = makeDeps();
+      const result = convertBbcBlocks(
+        [
+          { type: 'headline', model: { text: 'H' } },
+          { type: 'subheadline', model: { text: 'S' } },
+          {
+            type: 'text',
+            model: {
+              blocks: [
+                { type: 'paragraph', model: { text: 'A' } },
+                { type: 'paragraph', model: { text: 'B' } },
+              ],
+            },
+          },
+          { type: 'byline', model: { text: 'skip' } },
+        ],
+        deps
+      );
+
+      expect(result.map(b => b.type)).toEqual(['heading_1', 'heading_2', 'paragraph', 'paragraph']);
+    });
+  });
+});

--- a/tests/unit/content/extractors/blocks/StoryAtomsConverter.test.js
+++ b/tests/unit/content/extractors/blocks/StoryAtomsConverter.test.js
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Logger from '../../../../../scripts/utils/Logger.js';
+import {
+  convertStoryAtoms,
+  createBlockFromImageAtom,
+  createBlockFromTextAtom,
+} from '../../../../../scripts/content/extractors/blocks/StoryAtomsConverter.js';
+
+jest.mock('../../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
+
+function makeDeps() {
+  return {
+    richTextChunkBuilder: jest.fn(text => [{ type: 'text', text: { content: text } }]),
+    stripHtml: jest.fn(html => html.replaceAll(/<[^<>]*>/g, '')),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('StoryAtomsConverter', () => {
+  describe('createBlockFromTextAtom', () => {
+    test.each([
+      ['p', 'paragraph'],
+      ['h1', 'heading_1'],
+      ['h2', 'heading_2'],
+      ['h3', 'heading_3'],
+      ['blockquote', 'quote'],
+    ])('maps tagName=%s to block type=%s', (tagName, expectedType) => {
+      const deps = makeDeps();
+      const block = createBlockFromTextAtom({ content: '<p>Hello</p>', tagName }, deps);
+
+      expect(block).toEqual({
+        object: 'block',
+        type: expectedType,
+        [expectedType]: { rich_text: [{ type: 'text', text: { content: 'Hello' } }] },
+      });
+      expect(deps.stripHtml).toHaveBeenCalledWith('<p>Hello</p>');
+      expect(deps.richTextChunkBuilder).toHaveBeenCalledWith('Hello');
+    });
+
+    test('falls back to paragraph when tagName is missing', () => {
+      const deps = makeDeps();
+      const block = createBlockFromTextAtom({ content: 'plain' }, deps);
+
+      expect(block.type).toBe('paragraph');
+    });
+
+    test('returns null when content is falsy', () => {
+      const deps = makeDeps();
+      expect(createBlockFromTextAtom({ content: '' }, deps)).toBeNull();
+      expect(createBlockFromTextAtom({}, deps)).toBeNull();
+    });
+
+    test('returns null when stripped text is empty', () => {
+      const deps = makeDeps();
+      const block = createBlockFromTextAtom({ content: '   <span></span>  ', tagName: 'p' }, deps);
+      expect(block).toBeNull();
+      expect(deps.richTextChunkBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createBlockFromImageAtom', () => {
+    test('uses atom.url when present', () => {
+      const deps = makeDeps();
+      const block = createBlockFromImageAtom(
+        { url: 'https://cdn.example.com/a.jpg', caption: 'cap' },
+        deps
+      );
+
+      expect(block).toEqual({
+        object: 'block',
+        type: 'image',
+        image: {
+          type: 'external',
+          external: { url: 'https://cdn.example.com/a.jpg' },
+          caption: [{ type: 'text', text: { content: 'cap' } }],
+        },
+      });
+    });
+
+    test.each([['resized'], ['original'], ['lightbox']])(
+      'falls back to atom.size.%s.url',
+      sizeKey => {
+        const deps = makeDeps();
+        const block = createBlockFromImageAtom(
+          { size: { [sizeKey]: { url: `https://cdn.example.com/${sizeKey}.jpg` } } },
+          deps
+        );
+        expect(block.image.external.url).toBe(`https://cdn.example.com/${sizeKey}.jpg`);
+      }
+    );
+
+    test('returns null and logs structured debug when no image URL is found', () => {
+      const deps = makeDeps();
+      const atom = { tagName: 'figure', size: {} };
+
+      const block = createBlockFromImageAtom(atom, deps);
+
+      expect(block).toBeNull();
+      expect(Logger.debug).toHaveBeenCalledTimes(1);
+      const [, ctx] = Logger.debug.mock.calls[0];
+      expect(ctx).toEqual(
+        expect.objectContaining({
+          action: 'StoryAtomsConverter.createBlockFromImageAtom',
+          result: 'missing_image_url',
+          atomKeys: expect.arrayContaining(['tagName', 'size']),
+          hasSize: false,
+        })
+      );
+    });
+
+    test('hasSize is true when atom.size has at least one key', () => {
+      const deps = makeDeps();
+      createBlockFromImageAtom({ size: { resized: {} } }, deps);
+      const [, ctx] = Logger.debug.mock.calls[0];
+      expect(ctx.hasSize).toBe(true);
+    });
+  });
+
+  describe('convertStoryAtoms', () => {
+    test('returns [] when atoms is not an array', () => {
+      const deps = makeDeps();
+      expect(convertStoryAtoms(null, deps)).toEqual([]);
+      expect(convertStoryAtoms(undefined, deps)).toEqual([]);
+      expect(convertStoryAtoms({}, deps)).toEqual([]);
+    });
+
+    test('skips unknown atom types and falsy entries', () => {
+      const deps = makeDeps();
+      const result = convertStoryAtoms(
+        [
+          null,
+          'string-atom',
+          { type: 'unknown', content: 'x' },
+          { type: 'text', content: '<p>kept</p>', tagName: 'p' },
+        ],
+        deps
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('paragraph');
+    });
+
+    test('routes text and image atoms to their builders in order', () => {
+      const deps = makeDeps();
+      const result = convertStoryAtoms(
+        [
+          { type: 'text', content: '<p>hi</p>', tagName: 'h2' },
+          { type: 'image', url: 'https://cdn.example.com/x.jpg', caption: 'c' },
+        ],
+        deps
+      );
+      expect(result.map(b => b.type)).toEqual(['heading_2', 'image']);
+    });
+  });
+});


### PR DESCRIPTION
### 摘要
重構 BBC 和 StoryAtoms 的轉換邏輯，提升可重用性與可維護性。

### 變更內容
- 將 BBC blocks 的轉換邏輯移至 `BbcBlockConverter.js`，簡化主邏輯。
- 將 Yahoo storyAtoms 的轉換邏輯移至 `StoryAtomsConverter.js`，減少複雜度。
- 引入依賴注入模式，增強模組的靈活性。
- 精簡 BBC block 處理邏輯，提升可讀性。
- 增加對圖片和段落的處理邏輯，確保轉換的完整性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

