### PR TITLE
fix: 修正可搜索資料來源選擇器的顯示邏輯

### DIFF
--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -560,44 +560,65 @@ export class SearchableDatabaseSelector {
     }
   }
 
+  _handleClosedDropdownKeyNav(event) {
+    if (event.key === 'ArrowDown' || event.key === 'Enter') {
+      event.preventDefault();
+      this.showDropdown();
+    }
+  }
+
+  _handleArrowDownKey(event) {
+    event.preventDefault();
+    const prevIndex = this.focusedIndex;
+    this.focusedIndex = Math.min(this.focusedIndex + 1, this.filteredDataSources.length - 1);
+    this.updateFocusedItem(prevIndex);
+    this.scrollToFocused();
+  }
+
+  _handleArrowUpKey(event) {
+    event.preventDefault();
+    const prevIndex = this.focusedIndex;
+    this.focusedIndex = Math.max(this.focusedIndex - 1, -1);
+    this.updateFocusedItem(prevIndex);
+    this.scrollToFocused();
+  }
+
+  _handleEnterKey(event) {
+    event.preventDefault();
+    if (this.focusedIndex >= 0 && this.filteredDataSources[this.focusedIndex]) {
+      this.selectDataSource(this.filteredDataSources[this.focusedIndex]);
+    }
+  }
+
+  _handleEscapeKey(event) {
+    event.preventDefault();
+    this.hideDropdown();
+  }
+
   handleKeyNavigation(event) {
     if (!this.isOpen) {
-      if (event.key === 'ArrowDown' || event.key === 'Enter') {
-        event.preventDefault();
-        this.showDropdown();
-      }
+      this._handleClosedDropdownKeyNav(event);
       return;
     }
 
-    switch (event.key) {
-      case 'ArrowDown': {
-        event.preventDefault();
-        const prevIndex = this.focusedIndex;
-        this.focusedIndex = Math.min(this.focusedIndex + 1, this.filteredDataSources.length - 1);
-        this.updateFocusedItem(prevIndex);
-        this.scrollToFocused();
-        break;
-      }
-      case 'ArrowUp': {
-        event.preventDefault();
-        const prevIndex = this.focusedIndex;
-        this.focusedIndex = Math.max(this.focusedIndex - 1, -1);
-        this.updateFocusedItem(prevIndex);
-        this.scrollToFocused();
-        break;
-      }
-      case 'Enter': {
-        event.preventDefault();
-        if (this.focusedIndex >= 0 && this.filteredDataSources[this.focusedIndex]) {
-          this.selectDataSource(this.filteredDataSources[this.focusedIndex]);
-        }
-        break;
-      }
-      case 'Escape': {
-        event.preventDefault();
-        this.hideDropdown();
-        break;
-      }
+    const handlers = {
+      ArrowDown: evt => {
+        this._handleArrowDownKey(evt);
+      },
+      ArrowUp: evt => {
+        this._handleArrowUpKey(evt);
+      },
+      Enter: evt => {
+        this._handleEnterKey(evt);
+      },
+      Escape: evt => {
+        this._handleEscapeKey(evt);
+      },
+    };
+
+    const handler = handlers[event.key];
+    if (handler) {
+      handler(event);
     }
   }
 

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -291,51 +291,62 @@ export class SearchableDatabaseSelector {
   }
 
   async performServerSearch(query) {
-    if (!query || query.length < 2) {
+    if (SearchableDatabaseSelector._isQueryTooShort(query)) {
       return;
     }
     this.currentSearchQuery = query;
     const requestId = ++this.searchRequestId;
 
     try {
-      const apiKey = await this.getApiKey();
-      if (this.isStaleSearchRequest(requestId, query)) {
-        return;
-      }
-
-      if (!apiKey) {
-        Logger.warn('無法執行伺服器端搜尋：缺少 API Key');
-        return;
-      }
-
-      this.isSearching = true;
-      if (this.isStaleSearchRequest(requestId, query)) {
-        return;
-      }
-      this.showSearchingState(query);
-
-      await this.loadDataSources(apiKey, query);
-      if (this.isStaleSearchRequest(requestId, query)) {
-        return;
-      }
-
-      Logger.info('伺服器端搜尋完成', { queryLength: query.length });
+      await this._runServerSearchPipeline(requestId, query);
     } catch (error) {
-      // 安全地處理錯誤訊息
-      const safeError = sanitizeApiError(error, 'server_search');
-      Logger.error(
-        '❌ [錯誤] 伺服器端搜尋失敗',
-        SearchableDatabaseSelector.createSafeErrorLogContext(safeError)
-      );
-      const errorMsg = ErrorHandler.formatUserMessage(safeError);
-
-      this.showStatus(`搜尋失敗: ${errorMsg}`, 'error');
+      this._reportServerSearchError(error);
     } finally {
       if (!this.isStaleSearchRequest(requestId, query)) {
         this.isSearching = false;
         this.restoreListAfterLoading();
       }
     }
+  }
+
+  static _isQueryTooShort(query) {
+    return !query || query.length < 2;
+  }
+
+  async _runServerSearchPipeline(requestId, query) {
+    const apiKey = await this.getApiKey();
+    if (this.isStaleSearchRequest(requestId, query)) {
+      return;
+    }
+
+    if (!apiKey) {
+      Logger.warn('無法執行伺服器端搜尋：缺少 API Key');
+      return;
+    }
+
+    this.isSearching = true;
+    if (this.isStaleSearchRequest(requestId, query)) {
+      return;
+    }
+    this.showSearchingState(query);
+
+    await this.loadDataSources(apiKey, query);
+    if (this.isStaleSearchRequest(requestId, query)) {
+      return;
+    }
+
+    Logger.info('伺服器端搜尋完成', { queryLength: query.length });
+  }
+
+  _reportServerSearchError(error) {
+    // 安全地處理錯誤訊息
+    const safeError = sanitizeApiError(error, 'server_search');
+    Logger.error(
+      '❌ [錯誤] 伺服器端搜尋失敗',
+      SearchableDatabaseSelector.createSafeErrorLogContext(safeError)
+    );
+    const errorMsg = ErrorHandler.formatUserMessage(safeError);
+    this.showStatus(`搜尋失敗: ${errorMsg}`, 'error');
   }
 
   showSearchingState(query) {

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -38,6 +38,23 @@ function pickStringFieldsWithTransforms(source, transforms) {
   return result;
 }
 
+const PARENT_META_DISPATCH = {
+  workspace: { icon: UI_ICONS.WORKSPACE, text: ' 工作區' },
+  page_id: { icon: UI_ICONS.PAGE, text: ' 子頁面' },
+  data_source_id: { icon: UI_ICONS.DATABASE, text: ' 資料庫項目' },
+  database_id: { icon: UI_ICONS.DATABASE, text: ' 資料庫項目' },
+  block_id: { icon: UI_ICONS.BLOCK, text: ' 區塊項目' },
+};
+
+function resolveParentMeta(parentType) {
+  return (
+    PARENT_META_DISPATCH[parentType] || {
+      icon: UI_ICONS.HELP,
+      text: ` 其他 (${parentType})`,
+    }
+  );
+}
+
 const extractTitleFromPageProperties = ds => {
   if (ds.object === 'page' && ds.properties?.title?.title) {
     const titleContent = ds.properties.title.title;
@@ -363,7 +380,7 @@ export class SearchableDatabaseSelector {
     this.dataSourceList.append(fragment);
   }
 
-  createDataSourceItem(ds, index) {
+  _buildDataSourceItemRoot(ds, index) {
     const isSelected = this.selectedDataSource && this.selectedDataSource.id === ds.id;
     const isFocused = index === this.focusedIndex;
 
@@ -379,6 +396,10 @@ export class SearchableDatabaseSelector {
     itemDiv.dataset.index = index;
     itemDiv.dataset.type = ds.type;
 
+    return { itemDiv, isSelected, isFocused };
+  }
+
+  _buildTitleRow(ds) {
     const titleRow = document.createElement('div');
     titleRow.className = 'database-title';
 
@@ -397,55 +418,27 @@ export class SearchableDatabaseSelector {
       titleRow.append(badge);
     }
 
-    itemDiv.append(titleRow);
+    return titleRow;
+  }
 
-    const metaRow = document.createElement('div');
-    metaRow.className = 'database-meta-compact';
+  _buildParentMetaGroup(parent) {
+    const { icon, text } = resolveParentMeta(parent.type);
+    const parentGroup = document.createElement('span');
+    parentGroup.className = 'meta-group';
+    parentGroup.append(createSafeIcon(icon));
+    parentGroup.append(document.createTextNode(text));
 
-    if (ds.parent) {
-      let parentIcon = '';
-      let parentText = '';
+    const separator = document.createElement('span');
+    separator.className = 'meta-separator';
+    separator.textContent = '|';
 
-      switch (ds.parent.type) {
-        case 'workspace': {
-          parentIcon = UI_ICONS.WORKSPACE;
-          parentText = ' 工作區';
-          break;
-        }
-        case 'page_id': {
-          parentIcon = UI_ICONS.PAGE;
-          parentText = ' 子頁面';
-          break;
-        }
-        case 'data_source_id':
-        case 'database_id': {
-          parentIcon = UI_ICONS.DATABASE;
-          parentText = ' 資料庫項目';
-          break;
-        }
-        case 'block_id': {
-          parentIcon = UI_ICONS.BLOCK;
-          parentText = ' 區塊項目';
-          break;
-        }
-        default: {
-          parentIcon = UI_ICONS.HELP;
-          parentText = ` 其他 (${ds.parent.type})`;
-        }
-      }
+    const fragment = document.createDocumentFragment();
+    fragment.append(parentGroup);
+    fragment.append(separator);
+    return fragment;
+  }
 
-      const parentGroup = document.createElement('span');
-      parentGroup.className = 'meta-group';
-      parentGroup.append(createSafeIcon(parentIcon));
-      parentGroup.append(document.createTextNode(parentText));
-      metaRow.append(parentGroup);
-
-      const separator = document.createElement('span');
-      separator.className = 'meta-separator';
-      separator.textContent = '|';
-      metaRow.append(separator);
-    }
-
+  _buildTypeMetaGroup(ds) {
     const typeGroup = document.createElement('span');
     typeGroup.className = 'meta-group';
     const typeIconSpan = document.createElement('span');
@@ -455,7 +448,20 @@ export class SearchableDatabaseSelector {
     const typeLabelSpan = document.createElement('span');
     typeLabelSpan.textContent = ds.type === 'page' ? '頁面' : '資料來源';
     typeGroup.append(typeLabelSpan);
-    metaRow.append(typeGroup);
+    return typeGroup;
+  }
+
+  createDataSourceItem(ds, index) {
+    const { itemDiv } = this._buildDataSourceItemRoot(ds, index);
+    itemDiv.append(this._buildTitleRow(ds));
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'database-meta-compact';
+
+    if (ds.parent) {
+      metaRow.append(this._buildParentMetaGroup(ds.parent));
+    }
+    metaRow.append(this._buildTypeMetaGroup(ds));
 
     itemDiv.append(metaRow);
     return itemDiv;

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -162,7 +162,7 @@ export class SearchableDatabaseSelector {
     this.renderDataSourceList();
 
     if (this.container) {
-      this.container.style.display = 'block';
+      this.container.classList.remove('hidden');
     }
 
     if (this.searchInput) {
@@ -484,7 +484,7 @@ export class SearchableDatabaseSelector {
 
   showDropdown() {
     if (this.dropdown) {
-      this.dropdown.style.display = 'block';
+      this.dropdown.classList.remove('hidden');
     }
     this.isOpen = true;
     this.toggleButton?.classList.add('open');
@@ -493,7 +493,7 @@ export class SearchableDatabaseSelector {
 
   hideDropdown() {
     if (this.dropdown) {
-      this.dropdown.style.display = 'none';
+      this.dropdown.classList.add('hidden');
     }
     this.isOpen = false;
     this.focusedIndex = -1;

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -21,6 +21,23 @@ const { DATA_SOURCE } = UI_MESSAGES;
  */
 const KEYBOARD_FOCUS_CLASS = 'keyboard-focus';
 
+const SAFE_ERROR_FIELD_TRANSFORMS = {
+  message: val => val,
+  details: val => val,
+  code: val => val,
+  url: val => sanitizeUrlForLogging(val),
+};
+
+function pickStringFieldsWithTransforms(source, transforms) {
+  const result = {};
+  for (const [field, transform] of Object.entries(transforms)) {
+    if (source && typeof source[field] === 'string') {
+      result[field] = transform(source[field]);
+    }
+  }
+  return result;
+}
+
 const extractTitleFromPageProperties = ds => {
   if (ds.object === 'page' && ds.properties?.title?.title) {
     const titleContent = ds.properties.title.title;
@@ -686,25 +703,11 @@ export class SearchableDatabaseSelector {
     if (typeof safeError === 'string') {
       return { message: safeError };
     }
-
-    if (safeError && typeof safeError === 'object') {
-      const context = {};
-      if (typeof safeError.message === 'string') {
-        context.message = safeError.message;
-      }
-      if (typeof safeError.details === 'string') {
-        context.details = safeError.details;
-      }
-      if (typeof safeError.code === 'string') {
-        context.code = safeError.code;
-      }
-      if (typeof safeError.url === 'string') {
-        context.url = sanitizeUrlForLogging(safeError.url);
-      }
-      return Object.keys(context).length > 0 ? context : { message: DATA_SOURCE.UNKNOWN_ERROR_LOG };
+    if (!safeError || typeof safeError !== 'object') {
+      return { message: DATA_SOURCE.UNKNOWN_ERROR_LOG };
     }
-
-    return { message: DATA_SOURCE.UNKNOWN_ERROR_LOG };
+    const context = pickStringFieldsWithTransforms(safeError, SAFE_ERROR_FIELD_TRANSFORMS);
+    return Object.keys(context).length > 0 ? context : { message: DATA_SOURCE.UNKNOWN_ERROR_LOG };
   }
 
   static extractDataSourceTitle(ds) {

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -82,6 +82,19 @@ const extractTitleFromAnyTitleProp = ds => {
   return null;
 };
 
+function mapToInternalDataSource(ds) {
+  return {
+    id: ds.id,
+    title: SearchableDatabaseSelector.extractDataSourceTitle(ds),
+    type: ds.object, // 'page', 'database' 或 'data_source'
+    isWorkspace: ds.parent?.type === 'workspace',
+    parent: ds.parent,
+    raw: ds,
+    created: ds.created_time,
+    lastEdited: ds.last_edited_time,
+  };
+}
+
 export class SearchableDatabaseSelector {
   constructor(dependencies = {}) {
     const { showStatus, loadDataSources, getApiKey } = dependencies;
@@ -212,21 +225,10 @@ export class SearchableDatabaseSelector {
   }
 
   populateDataSources(dataSources, isSearchResult = false) {
-    const mappedDataSources = dataSources.map(ds => ({
-      id: ds.id,
-      title: SearchableDatabaseSelector.extractDataSourceTitle(ds),
-      type: ds.object, // 'page', 'database' 或 'data_source'
-      isWorkspace: ds.parent?.type === 'workspace',
-      parent: ds.parent,
-      raw: ds,
-      created: ds.created_time,
-      lastEdited: ds.last_edited_time,
-    }));
-
-    this.dataSources = mappedDataSources;
+    this.dataSources = dataSources.map(ds => mapToInternalDataSource(ds));
 
     if (!isSearchResult) {
-      this.initialDataSources = [...mappedDataSources];
+      this.initialDataSources = [...this.dataSources];
       Logger.info('已保存初始資料來源列表:', this.initialDataSources.length);
     }
 
@@ -237,23 +239,28 @@ export class SearchableDatabaseSelector {
     this.updateDataSourceCount();
     this.renderDataSourceList();
 
-    if (this.container) {
-      this.container.classList.remove('hidden');
-    }
+    this.container?.classList.remove('hidden');
 
     if (this.searchInput) {
       this.searchInput.placeholder = DATA_SOURCE.SEARCH_PLACEHOLDER;
     }
 
-    if (this.databaseIdInput?.value) {
-      const selectedDs = this.dataSources.find(ds => ds.id === this.databaseIdInput.value);
-      if (selectedDs) {
-        if (this.searchInput) {
-          this.searchInput.value = selectedDs.title;
-        }
-        this.selectedDataSource = selectedDs;
-      }
+    this._applyPreSelectedDataSource();
+  }
+
+  _applyPreSelectedDataSource() {
+    const preSelectedId = this.databaseIdInput?.value;
+    if (!preSelectedId) {
+      return;
     }
+    const selectedDs = this.dataSources.find(ds => ds.id === preSelectedId);
+    if (!selectedDs) {
+      return;
+    }
+    if (this.searchInput) {
+      this.searchInput.value = selectedDs.title;
+    }
+    this.selectedDataSource = selectedDs;
   }
 
   filterDataSourcesLocally(query) {

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -641,22 +641,22 @@ export class SearchableDatabaseSelector {
     if (!this.dataSourceList) {
       return;
     }
+    this._clearFocusFrom(prevIndex);
+    this._applyFocusTo(this.focusedIndex);
+  }
 
-    // 移除之前的焦點
-    if (prevIndex >= 0) {
-      const prevItem = this.dataSourceList.children[prevIndex];
-      if (prevItem) {
-        prevItem.classList.remove(KEYBOARD_FOCUS_CLASS);
-      }
+  _clearFocusFrom(index) {
+    if (index < 0) {
+      return;
     }
+    this.dataSourceList.children[index]?.classList.remove(KEYBOARD_FOCUS_CLASS);
+  }
 
-    // 設置新的焦點
-    if (this.focusedIndex >= 0) {
-      const currentItem = this.dataSourceList.children[this.focusedIndex];
-      if (currentItem) {
-        currentItem.classList.add(KEYBOARD_FOCUS_CLASS);
-      }
+  _applyFocusTo(index) {
+    if (index < 0) {
+      return;
     }
+    this.dataSourceList.children[index]?.classList.add(KEYBOARD_FOCUS_CLASS);
   }
 
   scrollToFocused() {

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -140,60 +140,75 @@ export class SearchableDatabaseSelector {
   }
 
   setupEventListeners() {
-    this._handleSearchInput = event => {
-      const query = event.target.value.trim();
-      this.currentSearchQuery = query;
+    const bindings = this._buildEventBindings();
+    this._boundEventBindings = bindings.map(({ target, type, methodName }) => ({
+      target,
+      type,
+      handler: this[methodName].bind(this),
+    }));
 
-      if (this.searchTimeout) {
-        clearTimeout(this.searchTimeout);
-      }
+    for (const { target, type, handler } of this._boundEventBindings) {
+      target?.addEventListener(type, handler);
+    }
+  }
 
-      if (!query) {
-        this.restoreInitialDataSources();
-        this.showDropdown();
-        return;
-      }
+  _buildEventBindings() {
+    return [
+      { target: this.searchInput, type: 'input', methodName: '_handleSearchInput' },
+      { target: this.searchInput, type: 'focus', methodName: '_handleSearchFocus' },
+      { target: this.searchInput, type: 'keydown', methodName: '_handleKeydown' },
+      { target: this.toggleButton, type: 'click', methodName: '_handleToggleClick' },
+      { target: this.refreshButton, type: 'click', methodName: '_handleRefreshClick' },
+      { target: document, type: 'click', methodName: '_handleDocumentClick' },
+    ];
+  }
 
-      this.filterDataSourcesLocally(query);
+  _handleSearchInput(event) {
+    const query = event.target.value.trim();
+    this.currentSearchQuery = query;
+
+    if (this.searchTimeout) {
+      clearTimeout(this.searchTimeout);
+    }
+
+    if (!query) {
+      this.restoreInitialDataSources();
       this.showDropdown();
+      return;
+    }
 
-      this.searchTimeout = setTimeout(() => {
-        this.performServerSearch(query);
-      }, 500);
-    };
+    this.filterDataSourcesLocally(query);
+    this.showDropdown();
 
-    this._handleSearchFocus = () => {
-      if (this.dataSources.length > 0) {
-        this.showDropdown();
-      }
-    };
+    this.searchTimeout = setTimeout(() => {
+      this.performServerSearch(query);
+    }, 500);
+  }
 
-    this._handleToggleClick = event => {
-      event.preventDefault();
-      this.toggleDropdown();
-    };
+  _handleSearchFocus() {
+    if (this.dataSources.length > 0) {
+      this.showDropdown();
+    }
+  }
 
-    this._handleRefreshClick = event => {
-      event.preventDefault();
-      this.refreshDataSources();
-    };
+  _handleToggleClick(event) {
+    event.preventDefault();
+    this.toggleDropdown();
+  }
 
-    this._handleDocumentClick = event => {
-      if (this.container && !this.container.contains(event.target)) {
-        this.hideDropdown();
-      }
-    };
+  _handleRefreshClick(event) {
+    event.preventDefault();
+    this.refreshDataSources();
+  }
 
-    this._handleKeydown = event => {
-      this.handleKeyNavigation(event);
-    };
+  _handleDocumentClick(event) {
+    if (this.container && !this.container.contains(event.target)) {
+      this.hideDropdown();
+    }
+  }
 
-    this.searchInput?.addEventListener('input', this._handleSearchInput);
-    this.searchInput?.addEventListener('focus', this._handleSearchFocus);
-    this.toggleButton?.addEventListener('click', this._handleToggleClick);
-    this.refreshButton?.addEventListener('click', this._handleRefreshClick);
-    document.addEventListener('click', this._handleDocumentClick);
-    this.searchInput?.addEventListener('keydown', this._handleKeydown);
+  _handleKeydown(event) {
+    this.handleKeyNavigation(event);
   }
 
   populateDataSources(dataSources, isSearchResult = false) {
@@ -753,19 +768,11 @@ export class SearchableDatabaseSelector {
       clearTimeout(this.searchTimeout);
       this.searchTimeout = null;
     }
-    if (this._handleSearchInput) {
-      this.searchInput?.removeEventListener('input', this._handleSearchInput);
-      this.searchInput?.removeEventListener('focus', this._handleSearchFocus);
-      this.searchInput?.removeEventListener('keydown', this._handleKeydown);
-      this.toggleButton?.removeEventListener('click', this._handleToggleClick);
-      this.refreshButton?.removeEventListener('click', this._handleRefreshClick);
-      document.removeEventListener('click', this._handleDocumentClick);
-      this._handleSearchInput = null;
-      this._handleSearchFocus = null;
-      this._handleToggleClick = null;
-      this._handleRefreshClick = null;
-      this._handleDocumentClick = null;
-      this._handleKeydown = null;
+    if (this._boundEventBindings) {
+      for (const { target, type, handler } of this._boundEventBindings) {
+        target?.removeEventListener(type, handler);
+      }
+      this._boundEventBindings = null;
     }
 
     // 防禦性清空：清除陣列與物件引用，防止銷毀後誤用

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -320,7 +320,11 @@ export class SearchableDatabaseSelector {
     }
 
     if (!apiKey) {
-      Logger.warn('無法執行伺服器端搜尋：缺少 API Key');
+      Logger.warn('無法執行伺服器端搜尋：缺少 API Key', {
+        action: 'server_search',
+        result: 'aborted',
+        reason: 'missing_api_key',
+      });
       return;
     }
 
@@ -335,16 +339,20 @@ export class SearchableDatabaseSelector {
       return;
     }
 
-    Logger.info('伺服器端搜尋完成', { queryLength: query.length });
+    Logger.info('伺服器端搜尋完成', {
+      action: 'server_search',
+      result: 'completed',
+      queryLength: query.length,
+    });
   }
 
   _reportServerSearchError(error) {
-    // 安全地處理錯誤訊息
     const safeError = sanitizeApiError(error, 'server_search');
-    Logger.error(
-      '❌ [錯誤] 伺服器端搜尋失敗',
-      SearchableDatabaseSelector.createSafeErrorLogContext(safeError)
-    );
+    Logger.error('伺服器端搜尋失敗', {
+      action: 'server_search',
+      result: 'failed',
+      ...SearchableDatabaseSelector.createSafeErrorLogContext(safeError),
+    });
     const errorMsg = ErrorHandler.formatUserMessage(safeError);
     this.showStatus(`搜尋失敗: ${errorMsg}`, 'error');
   }
@@ -701,7 +709,11 @@ export class SearchableDatabaseSelector {
     try {
       const apiKey = await this.getApiKey();
       if (!apiKey) {
-        Logger.warn('無法重新載入資料來源：缺少 API Key');
+        Logger.warn('無法重新載入資料來源：缺少 API Key', {
+          action: 'refresh_data_sources',
+          result: 'aborted',
+          reason: 'missing_api_key',
+        });
         return;
       }
 
@@ -709,10 +721,11 @@ export class SearchableDatabaseSelector {
       await this.loadDataSources(apiKey);
     } catch (error) {
       const safeError = sanitizeApiError(error, 'refresh_data_sources');
-      Logger.error(
-        '❌ [錯誤] 重新載入資料來源失敗',
-        SearchableDatabaseSelector.createSafeErrorLogContext(safeError)
-      );
+      Logger.error('重新載入資料來源失敗', {
+        action: 'refresh_data_sources',
+        result: 'failed',
+        ...SearchableDatabaseSelector.createSafeErrorLogContext(safeError),
+      });
       const errorMsg = ErrorHandler.formatUserMessage(safeError);
       this.showStatus(`重新載入失敗: ${errorMsg}`, 'error');
     } finally {

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -21,6 +21,33 @@ const { DATA_SOURCE } = UI_MESSAGES;
  */
 const KEYBOARD_FOCUS_CLASS = 'keyboard-focus';
 
+const extractTitleFromPageProperties = ds => {
+  if (ds.object === 'page' && ds.properties?.title?.title) {
+    const titleContent = ds.properties.title.title;
+    if (titleContent.length > 0) {
+      return titleContent[0].plain_text || titleContent[0].text?.content;
+    }
+  }
+  return null;
+};
+
+const extractTitleFromTopLevelTitle = ds => {
+  if (ds.title && ds.title.length > 0) {
+    return ds.title[0].plain_text || ds.title[0].text?.content;
+  }
+  return null;
+};
+
+const extractTitleFromAnyTitleProp = ds => {
+  if (ds.properties) {
+    const titleProp = Object.values(ds.properties).find(prop => prop.type === 'title');
+    if (titleProp?.title && titleProp.title.length > 0) {
+      return titleProp.title[0].plain_text || titleProp.title[0].text?.content;
+    }
+  }
+  return null;
+};
+
 export class SearchableDatabaseSelector {
   constructor(dependencies = {}) {
     const { showStatus, loadDataSources, getApiKey } = dependencies;
@@ -681,21 +708,14 @@ export class SearchableDatabaseSelector {
   }
 
   static extractDataSourceTitle(ds) {
-    let title = ds.object === 'page' ? DATA_SOURCE.UNTITLED_PAGE : DATA_SOURCE.UNTITLED_DATA_SOURCE;
-    if (ds.object === 'page' && ds.properties?.title?.title) {
-      const titleContent = ds.properties.title.title;
-      if (titleContent.length > 0) {
-        title = titleContent[0].plain_text || titleContent[0].text?.content || title;
-      }
-    } else if (ds.title && ds.title.length > 0) {
-      title = ds.title[0].plain_text || ds.title[0].text?.content || title;
-    } else if (ds.properties) {
-      const titleProp = Object.values(ds.properties).find(prop => prop.type === 'title');
-      if (titleProp?.title && titleProp.title.length > 0) {
-        title = titleProp.title[0].plain_text || titleProp.title[0].text?.content || title;
-      }
-    }
-    return title;
+    const defaultTitle =
+      ds.object === 'page' ? DATA_SOURCE.UNTITLED_PAGE : DATA_SOURCE.UNTITLED_DATA_SOURCE;
+    const extractors = [
+      extractTitleFromPageProperties,
+      extractTitleFromTopLevelTitle,
+      extractTitleFromAnyTitleProp,
+    ];
+    return extractors.map(extract => extract(ds)).find(Boolean) ?? defaultTitle;
   }
 
   destroy() {

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -672,5 +672,34 @@ describe('SearchableDatabaseSelector', () => {
       expect(documentRemoveSpy).toHaveBeenCalledWith('click', expect.any(Function));
       expect(selector.searchTimeout).toBeNull();
     });
+
+    it('setupEventListeners 應綁定 6 條 event 並支援後續 destroy 對稱解綁 (regression: C7 dispatch table)', () => {
+      // 重建 selector 以乾淨計數 add/remove
+      const localSelector = new SearchableDatabaseSelector({
+        showStatus: jest.fn(),
+        loadDataSources: jest.fn(),
+        getApiKey: jest.fn().mockResolvedValue('k'),
+      });
+
+      expect(Array.isArray(localSelector._boundEventBindings)).toBe(true);
+      expect(localSelector._boundEventBindings).toHaveLength(6);
+
+      // 解綁時必須使用同一份 bound reference 才能成功移除
+      const removeSpies = localSelector._boundEventBindings.map(({ target, type, handler }) => ({
+        target,
+        type,
+        handler,
+        spy: target ? jest.spyOn(target, 'removeEventListener') : null,
+      }));
+
+      localSelector.destroy();
+
+      for (const { spy, type, handler } of removeSpies) {
+        if (spy) {
+          expect(spy).toHaveBeenCalledWith(type, handler);
+        }
+      }
+      expect(localSelector._boundEventBindings).toBeNull();
+    });
   });
 });

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -154,6 +154,56 @@ describe('SearchableDatabaseSelector', () => {
     });
   });
 
+  describe('extractDataSourceTitle', () => {
+    it('應該自 page properties 中提取標題 (extractTitleFromPageProperties)', () => {
+      const ds = {
+        object: 'page',
+        properties: {
+          title: {
+            title: [{ plain_text: 'Page Prop Title' }],
+          },
+        },
+      };
+      expect(SearchableDatabaseSelector.extractDataSourceTitle(ds)).toBe('Page Prop Title');
+    });
+
+    it('應該自 top-level title 中提取標題 (extractTitleFromTopLevelTitle)', () => {
+      const ds = {
+        object: 'database',
+        title: [{ plain_text: 'Top Level Title' }],
+      };
+      expect(SearchableDatabaseSelector.extractDataSourceTitle(ds)).toBe('Top Level Title');
+    });
+
+    it('應該自 properties 內類型為 title 的任意屬性中提取標題 (extractTitleFromAnyTitleProp)', () => {
+      const ds = {
+        object: 'database',
+        properties: {
+          CustomName: {
+            type: 'title',
+            title: [{ plain_text: 'Any Title Prop' }],
+          },
+        },
+      };
+      expect(SearchableDatabaseSelector.extractDataSourceTitle(ds)).toBe('Any Title Prop');
+    });
+
+    it('當無任何標題且為 page 時應回傳預設的無標題頁面標題', () => {
+      const ds = {
+        object: 'page',
+        properties: {},
+      };
+      expect(SearchableDatabaseSelector.extractDataSourceTitle(ds)).toBe('未命名頁面');
+    });
+
+    it('當無任何標題且為 database 時應回傳預設的無標題資料來源標題', () => {
+      const ds = {
+        object: 'database',
+      };
+      expect(SearchableDatabaseSelector.extractDataSourceTitle(ds)).toBe('未命名資料來源');
+    });
+  });
+
   describe('filterDataSourcesLocally', () => {
     const mockDatabases = [
       { id: '1', object: 'database', title: [{ plain_text: 'Apple' }] },

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -553,6 +553,30 @@ describe('SearchableDatabaseSelector', () => {
       expect(selector.isOpen).toBe(true);
     });
 
+    it('should call preventDefault and showDropdown on ArrowDown or Enter when closed', () => {
+      selector.hideDropdown();
+      selector.showDropdown = jest.fn();
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+      event.preventDefault = jest.fn();
+      selector.handleKeyNavigation(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(selector.showDropdown).toHaveBeenCalled();
+    });
+
+    it('should not call preventDefault or showDropdown on other keys when closed', () => {
+      selector.hideDropdown();
+      selector.showDropdown = jest.fn();
+
+      const event = new KeyboardEvent('keydown', { key: 'KeyA' });
+      event.preventDefault = jest.fn();
+      selector.handleKeyNavigation(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(selector.showDropdown).not.toHaveBeenCalled();
+    });
+
     it('should navigate down with ArrowDown when open', () => {
       selector.showDropdown();
       selector.focusedIndex = 0;

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -25,12 +25,15 @@ describe('SearchableDatabaseSelector', () => {
     // Mock scrollIntoView (jsdom 不支援此方法)
     Element.prototype.scrollIntoView = jest.fn();
 
-    // DOM Setup
+    // DOM Setup — 對齊 production HTML：用 .hidden class 而非 inline display
+    // .hidden 在 options.css 裡是 `display: none !important`，
+    // 任何 inline style.display 都會被 !important 壓掉，
+    // 因此 fixture 必須與 production 一致才能擋住 hidden-class regression。
     document.body.innerHTML = `
-      <div id="database-selector-container" style="display: none;">
+      <div id="database-selector-container" class="hidden">
         <input type="text" id="database-search" />
         <button id="selector-toggle"></button>
-        <div id="database-dropdown" style="display: none;"></div>
+        <div id="database-dropdown" class="hidden"></div>
         <div id="data-source-list"></div>
         <div id="data-source-count"></div>
         <button id="refresh-databases"></button>
@@ -84,7 +87,7 @@ describe('SearchableDatabaseSelector', () => {
 
       expect(selector.dataSources).toHaveLength(2);
       expect(selector.dataSourceList.children).toHaveLength(2);
-      expect(selector.container.style.display).toBe('block');
+      expect(selector.container.classList.contains('hidden')).toBe(false);
 
       // Check formatting of items
       const firstItem = selector.dataSourceList.children[0];
@@ -207,12 +210,12 @@ describe('SearchableDatabaseSelector', () => {
       selector.populateDataSources([{ id: '1', object: 'database', title: [] }]);
       selector.toggleDropdown();
       expect(selector.isOpen).toBe(true);
-      expect(selector.dropdown.style.display).toBe('block');
+      expect(selector.dropdown.classList.contains('hidden')).toBe(false);
       expect(selector.toggleButton.getAttribute('aria-expanded')).toBe('true');
 
       selector.toggleDropdown();
       expect(selector.isOpen).toBe(false);
-      expect(selector.dropdown.style.display).toBe('none');
+      expect(selector.dropdown.classList.contains('hidden')).toBe(true);
       expect(selector.toggleButton.getAttribute('aria-expanded')).toBe('false');
     });
 
@@ -235,6 +238,39 @@ describe('SearchableDatabaseSelector', () => {
 
       expect(selector.dataSourceList.querySelector('.loading-state')).toBeNull();
       expect(mockShowStatus).toHaveBeenCalledWith(expect.stringContaining('重新載入失敗'), 'error');
+    });
+  });
+
+  // Regression: production HTML 預設 #database-selector-container 與
+  // #database-dropdown 帶 `class="hidden"`（CSS：display: none !important），
+  // 早期實作用 inline style.display 試圖顯示，被 !important 壓住，
+  // 60 個項目 render 進 DOM 卻永不可見。本區塊鎖住 .hidden class 的整段 lifecycle。
+  describe('hidden class lifecycle (regression)', () => {
+    it('should remove .hidden from container on populate', () => {
+      expect(selector.container.classList.contains('hidden')).toBe(true);
+
+      selector.populateDataSources([
+        { id: 'db1', object: 'database', title: [{ plain_text: 'DB One' }] },
+      ]);
+
+      expect(selector.container.classList.contains('hidden')).toBe(false);
+    });
+
+    it('should remove .hidden from dropdown on showDropdown', () => {
+      expect(selector.dropdown.classList.contains('hidden')).toBe(true);
+
+      selector.showDropdown();
+
+      expect(selector.dropdown.classList.contains('hidden')).toBe(false);
+    });
+
+    it('should add .hidden back to dropdown on hideDropdown', () => {
+      selector.showDropdown();
+      expect(selector.dropdown.classList.contains('hidden')).toBe(false);
+
+      selector.hideDropdown();
+
+      expect(selector.dropdown.classList.contains('hidden')).toBe(true);
     });
   });
 

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -503,6 +503,34 @@ describe('SearchableDatabaseSelector', () => {
       await selector.performServerSearch('test query');
       expect(mockShowStatus).toHaveBeenCalledWith('搜尋失敗: 發生未知錯誤，請稍後再試', 'error');
     });
+
+    // Regression: C10 拆出 _isQueryTooShort / _runServerSearchPipeline / _reportServerSearchError
+    // 三個 helper 後，主函式契約 (lifecycle setup + try/catch/finally) 與 helper 行為應分別可驗證
+    it('_isQueryTooShort: 對 empty / length<2 / valid 輸入分類正確 (regression: C10 static helper)', () => {
+      expect(SearchableDatabaseSelector._isQueryTooShort('')).toBe(true);
+      expect(SearchableDatabaseSelector._isQueryTooShort(null)).toBe(true);
+      expect(SearchableDatabaseSelector._isQueryTooShort('a')).toBe(true);
+      expect(SearchableDatabaseSelector._isQueryTooShort('ab')).toBe(false);
+      expect(SearchableDatabaseSelector._isQueryTooShort('long query')).toBe(false);
+    });
+
+    it('_reportServerSearchError: 應依序呼叫 sanitizeApiError → Logger.error → showStatus (regression: C10)', () => {
+      const error = new Error('boom');
+      selector._reportServerSearchError(error);
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('伺服器端搜尋失敗'),
+        expect.any(Object)
+      );
+      expect(mockShowStatus).toHaveBeenCalledWith(expect.stringContaining('搜尋失敗'), 'error');
+    });
+
+    it('_runServerSearchPipeline: 主函式 finally 應在 stale check 通過時清 isSearching (regression: C10 lifecycle separation)', async () => {
+      mockGetApiKey.mockResolvedValue('k');
+      selector.searchInput.value = 'fresh';
+      // 直接呼叫 pipeline 確認執行成功不丟錯（lifecycle 由主函式管理）
+      await expect(selector._runServerSearchPipeline(1, 'fresh')).resolves.toBeUndefined();
+    });
   });
 
   describe('showSearchingState', () => {

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -702,4 +702,45 @@ describe('SearchableDatabaseSelector', () => {
       expect(localSelector._boundEventBindings).toBeNull();
     });
   });
+
+  describe('updateFocusedItem (C8 helper extraction regression)', () => {
+    beforeEach(() => {
+      // 建立 3 個假 list item 以便測試 focus class 操作
+      selector.dataSourceList.replaceChildren();
+      for (let i = 0; i < 3; i++) {
+        const div = document.createElement('div');
+        div.className = 'database-item';
+        selector.dataSourceList.append(div);
+      }
+    });
+
+    it('updateFocusedItem 應在指定 index 上套用 keyboard-focus，並清掉前一個 index 的 focus', () => {
+      selector.focusedIndex = 1;
+      selector.updateFocusedItem(-1);
+      expect(selector.dataSourceList.children[1].classList.contains('keyboard-focus')).toBe(true);
+
+      selector.focusedIndex = 2;
+      selector.updateFocusedItem(1);
+      expect(selector.dataSourceList.children[1].classList.contains('keyboard-focus')).toBe(false);
+      expect(selector.dataSourceList.children[2].classList.contains('keyboard-focus')).toBe(true);
+    });
+
+    it('當 prevIndex < 0 時 _clearFocusFrom 應為 no-op，不應丟錯', () => {
+      selector.focusedIndex = 0;
+      expect(() => selector.updateFocusedItem(-1)).not.toThrow();
+      expect(selector.dataSourceList.children[0].classList.contains('keyboard-focus')).toBe(true);
+    });
+
+    it('當 focusedIndex < 0 時 _applyFocusTo 應為 no-op，僅執行 clear', () => {
+      selector.dataSourceList.children[1].classList.add('keyboard-focus');
+      selector.focusedIndex = -1;
+      selector.updateFocusedItem(1);
+      expect(selector.dataSourceList.children[1].classList.contains('keyboard-focus')).toBe(false);
+    });
+
+    it('當 dataSourceList 不存在時 updateFocusedItem 應為 no-op', () => {
+      selector.dataSourceList = null;
+      expect(() => selector.updateFocusedItem(0)).not.toThrow();
+    });
+  });
 });

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -204,6 +204,44 @@ describe('SearchableDatabaseSelector', () => {
     });
   });
 
+  describe('createSafeErrorLogContext', () => {
+    it('應該正確轉換字串錯誤格式', () => {
+      const result = SearchableDatabaseSelector.createSafeErrorLogContext('simple error');
+      expect(result).toEqual({ message: 'simple error' });
+    });
+
+    it('當輸入欄位 { message, details, code, url } 完整存在時應正確提取與轉換', () => {
+      const errorObj = {
+        message: 'API error',
+        details: 'Failed to fetch database list',
+        code: 'notion_api',
+        url: 'https://api.notion.com/v1/search?query=test',
+      };
+      const result = SearchableDatabaseSelector.createSafeErrorLogContext(errorObj);
+      expect(result.message).toBe('API error');
+      expect(result.details).toBe('Failed to fetch database list');
+      expect(result.code).toBe('notion_api');
+      expect(result.url).toContain('https://api.notion.com/');
+    });
+
+    it('當輸入空物件時應回傳預設未知錯誤訊息', () => {
+      const result = SearchableDatabaseSelector.createSafeErrorLogContext({});
+      expect(result).toEqual({ message: '未知錯誤' });
+    });
+
+    it('當輸入無效或為空值時應回傳預設未知錯誤訊息', () => {
+      expect(SearchableDatabaseSelector.createSafeErrorLogContext(null)).toEqual({
+        message: '未知錯誤',
+      });
+      expect(SearchableDatabaseSelector.createSafeErrorLogContext(undefined)).toEqual({
+        message: '未知錯誤',
+      });
+      expect(SearchableDatabaseSelector.createSafeErrorLogContext(123)).toEqual({
+        message: '未知錯誤',
+      });
+    });
+  });
+
   describe('filterDataSourcesLocally', () => {
     const mockDatabases = [
       { id: '1', object: 'database', title: [{ plain_text: 'Apple' }] },

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -242,6 +242,49 @@ describe('SearchableDatabaseSelector', () => {
     });
   });
 
+  describe('createDataSourceItem', () => {
+    it('應該正確套用 selected 與 keyboard-focus 樣式類別', () => {
+      const ds = { id: 'ds-test', title: 'Test Target', type: 'page' };
+      selector.selectedDataSource = ds;
+      selector.focusedIndex = 2;
+
+      const itemElementSelected = selector.createDataSourceItem(ds, 2);
+      expect(itemElementSelected.classList.contains('selected')).toBe(true);
+      expect(itemElementSelected.classList.contains('keyboard-focus')).toBe(true);
+
+      const itemElementUnselected = selector.createDataSourceItem(
+        { id: 'other', title: 'Other', type: 'page' },
+        0
+      );
+      expect(itemElementUnselected.classList.contains('selected')).toBe(false);
+      expect(itemElementUnselected.classList.contains('keyboard-focus')).toBe(false);
+    });
+
+    it('應該為各種 parent.type 建立正確的圖示與文字標記', () => {
+      const types = [
+        { type: 'workspace', text: '工作區' },
+        { type: 'page_id', text: '子頁面' },
+        { type: 'database_id', text: '資料庫項目' },
+        { type: 'data_source_id', text: '資料庫項目' },
+        { type: 'block_id', text: '區塊項目' },
+        { type: 'unknown_type', text: '其他 (unknown_type)' },
+      ];
+
+      types.forEach(({ type, text }) => {
+        const ds = {
+          id: `ds-${type}`,
+          title: `Item of ${type}`,
+          type: 'database',
+          parent: { type },
+        };
+        const itemElement = selector.createDataSourceItem(ds, 0);
+        const metaCompact = itemElement.querySelector('.database-meta-compact');
+        expect(metaCompact).toBeTruthy();
+        expect(metaCompact.textContent).toContain(text);
+      });
+    });
+  });
+
   describe('filterDataSourcesLocally', () => {
     const mockDatabases = [
       { id: '1', object: 'database', title: [{ plain_text: 'Apple' }] },

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -152,6 +152,21 @@ describe('SearchableDatabaseSelector', () => {
 
       expect(selector.searchInput.placeholder).toBe('搜尋保存目標...');
     });
+
+    // Regression: C9 抽 _applyPreSelectedDataSource instance helper 後，
+    // pre-selected 行為應與重構前 inline 版本完全等價
+    it('_applyPreSelectedDataSource: 當 #database-id 對應 ds 不存在時應 no-op，不丟錯也不寫 selectedDataSource (regression: C9)', () => {
+      document.querySelector('#database-id').value = 'nonexistent_id';
+      expect(() => selector.populateDataSources(mockDatabases)).not.toThrow();
+      expect(selector.selectedDataSource).toBeNull();
+      expect(selector.searchInput.value).toBe(''); // 沒有副作用寫到 searchInput
+    });
+
+    it('_applyPreSelectedDataSource: 當 #database-id 為空時應直接 return，不掃描 dataSources (regression: C9)', () => {
+      document.querySelector('#database-id').value = '';
+      selector.populateDataSources(mockDatabases);
+      expect(selector.selectedDataSource).toBeNull();
+    });
   });
 
   describe('extractDataSourceTitle', () => {

--- a/tests/unit/options/SearchableDatabaseSelector.test.js
+++ b/tests/unit/options/SearchableDatabaseSelector.test.js
@@ -525,11 +525,17 @@ describe('SearchableDatabaseSelector', () => {
       expect(mockShowStatus).toHaveBeenCalledWith(expect.stringContaining('搜尋失敗'), 'error');
     });
 
-    it('_runServerSearchPipeline: 主函式 finally 應在 stale check 通過時清 isSearching (regression: C10 lifecycle separation)', async () => {
+    it('performServerSearch: 主函式 finally 應在 stale check 通過時清 isSearching 並還原列表 (regression: C10 lifecycle separation)', async () => {
       mockGetApiKey.mockResolvedValue('k');
       selector.searchInput.value = 'fresh';
-      // 直接呼叫 pipeline 確認執行成功不丟錯（lifecycle 由主函式管理）
-      await expect(selector._runServerSearchPipeline(1, 'fresh')).resolves.toBeUndefined();
+
+      const restoreSpy = jest.spyOn(selector, 'restoreListAfterLoading');
+      await selector.performServerSearch('fresh');
+
+      expect(selector.isSearching).toBe(false);
+      expect(restoreSpy).toHaveBeenCalledTimes(1);
+
+      restoreSpy.mockRestore();
     });
   });
 
@@ -696,7 +702,14 @@ describe('SearchableDatabaseSelector', () => {
       mockGetApiKey.mockResolvedValue(null);
       selector.searchInput.value = 'query';
       await selector.performServerSearch('query');
-      expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining('缺少 API Key'));
+      expect(Logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('缺少 API Key'),
+        expect.objectContaining({
+          action: 'server_search',
+          result: 'aborted',
+          reason: 'missing_api_key',
+        })
+      );
     });
 
     it('_createHighlightedText 應該處理 regex 拋出的錯誤 (Line 410)', () => {


### PR DESCRIPTION
### 摘要
修正可搜索資料來源選擇器的顯示邏輯，確保使用 `hidden` 類別來控制顯示與隱藏，並重構相關邏輯以降低複雜度。

### 變更內容
- 將顯示和隱藏下拉選單的邏輯從使用 inline style 改為使用 class `hidden`。
- 重構 `extractDataSourceTitle`、`createSafeErrorLogContext`、`createDataSourceItem` 等方法以降低複雜度。
- 拆分 `handleKeyNavigation` 為鍵盤事件分發器，並重構事件監聽器的設置邏輯。
- 增加回歸測試以確保 `hidden` 類別的生命週期正確。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

