### PR TITLE
chore: update devDependencies and remove unused default exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@notionhq/client": "5.11.0"
       },
       "devDependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
+        "@jest/globals": "^30.2.0",
         "@playwright/test": "^1.58.2",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,10 @@
   },
   "homepage": "https://github.com/cowcfj/save-to-notion",
   "devDependencies": {
+    "@asamuzakjp/css-color": "^5.0.1",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
+    "@jest/globals": "^30.2.0",
     "@playwright/test": "^1.58.2",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",

--- a/scripts/highlighter/ui/Toast.js
+++ b/scripts/highlighter/ui/Toast.js
@@ -159,5 +159,3 @@ export class Toast {
     }
   }
 }
-
-export default Toast;

--- a/scripts/legacy/MigrationExecutor.js
+++ b/scripts/legacy/MigrationExecutor.js
@@ -490,5 +490,3 @@ if (globalThis.window !== undefined) {
   globalThis.MigrationExecutor = MigrationExecutor;
   globalThis.MigrationPhase = MigrationPhase;
 }
-
-export default MigrationExecutor;


### PR DESCRIPTION
### 摘要
更新開發依賴並移除未使用的預設匯出。

### 變更內容
- 將 `@jest/globals` 和 `@asamuzakjp/css-color` 設定為直接的開發依賴，以避免因為傳遞依賴的變更而導致的潛在問題。
- 移除 `Toast` 和 `MigrationExecutor` 模組中的未使用預設匯出，簡化匯出結構。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

