### PR TITLE
fix: resolve intermittent failures in e2e tests

### DIFF
--- a/tests/e2e/specs/floating-rail-display-settings.spec.js
+++ b/tests/e2e/specs/floating-rail-display-settings.spec.js
@@ -42,7 +42,7 @@ test('changing settings updates rail CSS variables on host', async ({
     });
   }, targetTabId);
 
-  const railHost = page.locator('#notion-floating-rail-host');
+  const railHost = page.locator('[id^="notion-floating-rail-host-"][data-rail-owner="true"]');
   await expect(railHost).toBeVisible({ timeout: 15_000 });
 
   const readVar = async name =>

--- a/tests/e2e/specs/highlight.spec.js
+++ b/tests/e2e/specs/highlight.spec.js
@@ -107,8 +107,8 @@ test.describe('Highlighting Feature', () => {
       throw new Error(`Injection failed: ${injectionResult.error}`);
     }
 
-    // 4. 驗證工具列存在
-    await page.waitForSelector('#notion-highlighter-v2', {
+    // 4. 驗證 Floating Rail 存在
+    await page.waitForSelector('[id^="notion-floating-rail-host-"][data-rail-owner="true"]', {
       timeout: 5000,
       state: 'attached',
     });
@@ -117,15 +117,21 @@ test.describe('Highlighting Feature', () => {
     //    刻意不真的呼叫 toast.show()——那會在 example.com 留下 DOM 影響後續斷言；
     //    僅做鴨子型別與 instance identity 檢查，補 unit test 涵蓋不到的整合風險：
     //    「toast 暴露給 windowAPI 卻沒注入 manager」這種 wire 斷裂只能在真實 Chrome 抓到。
-    const toastWireResult = await page.evaluate(() => {
-      const v2 = globalThis.HighlighterV2;
-      return {
-        hasV2: Boolean(v2),
-        hasToast: Boolean(v2?.toast),
-        toastShowIsFn: typeof v2?.toast?.show === 'function',
-        managerToastIsSameInstance: v2?.manager?.toast === v2?.toast,
-      };
-    });
+    const toastWireResult = await serviceWorker.evaluate(async tabId => {
+      const [result] = await chrome.scripting.executeScript({
+        target: { tabId },
+        func: () => {
+          const v2 = globalThis.HighlighterV2;
+          return {
+            hasV2: Boolean(v2),
+            hasToast: Boolean(v2?.toast),
+            toastShowIsFn: typeof v2?.toast?.show === 'function',
+            managerToastIsSameInstance: v2?.manager?.toast === v2?.toast,
+          };
+        },
+      });
+      return result.result;
+    }, targetTabId);
 
     expect(toastWireResult.hasV2).toBe(true);
     expect(toastWireResult.hasToast).toBe(true);

--- a/tests/e2e/specs/preloader.spec.js
+++ b/tests/e2e/specs/preloader.spec.js
@@ -2,6 +2,34 @@
 import { test, expect } from '../fixtures';
 
 test.describe('Preloader E2E Tests', () => {
+  /**
+   * 輔助函式：發送訊息到專屬的 example.com tab，帶有 lastError 與無回應偵測
+   */
+  const sendPreloaderMessage = async (worker, action) => {
+    return worker.evaluate(
+      async msg => {
+        const tabs = await chrome.tabs.query({ url: 'https://example.com/*' });
+        const tab = tabs[0];
+        if (!tab) {
+          return { ok: false, error: 'Target tab not found (example.com)' };
+        }
+
+        return new Promise(resolve => {
+          chrome.tabs.sendMessage(tab.id, msg, response => {
+            if (chrome.runtime.lastError) {
+              resolve({ ok: false, error: chrome.runtime.lastError.message });
+            } else if (response === undefined) {
+              resolve({ ok: false, error: 'No response' });
+            } else {
+              resolve({ ok: true, response });
+            }
+          });
+        });
+      },
+      { action }
+    );
+  };
+
   test('should initialize and respond to PING', async ({ page, context }) => {
     // 1. 導航到測試頁面
     await page.goto('https://example.com');
@@ -13,22 +41,12 @@ test.describe('Preloader E2E Tests', () => {
     }
 
     // 3. 通過 Service Worker 發送 PING 消息給 Content Script (Preloader)
-    const response = await worker.evaluate(async () => {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (!tab) {
-        return { error: 'No active tab' };
-      }
+    const result = await sendPreloaderMessage(worker, 'PING');
 
-      return new Promise(resolve => {
-        chrome.tabs.sendMessage(tab.id, { action: 'PING' }, response => {
-          resolve(response);
-        });
-      });
-    });
-
-    // 驗證 Preloader 有回應
-    expect(response.status).toBe('preloader_only');
-    expect(response.hasCache).toBeDefined();
+    // 驗證 Preloader 有回應且成功
+    expect(result.ok).toBe(true);
+    expect(result.response.status).toBe('preloader_only');
+    expect(result.response.hasCache).toBeDefined();
   });
 
   test('should buffer shortcut events before bundle ready', async ({ page, context }) => {
@@ -44,17 +62,13 @@ test.describe('Preloader E2E Tests', () => {
     await page.waitForTimeout(500); // 給 preloader 時間初始化
 
     // 3. 驗證 Preloader 已載入並響應
-    const pingResponse = await worker.evaluate(async () => {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      return new Promise(resolve => {
-        chrome.tabs.sendMessage(tab.id, { action: 'PING' }, response => {
-          resolve(response || {});
-        });
-      });
-    });
+    const pingResult = await sendPreloaderMessage(worker, 'PING');
 
-    if (!pingResponse.status) {
-      test.skip(true, 'Preloader is not ready, skipping test');
+    if (!pingResult.ok || !pingResult.response.status) {
+      test.skip(
+        true,
+        `Preloader is not ready: ${pingResult.error || 'No response'}, skipping test`
+      );
     }
 
     // 4. 模擬按下 Ctrl+S（現在可以確保會被緩衝）
@@ -64,28 +78,16 @@ test.describe('Preloader E2E Tests', () => {
     await page.waitForTimeout(200);
 
     // 6. 測試 INIT_BUNDLE 是否顯示有緩衝事件
-    const initResponse = await worker.evaluate(async () => {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      return new Promise(resolve => {
-        chrome.tabs.sendMessage(tab.id, { action: 'INIT_BUNDLE' }, response => {
-          resolve(response || {});
-        });
-      });
-    });
+    const initResult = await sendPreloaderMessage(worker, 'INIT_BUNDLE');
 
-    expect(initResponse.ready).toBe(true);
+    expect(initResult.ok).toBe(true);
+    expect(initResult.response.ready).toBe(true);
 
     // 7. 測試 REPLAY_BUFFERED_EVENTS
-    const replayResponse = await worker.evaluate(async () => {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      return new Promise(resolve => {
-        chrome.tabs.sendMessage(tab.id, { action: 'REPLAY_BUFFERED_EVENTS' }, response => {
-          resolve(response || {});
-        });
-      });
-    });
+    const replayResult = await sendPreloaderMessage(worker, 'REPLAY_BUFFERED_EVENTS');
 
-    expect(Array.isArray(replayResponse.events)).toBe(true);
+    expect(replayResult.ok).toBe(true);
+    expect(Array.isArray(replayResult.response.events)).toBe(true);
   });
 
   test('should handle custom events for cache requests', async ({ page }) => {


### PR DESCRIPTION
### 摘要
修正了高亮顯示器、預加載器和顯示設置的端對端測試中出現的間歇性失敗問題。

### 變更內容
- 更新選擇器以正確定位浮動工具列。
- 使用輔助函式發送消息到特定的 tab，改善了與內容腳本的通信。
- 確保在測試中正確處理預加載器的回應。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

