### PR TITLE
fix: Enhance highlight position logic to handle context disambiguation

### DIFF
--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -193,7 +193,12 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
     return -1;
   }
   if (candidates.length === 1) {
-    return candidates[0]; // 唯一匹配，無需消歧義
+    const hasContext = Boolean(prefix || suffix);
+    if (!hasContext) {
+      return candidates[0]; // 唯一匹配且無上下文消歧義資訊，直接接受
+    }
+    // 雖為唯一匹配但有上下文消歧義資訊，評分必須大於 0（有部分 prefix/suffix 重合）才接受
+    return scoreCandidate(fullText, candidates[0], text, prefix, suffix) > 0 ? candidates[0] : -1;
   }
 
   // 3. prefix/suffix 計分消歧義：取最高分的候選

--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -160,6 +160,73 @@ function findCandidatePositions(fullText, text) {
   return candidates;
 }
 
+/**
+ * 從 highlight.rangeInfo 抽取 prefix / suffix 與 hasContext 旗標
+ *
+ * 把零散的 optional chaining 與 short-circuit 集中,讓主函數無需自行處理
+ * rangeInfo 缺失時的 fallback。
+ *
+ * @param {object|undefined} rangeInfo - 標註的 rangeInfo 子物件
+ * @returns {{ prefix: string, suffix: string, hasContext: boolean }}
+ */
+function extractContextFromRangeInfo(rangeInfo) {
+  const prefix = rangeInfo?.prefix || '';
+  const suffix = rangeInfo?.suffix || '';
+  return { prefix, suffix, hasContext: Boolean(prefix || suffix) };
+}
+
+/**
+ * 從唯一候選位置決定最終回傳值
+ *
+ * 無上下文資訊時直接接受;有上下文資訊時要求 prefix/suffix 至少部分重合,
+ * 否則視為跨段落殘留誤命中而拒絕。
+ *
+ * @param {string} fullText - 拼接後的純文本
+ * @param {number} idx - 唯一候選的位置索引
+ * @param {string} text - 標註文字
+ * @param {string} prefix - 消歧義前綴
+ * @param {string} suffix - 消歧義後綴
+ * @param {boolean} hasContext - 是否提供任一上下文
+ * @returns {number} 接受時為 idx,拒絕時為 -1
+ */
+function resolveSingleCandidate(fullText, idx, text, prefix, suffix, hasContext) {
+  if (!hasContext) {
+    return idx;
+  }
+  return scoreCandidate(fullText, idx, text, prefix, suffix) > 0 ? idx : -1;
+}
+
+/**
+ * 從多個候選位置中以 prefix/suffix 計分挑出最佳匹配
+ *
+ * 相同分數回退到第一個候選;有上下文資訊但全部候選評分為 0 時拒絕匹配。
+ *
+ * @param {string} fullText - 拼接後的純文本
+ * @param {Array<number>} candidates - 候選位置索引陣列(MUST length > 0)
+ * @param {string} text - 標註文字
+ * @param {string} prefix - 消歧義前綴
+ * @param {string} suffix - 消歧義後綴
+ * @param {boolean} hasContext - 是否提供任一上下文
+ * @returns {number} 最佳候選位置;若有上下文但無任何候選分數 > 0 則回 -1
+ */
+function resolveBestScoringCandidate(fullText, candidates, text, prefix, suffix, hasContext) {
+  let bestIdx = candidates[0];
+  let bestScore = -1;
+
+  for (const idx of candidates) {
+    const score = scoreCandidate(fullText, idx, text, prefix, suffix);
+    if (score > bestScore) {
+      bestScore = score;
+      bestIdx = idx;
+    }
+  }
+
+  if (hasContext && bestScore === 0) {
+    return -1;
+  }
+  return bestIdx;
+}
+
 // ============================================================================
 // 核心算法
 // ============================================================================
@@ -188,9 +255,7 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
     return -1;
   }
 
-  const prefix = rangeInfo?.prefix || '';
-  const suffix = rangeInfo?.suffix || '';
-  const hasContext = Boolean(prefix || suffix);
+  const { prefix, suffix, hasContext } = extractContextFromRangeInfo(rangeInfo);
 
   // 2. 找出所有匹配位置
   const candidates = findCandidatePositions(fullText, text);
@@ -199,30 +264,11 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
     return -1;
   }
   if (candidates.length === 1) {
-    if (!hasContext) {
-      return candidates[0]; // 唯一匹配且無上下文消歧義資訊，直接接受
-    }
-    // 雖為唯一匹配但有上下文消歧義資訊，評分必須大於 0（有部分 prefix/suffix 重合）才接受
-    return scoreCandidate(fullText, candidates[0], text, prefix, suffix) > 0 ? candidates[0] : -1;
+    return resolveSingleCandidate(fullText, candidates[0], text, prefix, suffix, hasContext);
   }
 
   // 3. prefix/suffix 計分消歧義：取最高分的候選
-  let bestIdx = candidates[0]; // 回退：第一個
-  let bestScore = -1;
-
-  for (const idx of candidates) {
-    const score = scoreCandidate(fullText, idx, text, prefix, suffix);
-    if (score > bestScore) {
-      bestScore = score;
-      bestIdx = idx;
-    }
-  }
-
-  if (hasContext && bestScore === 0) {
-    return -1;
-  }
-
-  return bestIdx;
+  return resolveBestScoringCandidate(fullText, candidates, text, prefix, suffix, hasContext);
 }
 
 /**

--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -146,6 +146,20 @@ function scoreCandidate(fullText, idx, text, prefix, suffix) {
   return score;
 }
 
+function findCandidatePositions(fullText, text) {
+  const candidates = [];
+  let searchStart = 0;
+  while (searchStart < fullText.length) {
+    const idx = fullText.indexOf(text, searchStart);
+    if (idx === -1) {
+      break;
+    }
+    candidates.push(idx);
+    searchStart = idx + 1;
+  }
+  return candidates;
+}
+
 // ============================================================================
 // 核心算法
 // ============================================================================
@@ -176,24 +190,15 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
 
   const prefix = rangeInfo?.prefix || '';
   const suffix = rangeInfo?.suffix || '';
+  const hasContext = Boolean(prefix || suffix);
 
   // 2. 找出所有匹配位置
-  const candidates = [];
-  let searchStart = 0;
-  while (searchStart < fullText.length) {
-    const idx = fullText.indexOf(text, searchStart);
-    if (idx === -1) {
-      break;
-    }
-    candidates.push(idx);
-    searchStart = idx + 1;
-  }
+  const candidates = findCandidatePositions(fullText, text);
 
   if (candidates.length === 0) {
     return -1;
   }
   if (candidates.length === 1) {
-    const hasContext = Boolean(prefix || suffix);
     if (!hasContext) {
       return candidates[0]; // 唯一匹配且無上下文消歧義資訊，直接接受
     }
@@ -211,6 +216,10 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
       bestScore = score;
       bestIdx = idx;
     }
+  }
+
+  if (hasContext && bestScore === 0) {
+    return -1;
   }
 
   return bestIdx;

--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -114,11 +114,11 @@ function resolveStyle(styleKey, highlight) {
  * @param {string} fullText - 拼接後的純文本
  * @param {number} idx - 候選位置索引
  * @param {string} text - 標註文字
- * @param {string} prefix - 消歧義前綴
- * @param {string} suffix - 消歧義後綴
+ * @param {{ prefix: string, suffix: string }} context - 消歧義上下文
  * @returns {number} 比對分數
  */
-function scoreCandidate(fullText, idx, text, prefix, suffix) {
+function scoreCandidate(fullText, idx, text, context) {
+  const { prefix, suffix } = context;
   let score = 0;
 
   if (prefix) {
@@ -184,16 +184,14 @@ function extractContextFromRangeInfo(rangeInfo) {
  * @param {string} fullText - 拼接後的純文本
  * @param {number} idx - 唯一候選的位置索引
  * @param {string} text - 標註文字
- * @param {string} prefix - 消歧義前綴
- * @param {string} suffix - 消歧義後綴
- * @param {boolean} hasContext - 是否提供任一上下文
+ * @param {{ prefix: string, suffix: string, hasContext: boolean }} context - 消歧義上下文
  * @returns {number} 接受時為 idx,拒絕時為 -1
  */
-function resolveSingleCandidate(fullText, idx, text, prefix, suffix, hasContext) {
-  if (!hasContext) {
+function resolveSingleCandidate(fullText, idx, text, context) {
+  if (!context.hasContext) {
     return idx;
   }
-  return scoreCandidate(fullText, idx, text, prefix, suffix) > 0 ? idx : -1;
+  return scoreCandidate(fullText, idx, text, context) > 0 ? idx : -1;
 }
 
 /**
@@ -204,24 +202,22 @@ function resolveSingleCandidate(fullText, idx, text, prefix, suffix, hasContext)
  * @param {string} fullText - 拼接後的純文本
  * @param {Array<number>} candidates - 候選位置索引陣列(MUST length > 0)
  * @param {string} text - 標註文字
- * @param {string} prefix - 消歧義前綴
- * @param {string} suffix - 消歧義後綴
- * @param {boolean} hasContext - 是否提供任一上下文
+ * @param {{ prefix: string, suffix: string, hasContext: boolean }} context - 消歧義上下文
  * @returns {number} 最佳候選位置;若有上下文但無任何候選分數 > 0 則回 -1
  */
-function resolveBestScoringCandidate(fullText, candidates, text, prefix, suffix, hasContext) {
+function resolveBestScoringCandidate(fullText, candidates, text, context) {
   let bestIdx = candidates[0];
   let bestScore = -1;
 
   for (const idx of candidates) {
-    const score = scoreCandidate(fullText, idx, text, prefix, suffix);
+    const score = scoreCandidate(fullText, idx, text, context);
     if (score > bestScore) {
       bestScore = score;
       bestIdx = idx;
     }
   }
 
-  if (hasContext && bestScore === 0) {
+  if (context.hasContext && bestScore === 0) {
     return -1;
   }
   return bestIdx;
@@ -255,7 +251,7 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
     return -1;
   }
 
-  const { prefix, suffix, hasContext } = extractContextFromRangeInfo(rangeInfo);
+  const context = extractContextFromRangeInfo(rangeInfo);
 
   // 2. 找出所有匹配位置
   const candidates = findCandidatePositions(fullText, text);
@@ -264,11 +260,11 @@ function findHighlightPosition(richTextArray, highlight, fullText) {
     return -1;
   }
   if (candidates.length === 1) {
-    return resolveSingleCandidate(fullText, candidates[0], text, prefix, suffix, hasContext);
+    return resolveSingleCandidate(fullText, candidates[0], text, context);
   }
 
   // 3. prefix/suffix 計分消歧義：取最高分的候選
-  return resolveBestScoringCandidate(fullText, candidates, text, prefix, suffix, hasContext);
+  return resolveBestScoringCandidate(fullText, candidates, text, context);
 }
 
 /**

--- a/scripts/highlighter/core/HighlightStorage.js
+++ b/scripts/highlighter/core/HighlightStorage.js
@@ -127,9 +127,11 @@ export class HighlightStorage {
       return [];
     }
     return Array.from(this.manager.highlights.values()).map(highlight => ({
+      id: highlight.id,
       text: highlight.text,
       color: highlight.color,
       timestamp: highlight.timestamp,
+      rangeInfo: highlight.rangeInfo,
     }));
   }
 

--- a/scripts/highlighter/core/HighlightStorage.js
+++ b/scripts/highlighter/core/HighlightStorage.js
@@ -131,7 +131,7 @@ export class HighlightStorage {
       text: highlight.text,
       color: highlight.color,
       timestamp: highlight.timestamp,
-      rangeInfo: highlight.rangeInfo,
+      ...(highlight.rangeInfo === undefined ? {} : { rangeInfo: highlight.rangeInfo }),
     }));
   }
 

--- a/scripts/highlighter/core/Range.js
+++ b/scripts/highlighter/core/Range.js
@@ -9,6 +9,85 @@ import { waitForDOMStability } from '../utils/domStability.js';
 
 const { CONTEXT_LENGTH } = HIGHLIGHT_ANCHORING;
 
+const BLOCK_BOUNDARY_TAGS = new Set([
+  'ADDRESS',
+  'ARTICLE',
+  'ASIDE',
+  'BLOCKQUOTE',
+  'DD',
+  'DETAILS',
+  'DIALOG',
+  'DIV',
+  'DL',
+  'DT',
+  'FIELDSET',
+  'FIGCAPTION',
+  'FIGURE',
+  'FOOTER',
+  'FORM',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'HEADER',
+  'HR',
+  'LI',
+  'MAIN',
+  'NAV',
+  'OL',
+  'P',
+  'PRE',
+  'SECTION',
+  'TABLE',
+  'UL',
+]);
+
+function isBlockBoundaryNode(node) {
+  return node?.nodeType === Node.ELEMENT_NODE && BLOCK_BOUNDARY_TAGS.has(node.tagName);
+}
+
+function createBoundaryRange(container, startOffset, endOffset) {
+  const boundaryRange = document.createRange();
+  boundaryRange.selectNodeContents(container);
+  boundaryRange.setStart(container, startOffset);
+  boundaryRange.setEnd(container, endOffset);
+  return boundaryRange;
+}
+
+function extractElementPrefix(container, offset) {
+  let startOffset = 0;
+  for (let i = offset - 1; i >= 0; i--) {
+    if (isBlockBoundaryNode(container.childNodes[i])) {
+      startOffset = i + 1;
+      break;
+    }
+  }
+
+  const text = createBoundaryRange(container, startOffset, offset).toString();
+  if (text.trim().length === 0) {
+    return '';
+  }
+  return text.slice(Math.max(0, text.length - CONTEXT_LENGTH));
+}
+
+function extractElementSuffix(container, offset) {
+  let endOffset = container.childNodes.length;
+  for (let i = offset; i < container.childNodes.length; i++) {
+    if (isBlockBoundaryNode(container.childNodes[i])) {
+      endOffset = i;
+      break;
+    }
+  }
+
+  const text = createBoundaryRange(container, offset, endOffset).toString();
+  if (text.trim().length === 0) {
+    return '';
+  }
+  return text.slice(0, CONTEXT_LENGTH);
+}
+
 /**
  * 序列化 Range 對象
  *
@@ -21,14 +100,10 @@ export function serializeRange(range) {
     const text = range.startContainer.textContent;
     prefix = text.slice(Math.max(0, range.startOffset - CONTEXT_LENGTH), range.startOffset);
   } else {
-    // 當 startContainer 為元素節點時，startOffset 代表子節點索引。
-    // 創建一個從容器開頭到 startOffset 的 Range 來提取之前的文本。
+    // Element-node offsets are child indexes; clip context to the current text run
+    // so adjacent block text does not become a misleading prefix.
     try {
-      const prefixRange = document.createRange();
-      prefixRange.selectNodeContents(range.startContainer);
-      prefixRange.setEnd(range.startContainer, range.startOffset);
-      const text = prefixRange.toString();
-      prefix = text.slice(Math.max(0, text.length - CONTEXT_LENGTH));
+      prefix = extractElementPrefix(range.startContainer, range.startOffset);
     } catch {
       prefix = '';
     }
@@ -40,14 +115,10 @@ export function serializeRange(range) {
     const text = range.endContainer.textContent;
     suffix = text.slice(range.endOffset, Math.min(text.length, range.endOffset + CONTEXT_LENGTH));
   } else {
-    // 當 endContainer 為元素節點時，endOffset 代表子節點索引。
-    // 創建一個從 endOffset 到容器結尾的 Range 來提取之後的文本。
+    // Element-node offsets are child indexes; clip context to the current text run
+    // so adjacent block text does not become a misleading suffix.
     try {
-      const suffixRange = document.createRange();
-      suffixRange.selectNodeContents(range.endContainer);
-      suffixRange.setStart(range.endContainer, range.endOffset);
-      const text = suffixRange.toString();
-      suffix = text.slice(0, CONTEXT_LENGTH);
+      suffix = extractElementSuffix(range.endContainer, range.endOffset);
     } catch {
       suffix = '';
     }

--- a/tests/unit/background/utils/highlightStyleMerger.test.js
+++ b/tests/unit/background/utils/highlightStyleMerger.test.js
@@ -170,6 +170,26 @@ describe('findHighlightPosition', () => {
     expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(6);
   });
 
+  test('有 context 時，單一候選若 prefix/suffix 都不匹配應返回 -1', () => {
+    const richTextArray = [makeRT('Markdown is not good enough as a tool.')];
+    const hl = {
+      text: 'Markdown',
+      rangeInfo: { prefix: 'a reason ', suffix: ' is being' },
+    };
+    const fullText = buildFullText(richTextArray);
+    expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(-1);
+  });
+
+  test('有 context 且單一候選，雖然 prefix/suffix 只是部分匹配（但評分 > 0）應返回正確位置', () => {
+    const richTextArray = [makeRT('a reason Markdown is being discussed.')];
+    const hl = {
+      text: 'Markdown',
+      rangeInfo: { prefix: 'reason ', suffix: ' is being' },
+    };
+    const fullText = buildFullText(richTextArray);
+    expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(9);
+  });
+
   test('文字不存在時返回 -1', () => {
     const richTextArray = [makeRT('這篇文章沒有標註')];
     const hl = { text: '重要概念', rangeInfo: {} };
@@ -370,6 +390,36 @@ describe('mergeHighlightsWithStyle — 核心功能', () => {
     const richText = result[0].paragraph.rich_text;
     expect(richText.find(rt => rt.annotations?.color === 'red')?.text.content).toBe('紅色');
     expect(richText.find(rt => rt.annotations?.color === 'blue')?.text.content).toBe('藍色');
+  });
+
+  test('英文短詞在前段重複時應依 rangeInfo context 套用到正確 block', () => {
+    const blocks = [
+      makeParagraphBlock([makeRT('Markdown is not good enough as a tool.')]),
+      makeParagraphBlock([
+        makeRT('Of course, there’s a reason Markdown is being discussed again.'),
+      ]),
+    ];
+    const highlights = [
+      {
+        id: 'hl-markdown-context',
+        text: 'Markdown',
+        color: 'yellow',
+        rangeInfo: { prefix: 'a reason ', suffix: ' is being' },
+      },
+    ];
+
+    const result = mergeHighlightsWithStyle(blocks, highlights, 'COLOR_SYNC');
+
+    // 確保第一個 block 維持原樣，沒有被錯誤套用或分割
+    expect(result[0].paragraph.rich_text).toHaveLength(1);
+    expect(result[0].paragraph.rich_text[0].annotations?.color).toBeUndefined();
+
+    // 確保第二個 block 中的 Markdown 被正確套用黃色高亮背景
+    const highlighted = result[1].paragraph.rich_text.find(
+      rt => rt.annotations?.color === 'yellow_background'
+    );
+    expect(highlighted).toBeDefined();
+    expect(highlighted?.text.content).toBe('Markdown');
   });
 });
 

--- a/tests/unit/background/utils/highlightStyleMerger.test.js
+++ b/tests/unit/background/utils/highlightStyleMerger.test.js
@@ -135,25 +135,28 @@ describe('scoreCandidate', () => {
 
   test('prefix 完全匹配得 2 分', () => {
     const idx = fullText.indexOf('重要概念');
-    const score = scoreCandidate(fullText, idx, '重要概念', '探討一些', '');
+    const score = scoreCandidate(fullText, idx, '重要概念', { prefix: '探討一些', suffix: '' });
     expect(score).toBe(2);
   });
 
   test('suffix 完全匹配得 2 分', () => {
     const idx = fullText.indexOf('重要概念');
-    const score = scoreCandidate(fullText, idx, '重要概念', '', '和應用場景');
+    const score = scoreCandidate(fullText, idx, '重要概念', { prefix: '', suffix: '和應用場景' });
     expect(score).toBe(2);
   });
 
   test('prefix + suffix 都完全匹配得 4 分', () => {
     const idx = fullText.indexOf('重要概念');
-    const score = scoreCandidate(fullText, idx, '重要概念', '探討一些', '和應用場景');
+    const score = scoreCandidate(fullText, idx, '重要概念', {
+      prefix: '探討一些',
+      suffix: '和應用場景',
+    });
     expect(score).toBe(4);
   });
 
   test('無 prefix 且無 suffix 時得 0 分', () => {
     const idx = fullText.indexOf('重要概念');
-    const score = scoreCandidate(fullText, idx, '重要概念', '', '');
+    const score = scoreCandidate(fullText, idx, '重要概念', { prefix: '', suffix: '' });
     expect(score).toBe(0);
   });
 });

--- a/tests/unit/background/utils/highlightStyleMerger.test.js
+++ b/tests/unit/background/utils/highlightStyleMerger.test.js
@@ -210,6 +210,17 @@ describe('findHighlightPosition', () => {
     expect(pos).toBe(13);
   });
 
+  test('有 context 時，多個候選若全部不匹配 prefix/suffix 應返回 -1', () => {
+    const richTextArray = [makeRT('Markdown appears here. Markdown appears again.')];
+    const hl = {
+      text: 'Markdown',
+      rangeInfo: { prefix: 'a reason ', suffix: ' is being' },
+    };
+    const fullText = buildFullText(richTextArray);
+
+    expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(-1);
+  });
+
   test('多個匹配且無 prefix/suffix：回退到第一個匹配', () => {
     const richTextArray = [makeRT('概念是概念')];
     const hl = { text: '概念', rangeInfo: {} };

--- a/tests/unit/highlighter/core/HighlightStorage.test.js
+++ b/tests/unit/highlighter/core/HighlightStorage.test.js
@@ -199,12 +199,13 @@ describe('core/HighlightStorage', () => {
   });
 
   describe('collectForNotion', () => {
-    test('should collect highlight data for Notion', () => {
+    test('should collect highlight data with anchoring context for Notion', () => {
       mockManager.highlights.set('h1', {
         id: 'h1',
         text: 'Test text',
         color: 'yellow',
         timestamp: 12_345,
+        rangeInfo: { prefix: 'before ', suffix: ' after' },
         range: {},
       });
       mockManager.highlights.set('h2', {
@@ -212,6 +213,7 @@ describe('core/HighlightStorage', () => {
         text: 'Another',
         color: 'green',
         timestamp: 12_346,
+        rangeInfo: { prefix: 'prev ', suffix: ' next' },
         range: {},
       });
 
@@ -219,15 +221,21 @@ describe('core/HighlightStorage', () => {
 
       expect(collected).toHaveLength(2);
       expect(collected[0]).toEqual({
+        id: 'h1',
         text: 'Test text',
         color: 'yellow',
         timestamp: 12_345,
+        rangeInfo: { prefix: 'before ', suffix: ' after' },
       });
       expect(collected[1]).toEqual({
+        id: 'h2',
         text: 'Another',
         color: 'green',
         timestamp: 12_346,
+        rangeInfo: { prefix: 'prev ', suffix: ' next' },
       });
+      expect(collected[0]).not.toHaveProperty('range');
+      expect(collected[1]).not.toHaveProperty('range');
     });
 
     test('should return empty array when no highlights', () => {
@@ -251,19 +259,29 @@ describe('core/HighlightStorage', () => {
     });
 
     test('should map highlights correctly and exclude extra properties', () => {
-      const mockHighlight = { text: 't', color: 'c', timestamp: 123, other: 'ignored' };
+      const mockHighlight = {
+        id: 'h1',
+        text: 't',
+        color: 'c',
+        timestamp: 123,
+        other: 'ignored',
+        range: {},
+      };
       mockManager.highlights.set('h1', mockHighlight);
 
       const result = storage.collectForNotion();
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
+        id: 'h1',
         text: 't',
         color: 'c',
         timestamp: 123,
+        rangeInfo: undefined,
       });
-      // Verify 'other' property is not included
+      // Verify 'other' and 'range' property is not included
       expect(result[0]).not.toHaveProperty('other');
+      expect(result[0]).not.toHaveProperty('range');
     });
   });
 

--- a/tests/unit/highlighter/core/HighlightStorage.test.js
+++ b/tests/unit/highlighter/core/HighlightStorage.test.js
@@ -277,11 +277,11 @@ describe('core/HighlightStorage', () => {
         text: 't',
         color: 'c',
         timestamp: 123,
-        rangeInfo: undefined,
       });
       // Verify 'other' and 'range' property is not included
       expect(result[0]).not.toHaveProperty('other');
       expect(result[0]).not.toHaveProperty('range');
+      expect(result[0]).not.toHaveProperty('rangeInfo');
     });
   });
 

--- a/tests/unit/highlighter/core/Range.test.js
+++ b/tests/unit/highlighter/core/Range.test.js
@@ -68,6 +68,26 @@ describe('core/Range', () => {
       expect(serialized.suffix).toHaveLength(32);
       expect(serialized.suffix).toBe('...and a very long suffix string');
     });
+
+    test('should not use adjacent block text as context for element-node ranges', () => {
+      const article = document.createElement('article');
+      article.innerHTML = [
+        '<p>Previous block should not become prefix.</p>',
+        '<p>First selected block.</p>',
+        '<p>Second selected block.</p>',
+        '<p>Next block should not become suffix.</p>',
+      ].join('');
+      document.body.append(article);
+
+      const range = document.createRange();
+      range.setStart(article, 1);
+      range.setEnd(article, 3);
+
+      const serialized = serializeRange(range);
+
+      expect(serialized.prefix).toBe('');
+      expect(serialized.suffix).toBe('');
+    });
   });
 
   describe('deserializeRange', () => {


### PR DESCRIPTION
### 摘要
增強標註位置查找邏輯，以考慮上下文資訊，改善唯一候選的返回值。

### 變更內容
- 修改 `findHighlightPosition` 函數，當唯一候選的上下文不匹配時返回 -1。
- 更新 `HighlightStorage` 類別，新增 `rangeInfo` 以收集上下文資訊。
- 新增測試案例以驗證在有上下文的情況下，單一候選的正確返回值。

### 測試方式
已新增測試案例以驗證功能。

### 潛在風險
無顯著風險。

