### PR TITLE
refactor: Adjust TabService status update delay to improve IPC ordering

### DIFF
--- a/scripts/config/shared/core.js
+++ b/scripts/config/shared/core.js
@@ -31,7 +31,11 @@ export const HANDLER_CONSTANTS = {
 
 export const TAB_SERVICE = {
   LOADING_TIMEOUT_MS: 10_000,
-  STATUS_UPDATE_DELAY_MS: 1000,
+  // 100ms buffer between tabs.onUpdated 'complete' and updateTabStatus.
+  // _waitForTabCompilation already gates on tab.status === 'complete'; this
+  // buffer only smooths microscopic IPC ordering. Was 1000ms historically
+  // (undocumented); rail save/sync availability is delayed by this value.
+  STATUS_UPDATE_DELAY_MS: 100,
   PRELOADER_PING_TIMEOUT_MS: 500,
 };
 

--- a/scripts/config/shared/core.js
+++ b/scripts/config/shared/core.js
@@ -31,10 +31,10 @@ export const HANDLER_CONSTANTS = {
 
 export const TAB_SERVICE = {
   LOADING_TIMEOUT_MS: 10_000,
-  // 100ms buffer between tabs.onUpdated 'complete' and updateTabStatus.
-  // _waitForTabCompilation already gates on tab.status === 'complete'; this
-  // buffer only smooths microscopic IPC ordering. Was 1000ms historically
-  // (undocumented); rail save/sync availability is delayed by this value.
+  // tabs.onUpdated 'complete' 與 updateTabStatus 之間的 100ms 緩衝。
+  // _waitForTabCompilation 已守備 tab.status === 'complete';此緩衝僅
+  // 平滑微觀 IPC 排序。歷史值為 1000ms（無文件化原因）;此值決定
+  // floating rail 上 save/sync 按鈕的可用延遲。
   STATUS_UPDATE_DELAY_MS: 100,
   PRELOADER_PING_TIMEOUT_MS: 500,
 };


### PR DESCRIPTION
### 摘要
調整 TabService 的狀態更新延遲，以改善 IPC 排序和減少 rail save/sync 的可用性延遲。

### 變更內容
- 將 STATUS_UPDATE_DELAY_MS 的值從 1000ms 調整為 100ms。
- 增加註解以解釋此延遲的目的，確保在 tabs.onUpdated 'complete' 和 updateTabStatus 之間有 100ms 的緩衝。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

