### PR TITLE
perf: optimize DOM stability check for NextJs fallback

### DIFF
--- a/scripts/content/extractors/ContentExtractor.js
+++ b/scripts/content/extractors/ContentExtractor.js
@@ -121,6 +121,7 @@ const runNextJsExtractionAsync = async (doc, action) => {
       await waitForDOMStability({
         stabilityThresholdMs: DOM_STABILITY.THRESHOLD_MS,
         maxWaitMs: DOM_STABILITY.MAX_WAIT_MS,
+        initialGracePeriodMs: 0,
       });
     }
   } catch (error) {

--- a/scripts/highlighter/utils/domStability.js
+++ b/scripts/highlighter/utils/domStability.js
@@ -11,6 +11,9 @@
  * @param {string} [options.containerSelector] - 要監視的容器選擇器
  * @param {number} [options.stabilityThresholdMs=150] - 穩定閾值（毫秒）
  * @param {number} [options.maxWaitMs=5000] - 最大等待時間（毫秒）
+ * @param {number} [options.initialGracePeriodMs] - 首次 stability check 之前的等待時間;
+ *   預設等於 `stabilityThresholdMs`(維持向後相容);傳 0 則 caller opt-in zero-grace 模式,
+ *   只有實際發生 mutation 才會延後返回。
  * @returns {Promise<boolean>} true=成功穩定, false=超時或找不到容器
  * @example
  * const isStable = await waitForDOMStability();
@@ -20,9 +23,21 @@
  *   stabilityThresholdMs: 200,
  *   maxWaitMs: 3000
  * });
+ * @example
+ * // zero-grace: 沒 mutation 就立即返回 true
+ * const isStable = await waitForDOMStability({
+ *   stabilityThresholdMs: 150,
+ *   maxWaitMs: 500,
+ *   initialGracePeriodMs: 0,
+ * });
  */
 export function waitForDOMStability(options = {}) {
-  const { containerSelector = null, stabilityThresholdMs = 150, maxWaitMs = 5000 } = options;
+  const {
+    containerSelector = null,
+    stabilityThresholdMs = 150,
+    maxWaitMs = 5000,
+    initialGracePeriodMs = stabilityThresholdMs,
+  } = options;
 
   return new Promise(resolve => {
     // 確保 document.body 存在
@@ -47,7 +62,11 @@ export function waitForDOMStability(options = {}) {
     let stabilityTimerId = null;
     let maxWaitTimerId = null;
     let idleCallbackId = null;
-    let lastMutationTime = Date.now();
+    // 將 lastMutationTime 退回 stabilityThresholdMs,如此首次 stability check
+    // 在 caller 傳 initialGracePeriodMs=0 時即可立即判定穩定;一旦 MutationObserver
+    // 觀察到實際 mutation,lastMutationTime 會被更新成現在,演算法退回原行為。
+    let lastMutationTime = Date.now() - stabilityThresholdMs;
+    let isFirstCheck = true;
 
     // 清理所有資源
     const cleanup = () => {
@@ -93,13 +112,16 @@ export function waitForDOMStability(options = {}) {
         idleCallbackId = null;
       }
 
+      const delay = isFirstCheck ? initialGracePeriodMs : stabilityThresholdMs;
+      isFirstCheck = false;
+
       // 優先使用 requestIdleCallback
       if (typeof requestIdleCallback === 'undefined') {
         stabilityTimerId = setTimeout(() => {
           if (!checkStability()) {
             scheduleStabilityCheck();
           }
-        }, stabilityThresholdMs);
+        }, delay);
       } else {
         idleCallbackId = requestIdleCallback(
           () => {
@@ -107,7 +129,7 @@ export function waitForDOMStability(options = {}) {
               stabilityTimerId = setTimeout(scheduleStabilityCheck, stabilityThresholdMs);
             }
           },
-          { timeout: stabilityThresholdMs }
+          { timeout: delay }
         );
       }
     };

--- a/tests/unit/content/extractors/ContentExtractor.test.js
+++ b/tests/unit/content/extractors/ContentExtractor.test.js
@@ -245,6 +245,7 @@ describe('ContentExtractor', () => {
       expect(domStability.waitForDOMStability).toHaveBeenCalledWith({
         stabilityThresholdMs: DOM_STABILITY.THRESHOLD_MS,
         maxWaitMs: DOM_STABILITY.MAX_WAIT_MS,
+        initialGracePeriodMs: 0,
       });
       expect(result.content).toBe('<div>Async Readability</div>');
     });

--- a/tests/unit/highlighter/utils/domStability.test.js
+++ b/tests/unit/highlighter/utils/domStability.test.js
@@ -60,5 +60,40 @@ describe('utils/domStability', () => {
       const result = await promise;
       expect(result).toBe(true);
     });
+
+    test('initialGracePeriodMs=0 應該在 0ms 後即判定穩定(無 mutation 時)', async () => {
+      const promise = waitForDOMStability({
+        stabilityThresholdMs: 150,
+        maxWaitMs: 500,
+        initialGracePeriodMs: 0,
+      });
+
+      // 推進 0ms 即跑首次 check;預設沒 mutation,該立即 resolve(true)。
+      jest.advanceTimersByTime(0);
+
+      const result = await promise;
+      expect(result).toBe(true);
+    });
+
+    test('initialGracePeriodMs=0 + 在 grace 後 mutation,後續仍要等 thresholdMs', async () => {
+      const container = document.createElement('div');
+      container.id = 'mut-test';
+      document.body.append(container);
+
+      const promise = waitForDOMStability({
+        containerSelector: '#mut-test',
+        stabilityThresholdMs: 100,
+        maxWaitMs: 1000,
+        initialGracePeriodMs: 0,
+      });
+
+      // 立刻 mutate,首次 check 在 0ms 跑時 lastMutationTime 已被更新。
+      container.append(document.createElement('span'));
+
+      jest.advanceTimersByTime(150);
+
+      const result = await promise;
+      expect(result).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
### 摘要
優化 NextJs fallback 的 DOM 穩定性檢查，減少不必要的等待時間。

### 變更內容
- 新增可選的 `initialGracePeriodMs` 參數，預設為 `stabilityThresholdMs`，允許在無 mutation 時立即返回穩定結果。
- 當 `initialGracePeriodMs` 設為 0 時，首次穩定性檢查將立即執行。
- 調整 `waitForDOMStability` 函數以支持新的參數，並更新相關測試。

### 測試方式
- 新增測試案例以驗證 `initialGracePeriodMs` 的行為，確保在無 mutation 時能立即返回穩定結果。

### 潛在風險
無顯著風險。

