### PR TITLE
refactor: reduce DomConverter complexity

### DIFF
--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -118,11 +118,25 @@ function resolveStyle(styleKey, highlight) {
  * @returns {number} 比對分數
  */
 function scoreCandidate(fullText, idx, text, context) {
-  const { prefix, suffix } = context;
+  const indexedFullText = buildSearchIndex(fullText);
+  const normalizedText = normalizeTextForSearch(text);
+  const candidate =
+    findCandidateMatches(indexedFullText, normalizedText).find(match => match.start === idx) ??
+    createFallbackCandidate(idx, normalizedText);
+
+  return scoreCandidateMatch(indexedFullText, candidate, context);
+}
+
+function scoreCandidateMatch(indexedFullText, candidate, context) {
+  const prefix = normalizeTextForSearch(context.prefix, { trim: false });
+  const suffix = normalizeTextForSearch(context.suffix, { trim: false });
   let score = 0;
 
   if (prefix) {
-    const actualPrefix = fullText.slice(Math.max(0, idx - prefix.length), idx);
+    const actualPrefix = indexedFullText.text.slice(
+      Math.max(0, candidate.normalizedStart - prefix.length),
+      candidate.normalizedStart
+    );
     if (actualPrefix.endsWith(prefix)) {
       score += HIGHLIGHT_MATCH_SCORING.EXACT_CONTEXT_SCORE;
     } else if (
@@ -133,7 +147,10 @@ function scoreCandidate(fullText, idx, text, context) {
   }
 
   if (suffix) {
-    const actualSuffix = fullText.slice(idx + text.length, idx + text.length + suffix.length);
+    const actualSuffix = indexedFullText.text.slice(
+      candidate.normalizedEnd,
+      candidate.normalizedEnd + suffix.length
+    );
     if (actualSuffix.startsWith(suffix)) {
       score += HIGHLIGHT_MATCH_SCORING.EXACT_CONTEXT_SCORE;
     } else if (
@@ -146,15 +163,63 @@ function scoreCandidate(fullText, idx, text, context) {
   return score;
 }
 
-function findCandidatePositions(fullText, text) {
+function normalizeTextForSearch(text, options = {}) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+
+  const normalized = text.replaceAll(/\s+/g, ' ');
+  return options.trim === false ? normalized : normalized.trim();
+}
+
+function createFallbackCandidate(idx, normalizedText) {
+  return {
+    start: idx,
+    end: idx + normalizedText.length,
+    normalizedStart: idx,
+    normalizedEnd: idx + normalizedText.length,
+  };
+}
+
+function buildSearchIndex(fullText) {
+  const charMap = [];
+  let text = '';
+  let index = 0;
+
+  while (index < fullText.length) {
+    if (/\s/.test(fullText[index])) {
+      const whitespaceStart = index;
+      while (index < fullText.length && /\s/.test(fullText[index])) {
+        index++;
+      }
+      text += ' ';
+      charMap.push({ start: whitespaceStart, end: index });
+      continue;
+    }
+
+    text += fullText[index];
+    charMap.push({ start: index, end: index + 1 });
+    index++;
+  }
+
+  return { text, charMap };
+}
+
+function findCandidateMatches(indexedFullText, normalizedText) {
   const candidates = [];
   let searchStart = 0;
-  while (searchStart < fullText.length) {
-    const idx = fullText.indexOf(text, searchStart);
+  while (searchStart < indexedFullText.text.length) {
+    const idx = indexedFullText.text.indexOf(normalizedText, searchStart);
     if (idx === -1) {
       break;
     }
-    candidates.push(idx);
+    const lastCharMap = indexedFullText.charMap[idx + normalizedText.length - 1];
+    candidates.push({
+      start: indexedFullText.charMap[idx].start,
+      end: lastCharMap.end,
+      normalizedStart: idx,
+      normalizedEnd: idx + normalizedText.length,
+    });
     searchStart = idx + 1;
   }
   return candidates;
@@ -172,7 +237,11 @@ function findCandidatePositions(fullText, text) {
 function extractContextFromRangeInfo(rangeInfo) {
   const prefix = rangeInfo?.prefix || '';
   const suffix = rangeInfo?.suffix || '';
-  return { prefix, suffix, hasContext: Boolean(prefix || suffix) };
+  return {
+    prefix,
+    suffix,
+    hasContext: Boolean(normalizeTextForSearch(prefix) || normalizeTextForSearch(suffix)),
+  };
 }
 
 /**
@@ -181,17 +250,16 @@ function extractContextFromRangeInfo(rangeInfo) {
  * 無上下文資訊時直接接受;有上下文資訊時要求 prefix/suffix 至少部分重合,
  * 否則視為跨段落殘留誤命中而拒絕。
  *
- * @param {string} fullText - 拼接後的純文本
- * @param {number} idx - 唯一候選的位置索引
- * @param {string} text - 標註文字
+ * @param {{ text: string, charMap: Array<{start: number, end: number}> }} indexedFullText - 正規化文字索引
+ * @param {{ start: number, end: number, normalizedStart: number, normalizedEnd: number }} candidate - 候選匹配
  * @param {{ prefix: string, suffix: string, hasContext: boolean }} context - 消歧義上下文
- * @returns {number} 接受時為 idx,拒絕時為 -1
+ * @returns {object|null} 接受時為候選匹配，拒絕時為 null
  */
-function resolveSingleCandidate(fullText, idx, text, context) {
+function resolveSingleCandidate(indexedFullText, candidate, context) {
   if (!context.hasContext) {
-    return idx;
+    return candidate;
   }
-  return scoreCandidate(fullText, idx, text, context) > 0 ? idx : -1;
+  return scoreCandidateMatch(indexedFullText, candidate, context) > 0 ? candidate : null;
 }
 
 /**
@@ -199,28 +267,27 @@ function resolveSingleCandidate(fullText, idx, text, context) {
  *
  * 相同分數回退到第一個候選;有上下文資訊但全部候選評分為 0 時拒絕匹配。
  *
- * @param {string} fullText - 拼接後的純文本
- * @param {Array<number>} candidates - 候選位置索引陣列(MUST length > 0)
- * @param {string} text - 標註文字
+ * @param {{ text: string, charMap: Array<{start: number, end: number}> }} indexedFullText - 正規化文字索引
+ * @param {Array<{ start: number, end: number, normalizedStart: number, normalizedEnd: number }>} candidates - 候選匹配陣列(MUST length > 0)
  * @param {{ prefix: string, suffix: string, hasContext: boolean }} context - 消歧義上下文
- * @returns {number} 最佳候選位置;若有上下文但無任何候選分數 > 0 則回 -1
+ * @returns {object|null} 最佳候選匹配;若有上下文但無任何候選分數 > 0 則回 null
  */
-function resolveBestScoringCandidate(fullText, candidates, text, context) {
-  let bestIdx = candidates[0];
+function resolveBestScoringCandidate(indexedFullText, candidates, context) {
+  let bestCandidate = candidates[0];
   let bestScore = -1;
 
-  for (const idx of candidates) {
-    const score = scoreCandidate(fullText, idx, text, context);
+  for (const candidate of candidates) {
+    const score = scoreCandidateMatch(indexedFullText, candidate, context);
     if (score > bestScore) {
       bestScore = score;
-      bestIdx = idx;
+      bestCandidate = candidate;
     }
   }
 
   if (context.hasContext && bestScore === 0) {
-    return -1;
+    return null;
   }
-  return bestIdx;
+  return bestCandidate;
 }
 
 // ============================================================================
@@ -239,32 +306,39 @@ function resolveBestScoringCandidate(fullText, candidates, text, context) {
  * @returns {number} 匹配到的字符偏移量（在拼接純文本中），-1 表示未找到
  */
 function findHighlightPosition(richTextArray, highlight, fullText) {
+  const match = findHighlightMatch(richTextArray, highlight, fullText);
+  return match ? match.start : -1;
+}
+
+function findHighlightMatch(richTextArray, highlight, fullText) {
   if (!Array.isArray(richTextArray)) {
-    return -1;
+    return null;
   }
   if (typeof fullText !== 'string') {
     throw new TypeError('[HighlightMerger] fullText is required');
   }
 
   const { text, rangeInfo } = highlight;
-  if (!text || fullText.length === 0) {
-    return -1;
+  const normalizedText = normalizeTextForSearch(text);
+  if (!normalizedText || fullText.length === 0) {
+    return null;
   }
 
   const context = extractContextFromRangeInfo(rangeInfo);
+  const indexedFullText = buildSearchIndex(fullText);
 
   // 2. 找出所有匹配位置
-  const candidates = findCandidatePositions(fullText, text);
+  const candidates = findCandidateMatches(indexedFullText, normalizedText);
 
   if (candidates.length === 0) {
-    return -1;
+    return null;
   }
   if (candidates.length === 1) {
-    return resolveSingleCandidate(fullText, candidates[0], text, context);
+    return resolveSingleCandidate(indexedFullText, candidates[0], context);
   }
 
   // 3. prefix/suffix 計分消歧義：取最高分的候選
-  return resolveBestScoringCandidate(fullText, candidates, text, context);
+  return resolveBestScoringCandidate(indexedFullText, candidates, context);
 }
 
 /**
@@ -407,9 +481,9 @@ function applyHighlightsToBlock(block, highlights, styleKey, consumed) {
     if (consumed?.has(key)) {
       continue;
     }
-    const pos = findHighlightPosition(richTextArray, hl, fullText);
-    if (pos !== -1) {
-      matches.push({ start: pos, end: pos + hl.text.length, highlight: hl });
+    const match = findHighlightMatch(richTextArray, hl, fullText);
+    if (match) {
+      matches.push({ start: match.start, end: match.end, highlight: hl });
       if (consumed) {
         consumed.add(key);
       }

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -338,10 +338,7 @@ class DomConverter {
 
   createParagraphBlock(node) {
     const imageOnlyParagraphImages = DomConverter._getImageOnlyParagraphImages(node);
-    if (imageOnlyParagraphImages.length === 1) {
-      return this.createImageBlock(imageOnlyParagraphImages[0]);
-    }
-    if (imageOnlyParagraphImages.length > 1) {
+    if (imageOnlyParagraphImages.length > 0) {
       return imageOnlyParagraphImages.map(img => this.createImageBlock(img)).filter(Boolean);
     }
 
@@ -352,14 +349,16 @@ class DomConverter {
 
     const richText = this.parseRichText(node);
     if (richText.length === 0) {
-      return null;
+      return [];
     }
 
-    return {
-      object: 'block',
-      type: 'paragraph',
-      paragraph: { rich_text: richText },
-    };
+    return [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { rich_text: richText },
+      },
+    ];
   }
 
   static _getImageOnlyParagraphImages(node) {

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -973,14 +973,14 @@ class DomConverter {
     const bounds = DomConverter._findRichTextContentBounds(richTextArray);
 
     for (const [index, rt] of richTextArray.entries()) {
-      const content = DomConverter._formatRichTextContent(
-        rt.text?.content ?? '',
+      const context = {
         index,
-        count,
-        bounds.firstNonEmptyIndex,
-        bounds.lastNonEmptyIndex,
-        preserveCodeWhitespace
-      );
+        totalCount: count,
+        firstNonEmptyIndex: bounds.firstNonEmptyIndex,
+        lastNonEmptyIndex: bounds.lastNonEmptyIndex,
+        preserveCodeWhitespace,
+      };
+      const content = DomConverter._formatRichTextContent(rt.text?.content ?? '', context);
       const appendResult = DomConverter._appendFormattedRichText(
         processed,
         rt,
@@ -997,38 +997,35 @@ class DomConverter {
     return processed;
   }
 
-  static _formatRichTextContent(
-    content,
-    index,
-    totalCount,
-    firstNonEmptyIndex,
-    lastNonEmptyIndex,
-    preserveCodeWhitespace
-  ) {
+  static _formatRichTextContent(content, context) {
     // code rich_text 的前後空白與換行是有語意的，需保留原始內容；
     // 但若整組內容都只有空白，仍維持既有 fallback 路徑，由 _cleanRichText 補單一空格。
-    if (preserveCodeWhitespace) {
-      return firstNonEmptyIndex === -1 ? '' : content;
+    if (context.preserveCodeWhitespace) {
+      return context.firstNonEmptyIndex === -1 ? '' : content;
     }
 
     // 邊界之外的純空白節點：直接返回空字串（會被過濾掉）
-    if (index < firstNonEmptyIndex || index > lastNonEmptyIndex) {
+    if (context.index < context.firstNonEmptyIndex || context.index > context.lastNonEmptyIndex) {
       return '';
     }
 
+    return DomConverter._formatBoundaryRichTextContent(content, context);
+  }
+
+  static _formatBoundaryRichTextContent(content, context) {
     let formatted = content;
 
     // 只對第一個非空白元素做 trimStart
-    if (index === firstNonEmptyIndex) {
+    if (context.index === context.firstNonEmptyIndex) {
       formatted = formatted.trimStart();
     }
 
     // 只對最後一個非空白元素做 trimEnd
-    if (index === lastNonEmptyIndex) {
+    if (context.index === context.lastNonEmptyIndex) {
       formatted = formatted.trimEnd();
     }
 
-    if (!formatted.trim() && totalCount === 1) {
+    if (!formatted.trim() && context.totalCount === 1) {
       return ' ';
     }
 

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -10,19 +10,7 @@
 
 // ImageUtils 由 Rollup intro 從 window.ImageUtils 注入
 // 使用 getter 函數以支持測試時的 mock 覆蓋
-const hasWindowScope = () => globalThis.window !== undefined;
-const hasGlobalScope = () => globalThis.global !== undefined;
-const getImageUtils = () => {
-  if (hasWindowScope()) {
-    return globalThis.ImageUtils ?? {};
-  }
-
-  if (hasGlobalScope()) {
-    return globalThis.ImageUtils ?? {};
-  }
-
-  return {};
-};
+const getImageUtils = () => globalThis.ImageUtils ?? {};
 
 import Logger from '../../utils/Logger.js';
 

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -933,16 +933,6 @@ class DomConverter {
     return { firstNonEmptyIndex, lastNonEmptyIndex };
   }
 
-  static _buildRichTextFormatContext(index, totalCount, bounds, preserveCodeWhitespace) {
-    return {
-      index,
-      totalCount,
-      firstNonEmptyIndex: bounds.firstNonEmptyIndex,
-      lastNonEmptyIndex: bounds.lastNonEmptyIndex,
-      preserveCodeWhitespace,
-    };
-  }
-
   static _cloneRichTextWithContent(rt, content) {
     return {
       ...rt,
@@ -984,13 +974,14 @@ class DomConverter {
     const bounds = DomConverter._findRichTextContentBounds(richTextArray);
 
     for (const [index, rt] of richTextArray.entries()) {
-      const context = DomConverter._buildRichTextFormatContext(
+      const content = DomConverter._formatRichTextContent(
+        rt.text?.content ?? '',
         index,
         count,
-        bounds,
+        bounds.firstNonEmptyIndex,
+        bounds.lastNonEmptyIndex,
         preserveCodeWhitespace
       );
-      const content = DomConverter._formatRichTextContent(rt.text?.content ?? '', context);
       const appendResult = DomConverter._appendFormattedRichText(
         processed,
         rt,
@@ -1007,64 +998,42 @@ class DomConverter {
     return processed;
   }
 
-  static _formatRichTextContent(content, context) {
+  static _formatRichTextContent(
+    content,
+    index,
+    totalCount,
+    firstNonEmptyIndex,
+    lastNonEmptyIndex,
+    preserveCodeWhitespace
+  ) {
     // code rich_text 的前後空白與換行是有語意的，需保留原始內容；
     // 但若整組內容都只有空白，仍維持既有 fallback 路徑，由 _cleanRichText 補單一空格。
-    if (context.preserveCodeWhitespace) {
-      return DomConverter._formatCodeRichTextContent(content, context);
+    if (preserveCodeWhitespace) {
+      return firstNonEmptyIndex === -1 ? '' : content;
     }
 
     // 邊界之外的純空白節點：直接返回空字串（會被過濾掉）
-    if (DomConverter._isOutsideRichTextBounds(context)) {
+    if (index < firstNonEmptyIndex || index > lastNonEmptyIndex) {
       return '';
     }
 
-    const formatted = DomConverter._trimRichTextBoundaryContent(content, context);
-    if (DomConverter._shouldUseSingleWhitespaceFallback(formatted, context.totalCount)) {
-      return ' ';
-    }
-
-    return formatted;
-  }
-
-  static _formatCodeRichTextContent(content, context) {
-    if (context.firstNonEmptyIndex === -1) {
-      return '';
-    }
-
-    return content;
-  }
-
-  static _isOutsideRichTextBounds(context) {
-    if (context.index < context.firstNonEmptyIndex) {
-      return true;
-    }
-
-    return context.index > context.lastNonEmptyIndex;
-  }
-
-  static _trimRichTextBoundaryContent(content, context) {
     let formatted = content;
 
     // 只對第一個非空白元素做 trimStart
-    if (context.index === context.firstNonEmptyIndex) {
+    if (index === firstNonEmptyIndex) {
       formatted = formatted.trimStart();
     }
 
     // 只對最後一個非空白元素做 trimEnd
-    if (context.index === context.lastNonEmptyIndex) {
+    if (index === lastNonEmptyIndex) {
       formatted = formatted.trimEnd();
     }
 
-    return formatted;
-  }
-
-  static _shouldUseSingleWhitespaceFallback(formatted, totalCount) {
-    if (formatted.trim()) {
-      return false;
+    if (!formatted.trim() && totalCount === 1) {
+      return ' ';
     }
 
-    return totalCount === 1;
+    return formatted;
   }
 
   static _isUnsafeListChild(child) {

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -349,11 +349,12 @@ class DomConverter {
   }
 
   createParagraphBlock(node) {
-    // 檢查是否包含圖片（Image inside P）
-    const img = node.querySelector('img');
-    // 如果段落只包含圖片，直接返回圖片 Block
-    if (DomConverter._isImageOnlyParagraph(node, img)) {
-      return this.createImageBlock(img);
+    const imageOnlyParagraphImages = DomConverter._getImageOnlyParagraphImages(node);
+    if (imageOnlyParagraphImages.length === 1) {
+      return this.createImageBlock(imageOnlyParagraphImages[0]);
+    }
+    if (imageOnlyParagraphImages.length > 1) {
+      return imageOnlyParagraphImages.map(img => this.createImageBlock(img)).filter(Boolean);
     }
 
     // 檢查是否是 "偽裝列表" (List-like paragraph)
@@ -373,12 +374,12 @@ class DomConverter {
     };
   }
 
-  static _isImageOnlyParagraph(node, img) {
-    if (!img) {
-      return false;
+  static _getImageOnlyParagraphImages(node) {
+    if (node.textContent.trim().length > 0) {
+      return [];
     }
 
-    return node.textContent.trim().length === 0;
+    return Array.from(node.querySelectorAll('img'));
   }
 
   processDiv(node) {
@@ -536,11 +537,21 @@ class DomConverter {
   }
 
   _resolveImageExternalUrl(src, cleanImageUrl) {
+    let resolved;
     try {
-      const resolved = new URL(src, document.baseURI).href;
-      return cleanImageUrl ? cleanImageUrl(resolved) : resolved;
+      resolved = new URL(src, document.baseURI).href;
     } catch {
       return src;
+    }
+
+    if (typeof cleanImageUrl !== 'function') {
+      return resolved;
+    }
+
+    try {
+      return cleanImageUrl(resolved);
+    } catch {
+      return resolved;
     }
   }
 

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -10,10 +10,19 @@
 
 // ImageUtils 由 Rollup intro 從 window.ImageUtils 注入
 // 使用 getter 函數以支持測試時的 mock 覆蓋
-const getImageUtils = () =>
-  (globalThis.window !== undefined && globalThis.ImageUtils) ||
-  (globalThis.global !== undefined && globalThis.ImageUtils) ||
-  {};
+const hasWindowScope = () => globalThis.window !== undefined;
+const hasGlobalScope = () => globalThis.global !== undefined;
+const getImageUtils = () => {
+  if (hasWindowScope()) {
+    return globalThis.ImageUtils ?? {};
+  }
+
+  if (hasGlobalScope()) {
+    return globalThis.ImageUtils ?? {};
+  }
+
+  return {};
+};
 
 import Logger from '../../utils/Logger.js';
 
@@ -109,6 +118,40 @@ const UNSAFE_LIST_CHILDREN_FOR_FLATTENING = new Set([
 ]);
 
 /**
+ * HTML 標籤到 Notion Rich Text Annotations 屬性名稱的映射表
+ */
+const INLINE_ANNOTATION_BY_TAG = {
+  B: 'bold',
+  STRONG: 'bold',
+  I: 'italic',
+  EM: 'italic',
+  U: 'underline',
+  INS: 'underline',
+  S: 'strikethrough',
+  DEL: 'strikethrough',
+  STRIKE: 'strikethrough',
+  CODE: 'code',
+  KBD: 'code',
+  SAMP: 'code',
+  TT: 'code',
+};
+
+/**
+ * 用於搜尋代碼語言提示的 HTML 屬性清單
+ */
+const CODE_LANGUAGE_HINT_ATTRIBUTES = ['data-language', 'data-lang', 'language', 'lang'];
+
+/**
+ * 用於搜尋代碼語言提示的 class 名稱前綴清單
+ */
+const CODE_LANGUAGE_CLASS_PREFIXES = ['language-', 'lang-'];
+
+/**
+ * Notion block children 遞迴保留深度上限
+ */
+const MAX_BLOCK_CHILD_DEPTH = 1;
+
+/**
  * DomConverter 類
  * 負責將 HTML DOM 節點轉換為 Notion Blocks
  */
@@ -193,20 +236,38 @@ class DomConverter {
     const blocks = [];
     parentNode.childNodes.forEach(child => {
       const result = this.processNode(child);
-      if (result) {
-        if (Array.isArray(result)) {
-          // 只 push 有效的 blocks（必須有 type）
-          result.forEach(item => {
-            if (item && typeof item === 'object' && item.type) {
-              blocks.push(item);
-            }
-          });
-        } else if (typeof result === 'object' && result.type) {
-          blocks.push(result);
-        }
+      if (!result) {
+        return;
       }
+
+      if (Array.isArray(result)) {
+        result.forEach(item => DomConverter._appendValidBlock(blocks, item));
+        return;
+      }
+
+      DomConverter._appendValidBlock(blocks, result);
     });
     return blocks;
+  }
+
+  static _appendValidBlock(blocks, item) {
+    if (!DomConverter._isBlockLike(item)) {
+      return;
+    }
+
+    blocks.push(item);
+  }
+
+  static _isBlockLike(item) {
+    if (!item) {
+      return false;
+    }
+
+    if (typeof item !== 'object') {
+      return false;
+    }
+
+    return Boolean(item.type);
   }
 
   /**
@@ -220,8 +281,7 @@ class DomConverter {
       return null;
     }
 
-    // 忽略隱藏元素
-    if (node.style?.display === 'none' || node.style?.visibility === 'hidden') {
+    if (DomConverter._isHiddenElement(node)) {
       return null;
     }
 
@@ -235,6 +295,14 @@ class DomConverter {
     // 但如果是 inline 元素被當作 block，可能需要包裝成 paragraph？
     // 這裡我們簡單地採用穿透策略，嘗試提取有用的子 Block
     return this.processChildren(node);
+  }
+
+  static _isHiddenElement(node) {
+    if (node.style?.display === 'none') {
+      return true;
+    }
+
+    return node.style?.visibility === 'hidden';
   }
 
   processListItem(node) {
@@ -284,7 +352,7 @@ class DomConverter {
     // 檢查是否包含圖片（Image inside P）
     const img = node.querySelector('img');
     // 如果段落只包含圖片，直接返回圖片 Block
-    if (img && node.textContent.trim().length === 0) {
+    if (DomConverter._isImageOnlyParagraph(node, img)) {
       return this.createImageBlock(img);
     }
 
@@ -305,36 +373,48 @@ class DomConverter {
     };
   }
 
+  static _isImageOnlyParagraph(node, img) {
+    if (!img) {
+      return false;
+    }
+
+    return node.textContent.trim().length === 0;
+  }
+
   processDiv(node) {
     // Div 是一個通用容器。
     // 策略：直接處理子節點 (Unwrap)
     return this.processChildren(node);
   }
 
+  _appendBlocks(blocks, result) {
+    if (!result) {
+      return;
+    }
+    if (Array.isArray(result)) {
+      blocks.push(...result);
+    } else {
+      blocks.push(result);
+    }
+  }
+
+  _appendConvertedListChild(blocks, child, type) {
+    if (child.nodeName === 'LI') {
+      const liBlock = this.createListItemBlock(child, type);
+      if (liBlock) {
+        blocks.push(liBlock);
+      }
+    } else {
+      const result = this.processNode(child);
+      this._appendBlocks(blocks, result);
+    }
+  }
+
   processList(node, type) {
     const blocks = [];
-
-    // 遍歷子節點，只處理 LI
     node.childNodes.forEach(child => {
-      if (child.nodeName === 'LI') {
-        // 處理 LI
-        const liBlock = this.createListItemBlock(child, type);
-        if (liBlock) {
-          blocks.push(liBlock);
-        }
-      } else {
-        // 處理非 LI 直接子節點 (可能是嵌套錯誤的 HTML，嘗試穿透)
-        const result = this.processNode(child);
-        if (result) {
-          if (Array.isArray(result)) {
-            blocks.push(...result);
-          } else {
-            blocks.push(result);
-          }
-        }
-      }
+      this._appendConvertedListChild(blocks, child, type);
     });
-
     return blocks;
   }
 
@@ -381,11 +461,19 @@ class DomConverter {
     } else if (child.nodeName === 'P') {
       const pRichText = this.parseRichText(child);
       richTexts.push(...pRichText);
-    } else if (child.nodeType !== Node.ELEMENT_NODE || DomConverter.isInlineNode(child)) {
+    } else if (DomConverter._isListItemInlineContent(child)) {
       this._processTextInsideItem(child, richTexts);
     } else {
       this._processBlockInsideItem(child, childrenBlocks);
     }
+  }
+
+  static _isListItemInlineContent(child) {
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      return true;
+    }
+
+    return DomConverter.isInlineNode(child);
   }
 
   _processListInsideItem(child, childrenBlocks) {
@@ -398,7 +486,7 @@ class DomConverter {
 
   _processTextInsideItem(child, richTexts) {
     const rt = this.processInlineNode(child);
-    if (rt && rt.length > 0) {
+    if (DomConverter._hasRichTextItems(rt)) {
       richTexts.push(...rt);
     }
   }
@@ -431,8 +519,8 @@ class DomConverter {
 
   static createCodeBlock(node) {
     // PRE 通常包含 CODE
-    const codeNode = node.querySelector('code') || node;
-    const text = codeNode.textContent || '';
+    const codeNode = node.querySelector('code') ?? node;
+    const text = codeNode.textContent ?? '';
     const language = DomConverter.extractCodeLanguage(node, codeNode);
 
     return {
@@ -443,6 +531,27 @@ class DomConverter {
           { type: 'text', text: { content: text.slice(0, Math.max(0, MAX_TEXT_LENGTH)) } },
         ],
         language,
+      },
+    };
+  }
+
+  _resolveImageExternalUrl(src, cleanImageUrl) {
+    try {
+      const resolved = new URL(src, document.baseURI).href;
+      return cleanImageUrl ? cleanImageUrl(resolved) : resolved;
+    } catch {
+      return src;
+    }
+  }
+
+  _buildImageBlock(finalUrl, alt) {
+    return {
+      object: 'block',
+      type: 'image',
+      image: {
+        type: 'external',
+        external: { url: finalUrl },
+        caption: alt ? [{ type: 'text', text: { content: alt } }] : [],
       },
     };
   }
@@ -464,16 +573,10 @@ class DomConverter {
       return null;
     }
 
-    let finalUrl = src;
-    try {
-      finalUrl = new URL(src, document.baseURI).href;
-      finalUrl = cleanImageUrl?.(finalUrl) ?? finalUrl;
-    } catch {
-      // ignore invalid url
-    }
+    const finalUrl = this._resolveImageExternalUrl(src, cleanImageUrl);
 
     // 使用已清理的 URL 進行驗證，避免重複標準化
-    if (isValidCleanedImageUrl && !isValidCleanedImageUrl(finalUrl)) {
+    if (DomConverter._isInvalidCleanedImageUrl(isValidCleanedImageUrl, finalUrl)) {
       Logger.warn('[Content] Dropping invalid image to ensure page save', {
         action: 'createImageBlock',
         url: sanitizeUrlForLogging(finalUrl),
@@ -481,37 +584,39 @@ class DomConverter {
       return null;
     }
 
-    const alt = node.getAttribute('alt') || '';
-
-    const block = {
-      object: 'block',
-      type: 'image',
-      image: {
-        type: 'external',
-        external: { url: finalUrl },
-        caption: alt ? [{ type: 'text', text: { content: alt } }] : [],
-      },
-    };
+    const alt = node.getAttribute('alt') ?? '';
+    const block = this._buildImageBlock(finalUrl, alt);
 
     this.imageCount++; // Increment counter
     return block;
   }
 
-  processFigure(node) {
-    // 處理 Figure，通常包含 Img 和 Figcaption
-    const img = node.querySelector('img');
-    if (img) {
-      const block = this.createImageBlock(img);
-      const caption = node.querySelector('figcaption');
-      if (block && caption) {
-        const captionText = caption.textContent.trim();
-        if (captionText) {
-          block.image.caption = [{ type: 'text', text: { content: captionText } }];
-        }
-      }
-      return block;
+  static _isInvalidCleanedImageUrl(isValidCleanedImageUrl, finalUrl) {
+    if (!isValidCleanedImageUrl) {
+      return false;
     }
-    return null;
+
+    return !isValidCleanedImageUrl(finalUrl);
+  }
+
+  processFigure(node) {
+    const img = node.querySelector('img');
+    if (!img) {
+      return null;
+    }
+
+    const block = this.createImageBlock(img);
+    if (!block) {
+      return null;
+    }
+
+    const figcaption = node.querySelector('figcaption');
+    const captionText = figcaption?.textContent.trim();
+    if (captionText) {
+      block.image.caption = [{ type: 'text', text: { content: captionText } }];
+    }
+
+    return block;
   }
 
   // --- Rich Text Parsing ---
@@ -520,7 +625,7 @@ class DomConverter {
     const richTexts = [];
     node.childNodes.forEach(child => {
       const rt = this.processInlineNode(child);
-      if (rt && rt.length > 0) {
+      if (DomConverter._hasRichTextItems(rt)) {
         richTexts.push(...rt);
       }
     });
@@ -546,7 +651,7 @@ class DomConverter {
     const childrenRichTexts = [];
     node.childNodes.forEach(child => {
       const rt = this.processInlineNode(child, newAnnotations);
-      if (rt && rt.length > 0) {
+      if (DomConverter._hasRichTextItems(rt)) {
         if (link) {
           this._applyLinkToRichTexts(rt, link);
         }
@@ -573,36 +678,34 @@ class DomConverter {
 
   _mergeAnnotations(node, annotations) {
     const newAnnotations = { ...annotations };
-    const tagName = node.tagName;
-
-    if (['B', 'STRONG'].includes(tagName)) {
-      newAnnotations.bold = true;
-    } else if (['I', 'EM'].includes(tagName)) {
-      newAnnotations.italic = true;
-    } else if (['U', 'INS'].includes(tagName)) {
-      newAnnotations.underline = true;
-    } else if (['S', 'DEL', 'STRIKE'].includes(tagName)) {
-      newAnnotations.strikethrough = true;
-    } else if (['CODE', 'KBD', 'SAMP', 'TT'].includes(tagName)) {
-      newAnnotations.code = true;
+    const prop = INLINE_ANNOTATION_BY_TAG[node.tagName];
+    if (prop) {
+      newAnnotations[prop] = true;
     }
-
     return newAnnotations;
   }
 
+  _isSupportedLinkProtocol(url) {
+    return ['http:', 'https:'].includes(url.protocol);
+  }
+
   _extractLink(node) {
-    if (node.tagName === 'A') {
-      const href = node.getAttribute('href');
-      if (href) {
-        try {
-          const url = new URL(href, document.baseURI);
-          if (['http:', 'https:'].includes(url.protocol)) {
-            return { url: url.href };
-          }
-        } catch {
-          /* ignore */
-        }
+    if (node.tagName !== 'A') {
+      return null;
+    }
+
+    const href = node.getAttribute('href');
+    if (!href) {
+      return null;
+    }
+
+    try {
+      const url = new URL(href, document.baseURI);
+      if (this._isSupportedLinkProtocol(url)) {
+        return { url: url.href };
       }
+    } catch {
+      // ignore
     }
     return null;
   }
@@ -623,6 +726,14 @@ class DomConverter {
     return inlineTags.includes(node.nodeName);
   }
 
+  static _hasRichTextItems(richTextItems) {
+    if (!richTextItems) {
+      return false;
+    }
+
+    return richTextItems.length > 0;
+  }
+
   static mergeRichText(richTextArray) {
     if (richTextArray.length === 0) {
       return [];
@@ -634,10 +745,7 @@ class DomConverter {
     for (let i = 1; i < richTextArray.length; i++) {
       const next = richTextArray[i];
       // 如果樣式和連結完全相同，則合併文本
-      if (
-        DomConverter.areAnnotationsEqual(current.annotations, next.annotations) &&
-        DomConverter.areLinksEqual(current.text?.link, next.text?.link)
-      ) {
+      if (DomConverter._canMergeRichText(current, next)) {
         current.text.content += next.text.content;
       } else {
         merged.push(current);
@@ -646,6 +754,14 @@ class DomConverter {
     }
     merged.push(current);
     return merged;
+  }
+
+  static _canMergeRichText(current, next) {
+    if (!DomConverter.areAnnotationsEqual(current.annotations, next.annotations)) {
+      return false;
+    }
+
+    return DomConverter.areLinksEqual(current.text?.link, next.text?.link);
   }
 
   static areAnnotationsEqual(a1 = {}, a2 = {}) {
@@ -670,6 +786,41 @@ class DomConverter {
     return NOTION_CODE_LANGUAGE_PLAIN_TEXT;
   }
 
+  static _addCodeLanguageAttributeHints(hints, node) {
+    CODE_LANGUAGE_HINT_ATTRIBUTES.forEach(attr => {
+      const value = node.getAttribute(attr);
+      const normalizedValue = DomConverter._normalizeCodeLanguageHintValue(value);
+      if (normalizedValue) {
+        hints.add(normalizedValue);
+      }
+    });
+  }
+
+  static _normalizeCodeLanguageHintValue(value) {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const normalizedValue = value.trim();
+    if (!normalizedValue) {
+      return null;
+    }
+
+    return normalizedValue;
+  }
+
+  static _addCodeLanguageClassHints(hints, node) {
+    Array.from(node.classList ?? []).forEach(token => {
+      const normalizedToken = token.toLowerCase();
+      for (const prefix of CODE_LANGUAGE_CLASS_PREFIXES) {
+        if (normalizedToken.startsWith(prefix)) {
+          hints.add(normalizedToken.slice(prefix.length));
+          break;
+        }
+      }
+    });
+  }
+
   static collectCodeLanguageHints(...nodes) {
     const hints = new Set();
 
@@ -678,21 +829,8 @@ class DomConverter {
         return;
       }
 
-      ['data-language', 'data-lang', 'language', 'lang'].forEach(attr => {
-        const value = node.getAttribute(attr);
-        if (typeof value === 'string' && value.trim()) {
-          hints.add(value.trim());
-        }
-      });
-
-      Array.from(node.classList || []).forEach(token => {
-        const normalizedToken = token.toLowerCase();
-        if (normalizedToken.startsWith('language-')) {
-          hints.add(normalizedToken.slice('language-'.length));
-        } else if (normalizedToken.startsWith('lang-')) {
-          hints.add(normalizedToken.slice('lang-'.length));
-        }
-      });
+      DomConverter._addCodeLanguageAttributeHints(hints, node);
+      DomConverter._addCodeLanguageClassHints(hints, node);
     });
 
     return [...hints];
@@ -708,12 +846,12 @@ class DomConverter {
       return null;
     }
 
-    const mapped = CODE_LANGUAGE_MAP[normalized] || normalized;
+    const mapped = CODE_LANGUAGE_MAP[normalized] ?? normalized;
     return NOTION_SUPPORTED_LANGUAGES.has(mapped) ? mapped : null;
   }
 
   static mapLanguage(lang) {
-    return DomConverter.resolveLanguageHint(lang) || NOTION_CODE_LANGUAGE_PLAIN_TEXT;
+    return DomConverter.resolveLanguageHint(lang) ?? NOTION_CODE_LANGUAGE_PLAIN_TEXT;
   }
 
   /**
@@ -726,13 +864,13 @@ class DomConverter {
    * @returns {Array} 清洗後的區塊陣列
    */
   static cleanBlocks(blocks, depth = 0) {
-    if (!blocks || !Array.isArray(blocks)) {
+    if (!DomConverter._isBlockArray(blocks)) {
       return [];
     }
 
     return blocks.flatMap(block => {
       // 1. Basic Validation
-      if (!block || typeof block !== 'object' || !block.type || !block[block.type]) {
+      if (!DomConverter._isCleanableBlock(block)) {
         return [];
       }
 
@@ -744,11 +882,27 @@ class DomConverter {
     });
   }
 
+  static _isBlockArray(blocks) {
+    if (!blocks) {
+      return false;
+    }
+
+    return Array.isArray(blocks);
+  }
+
+  static _isCleanableBlock(block) {
+    if (!DomConverter._isBlockLike(block)) {
+      return false;
+    }
+
+    return Boolean(block[block.type]);
+  }
+
   static _cleanRichText(block) {
     const type = block.type;
     const blockData = block[type];
 
-    if (!blockData.rich_text || blockData.rich_text.length === 0) {
+    if (!DomConverter._hasRichTextItems(blockData.rich_text)) {
       // Ensure rich_text exists if property is present?
       // Note: Some blocks might imply rich_text.
       // Original code checked block[type].rich_text existence.
@@ -765,17 +919,11 @@ class DomConverter {
     }
   }
 
-  static _processRichTextArray(richTextArray) {
-    let totalLength = 0;
-    const processed = [];
-    const count = richTextArray.length;
-    const preserveCodeWhitespace = richTextArray.some(rt => rt.annotations?.code === true);
-
-    // 找出第一個和最後一個非空白元素的索引
+  static _findRichTextContentBounds(richTextArray) {
     let firstNonEmptyIndex = -1;
     let lastNonEmptyIndex = -1;
-    for (let i = 0; i < count; i++) {
-      const content = richTextArray[i].text?.content || '';
+    for (const [i, rt] of richTextArray.entries()) {
+      const content = rt.text?.content ?? '';
       if (content.trim()) {
         if (firstNonEmptyIndex === -1) {
           firstNonEmptyIndex = i;
@@ -783,96 +931,186 @@ class DomConverter {
         lastNonEmptyIndex = i;
       }
     }
+    return { firstNonEmptyIndex, lastNonEmptyIndex };
+  }
+
+  static _buildRichTextFormatContext(index, totalCount, bounds, preserveCodeWhitespace) {
+    return {
+      index,
+      totalCount,
+      firstNonEmptyIndex: bounds.firstNonEmptyIndex,
+      lastNonEmptyIndex: bounds.lastNonEmptyIndex,
+      preserveCodeWhitespace,
+    };
+  }
+
+  static _cloneRichTextWithContent(rt, content) {
+    return {
+      ...rt,
+      text: {
+        ...rt.text,
+        content,
+      },
+    };
+  }
+
+  static _appendFormattedRichText(processed, rt, content, availableLength) {
+    if (!content) {
+      return { addedLength: 0, shouldContinue: true };
+    }
+
+    if (content.length > availableLength) {
+      DomConverter._appendTruncatedRichText(processed, rt, content, availableLength);
+      return { addedLength: Math.max(0, availableLength), shouldContinue: false };
+    }
+
+    processed.push(DomConverter._cloneRichTextWithContent(rt, content));
+    return { addedLength: content.length, shouldContinue: true };
+  }
+
+  static _appendTruncatedRichText(processed, rt, content, availableLength) {
+    if (availableLength <= 0) {
+      return;
+    }
+
+    processed.push(DomConverter._cloneRichTextWithContent(rt, content.slice(0, availableLength)));
+  }
+
+  static _processRichTextArray(richTextArray) {
+    let totalLength = 0;
+    const processed = [];
+    const count = richTextArray.length;
+    const preserveCodeWhitespace = richTextArray.some(rt => rt.annotations?.code === true);
+
+    const bounds = DomConverter._findRichTextContentBounds(richTextArray);
 
     for (const [index, rt] of richTextArray.entries()) {
-      const content = DomConverter._formatRichTextContent(
-        rt.text?.content || '',
+      const context = DomConverter._buildRichTextFormatContext(
         index,
         count,
-        firstNonEmptyIndex,
-        lastNonEmptyIndex,
+        bounds,
         preserveCodeWhitespace
       );
+      const content = DomConverter._formatRichTextContent(rt.text?.content ?? '', context);
+      const appendResult = DomConverter._appendFormattedRichText(
+        processed,
+        rt,
+        content,
+        MAX_TEXT_LENGTH - totalLength
+      );
 
-      if (totalLength + content.length > MAX_TEXT_LENGTH) {
-        const remaining = Math.max(0, MAX_TEXT_LENGTH - totalLength);
-        if (remaining > 0) {
-          // 建立副本避免污染原始輸入
-          const cloned = { ...rt, text: { ...rt.text, content: content.slice(0, remaining) } };
-          processed.push(cloned);
-        }
-        break; // Max reached
-      } else if (content) {
-        // 建立副本避免污染原始輸入
-        const cloned = { ...rt, text: { ...rt.text, content } };
-        totalLength += content.length;
-        processed.push(cloned);
+      totalLength += appendResult.addedLength;
+      if (!appendResult.shouldContinue) {
+        break;
       }
     }
 
     return processed;
   }
 
-  static _formatRichTextContent(
-    content,
-    index,
-    totalCount,
-    firstNonEmptyIndex,
-    lastNonEmptyIndex,
-    preserveCodeWhitespace = false
-  ) {
-    let formatted = content;
-
+  static _formatRichTextContent(content, context) {
     // code rich_text 的前後空白與換行是有語意的，需保留原始內容；
     // 但若整組內容都只有空白，仍維持既有 fallback 路徑，由 _cleanRichText 補單一空格。
-    if (preserveCodeWhitespace) {
-      return firstNonEmptyIndex === -1 ? '' : formatted;
+    if (context.preserveCodeWhitespace) {
+      return DomConverter._formatCodeRichTextContent(content, context);
     }
 
     // 邊界之外的純空白節點：直接返回空字串（會被過濾掉）
-    if (index < firstNonEmptyIndex || index > lastNonEmptyIndex) {
+    if (DomConverter._isOutsideRichTextBounds(context)) {
       return '';
     }
 
-    // 只對第一個非空白元素做 trimStart
-    if (index === firstNonEmptyIndex) {
-      formatted = formatted.trimStart();
-    }
-
-    // 只對最後一個非空白元素做 trimEnd
-    if (index === lastNonEmptyIndex) {
-      formatted = formatted.trimEnd();
-    }
-
-    // 如果只有一個元素且為空，保留一個空格
-    // 防禦性後備：當 totalCount === 1 且內容為空白時保留單一空格
-    // 註：正常情況下 firstNonEmptyIndex === -1 時會在上方邊界檢查返回空字串
-    // 此分支保留作為防禦性措施，處理意外輸入或未來邏輯變更的情況
-    if (!formatted.trim() && totalCount === 1) {
-      formatted = ' ';
+    const formatted = DomConverter._trimRichTextBoundaryContent(content, context);
+    if (DomConverter._shouldUseSingleWhitespaceFallback(formatted, context.totalCount)) {
+      return ' ';
     }
 
     return formatted;
   }
 
+  static _formatCodeRichTextContent(content, context) {
+    if (context.firstNonEmptyIndex === -1) {
+      return '';
+    }
+
+    return content;
+  }
+
+  static _isOutsideRichTextBounds(context) {
+    if (context.index < context.firstNonEmptyIndex) {
+      return true;
+    }
+
+    return context.index > context.lastNonEmptyIndex;
+  }
+
+  static _trimRichTextBoundaryContent(content, context) {
+    let formatted = content;
+
+    // 只對第一個非空白元素做 trimStart
+    if (context.index === context.firstNonEmptyIndex) {
+      formatted = formatted.trimStart();
+    }
+
+    // 只對最後一個非空白元素做 trimEnd
+    if (context.index === context.lastNonEmptyIndex) {
+      formatted = formatted.trimEnd();
+    }
+
+    return formatted;
+  }
+
+  static _shouldUseSingleWhitespaceFallback(formatted, totalCount) {
+    if (formatted.trim()) {
+      return false;
+    }
+
+    return totalCount === 1;
+  }
+
+  static _isUnsafeListChild(child) {
+    if (!child) {
+      return false;
+    }
+
+    return UNSAFE_LIST_CHILDREN_FOR_FLATTENING.has(child.type);
+  }
+
+  static _hasUnsafeListChild(children) {
+    return children.some(child => DomConverter._isUnsafeListChild(child));
+  }
+
+  static _isUnsafeListContainer(type, hasUnsafeChild) {
+    if (!hasUnsafeChild) {
+      return false;
+    }
+
+    return type.includes('list_item');
+  }
+
+  static _shouldFlattenChildren(type, depth, hasUnsafeChild) {
+    if (!BLOCKS_SUPPORTING_CHILDREN.has(type)) {
+      return true;
+    }
+
+    if (depth > MAX_BLOCK_CHILD_DEPTH) {
+      return true;
+    }
+
+    return DomConverter._isUnsafeListContainer(type, hasUnsafeChild);
+  }
+
   static _cleanBlockChildren(block, depth) {
     const type = block.type;
     const blockTypeData = block[type];
-    const hasChildren = blockTypeData?.children && blockTypeData.children.length > 0;
+    const hasChildren = DomConverter._hasBlockChildren(blockTypeData);
 
     if (!hasChildren) {
       return [block];
     }
 
-    const MAX_DEPTH = 1;
-    const isSupportedType = BLOCKS_SUPPORTING_CHILDREN.has(type);
-
-    const hasUnsafeChild = blockTypeData.children.some(
-      child => child && UNSAFE_LIST_CHILDREN_FOR_FLATTENING.has(child.type)
-    );
-
-    const shouldFlatten =
-      !isSupportedType || depth > MAX_DEPTH || (block.type.includes('list_item') && hasUnsafeChild);
+    const hasUnsafeChild = DomConverter._hasUnsafeListChild(blockTypeData.children);
+    const shouldFlatten = DomConverter._shouldFlattenChildren(type, depth, hasUnsafeChild);
 
     if (!shouldFlatten) {
       blockTypeData.children = DomConverter.cleanBlocks(blockTypeData.children, depth + 1);
@@ -888,6 +1126,14 @@ class DomConverter {
     const cleanChildren = DomConverter.cleanBlocks(children, depth);
 
     return [block, ...cleanChildren];
+  }
+
+  static _hasBlockChildren(blockTypeData) {
+    if (!blockTypeData?.children) {
+      return false;
+    }
+
+    return blockTypeData.children.length > 0;
   }
 }
 

--- a/tests/unit/background/utils/highlightStyleMerger.test.js
+++ b/tests/unit/background/utils/highlightStyleMerger.test.js
@@ -240,6 +240,16 @@ describe('findHighlightPosition', () => {
     expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(6);
   });
 
+  test('英文標註文字含換行時應匹配提取後的單空格文字', () => {
+    const richTextArray = [makeRT('The chasm between US and Chinese tech titans is widening.')];
+    const hl = {
+      text: 'US\nand Chinese tech',
+      rangeInfo: { prefix: 'between ', suffix: ' titans' },
+    };
+    const fullText = buildFullText(richTextArray);
+    expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(18);
+  });
+
   test('空文字返回 -1', () => {
     const richTextArray = [makeRT('這篇文章')];
     const hl = { text: '', rangeInfo: {} };
@@ -434,6 +444,28 @@ describe('mergeHighlightsWithStyle — 核心功能', () => {
     );
     expect(highlighted).toBeDefined();
     expect(highlighted?.text.content).toBe('Markdown');
+  });
+
+  test('英文標註文字含換行時應把樣式套回提取後的單空格原文', () => {
+    const blocks = [
+      makeParagraphBlock([makeRT('The chasm between US and Chinese tech titans is widening.')]),
+    ];
+    const highlights = [
+      {
+        id: 'hl-english-whitespace',
+        text: 'US\nand Chinese tech',
+        color: 'yellow',
+        rangeInfo: { prefix: 'between ', suffix: ' titans' },
+      },
+    ];
+
+    const result = mergeHighlightsWithStyle(blocks, highlights, 'COLOR_SYNC');
+    const highlightedText = result[0].paragraph.rich_text
+      .filter(rt => rt.annotations?.color === 'yellow_background')
+      .map(rt => rt.text.content)
+      .join('');
+
+    expect(highlightedText).toBe('US and Chinese tech');
   });
 });
 

--- a/tests/unit/content/converters/DomConverter.edge-cases.test.js
+++ b/tests/unit/content/converters/DomConverter.edge-cases.test.js
@@ -442,6 +442,53 @@ describe('DomConverter 覆蓋率補強', () => {
     });
   });
 
+  describe('重構風險與邊界情況保護', () => {
+    test('figure 同時有 alt 與 figcaption 時，figcaption 應該覆蓋 image caption', () => {
+      const html =
+        '<figure><img src="https://example.com/image.jpg" alt="Alt text"><figcaption>Figcaption text</figcaption></figure>';
+      const blocks = converter.convert(html);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].type).toBe('image');
+      expect(blocks[0].image.caption).toEqual([
+        { type: 'text', text: { content: 'Figcaption text' } },
+      ]);
+    });
+
+    test('nested list 內含 unsafe child block 時，cleanBlocks flatten 後仍保留 parent list item rich text', () => {
+      const blocks = [
+        {
+          type: 'bulleted_list_item',
+          bulleted_list_item: {
+            rich_text: [{ type: 'text', text: { content: 'Parent Item' } }],
+            children: [
+              {
+                type: 'image',
+                image: { type: 'external', external: { url: 'https://example.com/a.png' } },
+              },
+            ],
+          },
+        },
+      ];
+      const cleaned = DomConverter.cleanBlocks(blocks);
+      expect(cleaned).toHaveLength(2);
+      expect(cleaned[0].type).toBe('bulleted_list_item');
+      expect(cleaned[0].bulleted_list_item.rich_text).toEqual([
+        { type: 'text', text: { content: 'Parent Item' } },
+      ]);
+      expect(cleaned[1].type).toBe('image');
+    });
+
+    test('collectCodeLanguageHints 保持 code node hint 優先於 pre node hint', () => {
+      const pre = document.createElement('pre');
+      pre.setAttribute('class', 'language-css');
+      const code = document.createElement('code');
+      code.setAttribute('class', 'language-js');
+
+      const hints = DomConverter.collectCodeLanguageHints(code, pre);
+      expect(hints).toEqual(['js', 'css']);
+    });
+  });
+
   describe('domConverter 單例', () => {
     test('domConverter 應該是 DomConverter 實例', () => {
       expect(domConverter).toBeInstanceOf(DomConverter);

--- a/tests/unit/content/converters/DomConverter.edge-cases.test.js
+++ b/tests/unit/content/converters/DomConverter.edge-cases.test.js
@@ -92,6 +92,23 @@ describe('DomConverter 覆蓋率補強', () => {
     });
   });
 
+  describe('createParagraphBlock return type', () => {
+    const paragraphFrom = html =>
+      new DOMParser().parseFromString(html, 'text/html').body.firstElementChild;
+
+    test('always returns an array', () => {
+      const textParagraph = converter.createParagraphBlock(paragraphFrom('<p>Hello</p>'));
+      const emptyParagraph = converter.createParagraphBlock(paragraphFrom('<p></p>'));
+      const imageOnlyParagraph = converter.createParagraphBlock(
+        paragraphFrom('<p><img src="https://example.com/image.jpg" alt="test"></p>')
+      );
+
+      expect(Array.isArray(textParagraph)).toBe(true);
+      expect(Array.isArray(emptyParagraph)).toBe(true);
+      expect(Array.isArray(imageOnlyParagraph)).toBe(true);
+    });
+  });
+
   describe('createParagraphBlock 段落內圖片', () => {
     test('段落只包含圖片時應返回圖片 Block', () => {
       const html = '<p><img src="https://example.com/image.jpg" alt="test"></p>';

--- a/tests/unit/content/converters/DomConverter.edge-cases.test.js
+++ b/tests/unit/content/converters/DomConverter.edge-cases.test.js
@@ -101,6 +101,29 @@ describe('DomConverter 覆蓋率補強', () => {
       expect(blocks[0].type).toBe('image');
     });
 
+    test('段落只包含多張圖片時應返回多個圖片 Block', () => {
+      const html =
+        '<p><img src="https://example.com/image-1.jpg" alt="first"><img src="https://example.com/image-2.jpg" alt="second"></p>';
+      const blocks = converter.convert(html);
+
+      expect(blocks).toHaveLength(2);
+      expect(blocks.map(block => block.type)).toEqual(['image', 'image']);
+      expect(blocks.map(block => block.image.external.url)).toEqual([
+        'https://example.com/image-1.jpg',
+        'https://example.com/image-2.jpg',
+      ]);
+    });
+
+    test('段落只包含被連結包住的圖片時仍應返回圖片 Block', () => {
+      const html =
+        '<p><a href="https://example.com/article"><img src="https://example.com/wrapped.jpg" alt="wrapped"></a></p>';
+      const blocks = converter.convert(html);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].type).toBe('image');
+      expect(blocks[0].image.external.url).toBe('https://example.com/wrapped.jpg');
+    });
+
     test('段落包含圖片和文字時應返回段落', () => {
       const html = '<p><img src="https://example.com/image.jpg">Some text</p>';
       const blocks = converter.convert(html);

--- a/tests/unit/content/converters/DomConverter.richtext.test.js
+++ b/tests/unit/content/converters/DomConverter.richtext.test.js
@@ -101,5 +101,33 @@ describe('DomConverter 富文字處理', () => {
       expect(result).toHaveLength(1);
       expect(result[0].text.content).toBe('\n  const answer = 42;\n');
     });
+
+    test('重構 context 後仍保留 code whitespace 且符合 boundary trim semantics', () => {
+      const input = [
+        {
+          type: 'text',
+          text: { content: '  ' },
+          annotations: { code: true },
+        },
+        {
+          type: 'text',
+          text: { content: '\n  code_here();\n' },
+          annotations: { code: true },
+        },
+      ];
+      const result = DomConverter._processRichTextArray(input);
+      expect(result).toHaveLength(2);
+      expect(result[0].text.content).toBe('  ');
+      expect(result[1].text.content).toBe('\n  code_here();\n');
+    });
+
+    test('重構 context 後仍不 mutate original rich text item', () => {
+      const input = [{ type: 'text', text: { content: '  Hello  ' }, annotations: { bold: true } }];
+      const clonedInput = structuredClone(input);
+
+      const result = DomConverter._processRichTextArray(input);
+      expect(input).toEqual(clonedInput);
+      expect(result[0].text.content).toBe('Hello');
+    });
   });
 });

--- a/tests/unit/content/converters/DomConverter.test.js
+++ b/tests/unit/content/converters/DomConverter.test.js
@@ -245,6 +245,40 @@ describe('DomConverter', () => {
       expect(blocks[0].image.external.url).toBe(src);
     });
 
+    test('should keep resolved absolute URL when cleanImageUrl throws for relative src', () => {
+      const src = '/images/error.jpg';
+      const expectedUrl = new URL(src, document.baseURI).href;
+      globalThis.ImageUtils.extractImageSrc.mockReturnValue(src);
+      globalThis.ImageUtils.cleanImageUrl.mockImplementationOnce(() => {
+        throw new Error('Clean Error');
+      });
+
+      const html = `<img src="${src}" />`;
+      const blocks = domConverter.convert(html);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].image.external.url).toBe(expectedUrl);
+    });
+
+    test('should keep resolved absolute URL when cleanImageUrl is unavailable', () => {
+      const src = '/images/no-cleaner.jpg';
+      const expectedUrl = new URL(src, document.baseURI).href;
+      globalThis.ImageUtils.extractImageSrc.mockReturnValue(src);
+      const originalCleanImageUrl = globalThis.ImageUtils.cleanImageUrl;
+
+      try {
+        globalThis.ImageUtils.cleanImageUrl = null;
+
+        const html = `<img src="${src}" />`;
+        const blocks = domConverter.convert(html);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].image.external.url).toBe(expectedUrl);
+      } finally {
+        globalThis.ImageUtils.cleanImageUrl = originalCleanImageUrl;
+      }
+    });
+
     test('should drop image if validCleanedImageUrl returns false', () => {
       const src = 'https://example.com/invalid.jpg';
       globalThis.ImageUtils.extractImageSrc.mockReturnValue(src);


### PR DESCRIPTION
### 摘要
重構 DomConverter 以降低其複雜度，提升可維護性。

### 變更內容
- 簡化了 DomConverter 的邏輯結構。
- 增加了多個測試案例以確保重構後的行為符合預期。
- 確保在重構過程中不會改變原始 rich text 項目。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

