### PR TITLE
refactor: reduce content bridge complexity

### DIFF
--- a/scripts/content/converters/ContentBridge.js
+++ b/scripts/content/converters/ContentBridge.js
@@ -55,13 +55,7 @@ function bridgeContentToBlocks(extractedContent, options = {}) {
   });
 
   // 2. 轉換內容為 Notion Blocks
-  let blocks = _convertContent(content, type, options);
-
-  // 確保 blocks 是有效的陣列
-  if (!Array.isArray(blocks) || blocks.length === 0) {
-    Logger.warn('轉換結果為空，創建回退區塊', { action: 'bridgeContentToBlocks' });
-    blocks = _createFallbackBlocks();
-  }
+  const blocks = _ensureBlocks(_convertContent(content, type, options));
 
   Logger.success('[ContentBridge] 區塊生成完成', {
     action: 'bridgeContentToBlocks',
@@ -71,14 +65,32 @@ function bridgeContentToBlocks(extractedContent, options = {}) {
   // 3. 插入元數據 (封面圖等)
   _insertMetaBlocks(blocks, metadata, { includeFeaturedImage, includeTitle });
 
-  // 4. 提取 siteIcon
-  const siteIcon = metadata.siteIcon || metadata.favicon || null;
-
   return {
     title,
     blocks,
-    siteIcon,
+    siteIcon: _extractSiteIcon(metadata),
   };
+}
+
+function _ensureBlocks(blocks) {
+  if (Array.isArray(blocks) && blocks.length > 0) {
+    return blocks;
+  }
+
+  Logger.warn('轉換結果為空，創建回退區塊', { action: 'bridgeContentToBlocks' });
+  return _createFallbackBlocks();
+}
+
+function _extractSiteIcon(metadata) {
+  if (metadata.siteIcon) {
+    return metadata.siteIcon;
+  }
+
+  if (metadata.favicon) {
+    return metadata.favicon;
+  }
+
+  return null;
 }
 
 function _extractTitle(metadata, rawArticle) {
@@ -95,101 +107,132 @@ function _convertContent(content, type, options) {
     return [];
   }
 
+  if (!_isConvertibleContentType(type)) {
+    Logger.warn('未知內容類型，使用回退處理', { action: 'bridgeContentToBlocks', type });
+    return createTextBlocks(content);
+  }
+
   try {
-    if (type === 'html' || type === 'markdown') {
-      Logger.info('[ContentBridge] 準備轉換內容', { action: 'bridgeContentToBlocks', type });
-      const converter =
-        options.htmlConverter ||
-        globalThis.domConverter ||
-        (globalThis.ConverterFactory ? globalThis.ConverterFactory.getConverter(type) : null);
+    Logger.info('[ContentBridge] 準備轉換內容', { action: 'bridgeContentToBlocks', type });
+    const converter = _resolveConverter(type, options);
 
-      if (converter) {
-        return converter.convert(content);
-      }
-
+    if (!converter) {
       Logger.warn('轉換器不可用', { action: 'bridgeContentToBlocks', type });
       return createTextBlocks(content);
     }
 
-    Logger.warn('未知內容類型，使用回退處理', { action: 'bridgeContentToBlocks', type });
-    return createTextBlocks(content);
+    return converter.convert(content);
   } catch (error) {
     Logger.error('內容轉換失敗', { action: 'bridgeContentToBlocks', error: error.message });
     return createTextBlocks(content);
   }
 }
 
+function _isConvertibleContentType(type) {
+  return type === 'html' || type === 'markdown';
+}
+
+function _resolveConverter(type, options) {
+  if (options.htmlConverter) {
+    return options.htmlConverter;
+  }
+
+  if (globalThis.domConverter) {
+    return globalThis.domConverter;
+  }
+
+  if (!globalThis.ConverterFactory) {
+    return null;
+  }
+
+  return globalThis.ConverterFactory.getConverter(type);
+}
+
 function _createFallbackBlocks() {
-  return [
-    {
-      object: 'block',
-      type: 'paragraph',
-      paragraph: {
-        rich_text: [
-          {
-            type: 'text',
-            text: { content: 'Content extraction completed but no blocks were generated.' },
-          },
-        ],
-      },
-    },
-  ];
+  return [_createParagraphBlock('Content extraction completed but no blocks were generated.')];
 }
 
 function _insertMetaBlocks(blocks, metadata, options = {}) {
   const { includeFeaturedImage = true, includeTitle = false } = options;
 
-  // 1. 插入標題 (如果 metadata 有 title 且顯式要求)
-  if (includeTitle && metadata.title) {
-    const truncatedTitle = (metadata.title || '').slice(0, TEXT_PROCESSING.MAX_RICH_TEXT_LENGTH);
-    const hasTitle = blocks.some(
-      block =>
-        block.type === 'heading_1' &&
-        block.heading_1?.rich_text?.[0]?.text?.content === truncatedTitle
-    );
+  _insertTitleBlock(blocks, metadata, includeTitle);
+  _insertFeaturedImageBlock(blocks, metadata, includeFeaturedImage);
+}
 
-    if (!hasTitle) {
-      const titleBlock = {
-        object: 'block',
-        type: 'heading_1',
-        heading_1: {
-          rich_text: [
-            {
-              type: 'text',
-              text: {
-                content: truncatedTitle,
-              },
-            },
-          ],
-        },
-      };
-      blocks.splice(0, 0, titleBlock);
-    }
+function _insertTitleBlock(blocks, metadata, includeTitle) {
+  if (!includeTitle) {
+    return;
   }
 
-  // 2. 插入封面圖
-  if (includeFeaturedImage && metadata.featuredImage) {
-    const featuredImageUrl = metadata.featuredImage;
-
-    // 檢查是否已存在於 blocks 中
-    const isDuplicate = blocks.some(
-      block => block.type === 'image' && block.image?.external?.url === featuredImageUrl
-    );
-
-    if (isDuplicate) {
-      Logger.debug('[ContentBridge] 封面圖已存在，跳過插入', { action: 'bridgeContentToBlocks' });
-    } else {
-      blocks.unshift({
-        object: 'block',
-        type: 'image',
-        image: {
-          type: 'external',
-          external: { url: featuredImageUrl },
-        },
-      });
-      Logger.debug('[ContentBridge] 封面圖已插入到區塊開頭', { action: 'bridgeContentToBlocks' });
-    }
+  if (!metadata.title) {
+    return;
   }
+
+  const truncatedTitle = _truncateRichText(metadata.title);
+  if (_hasHeadingTitle(blocks, truncatedTitle)) {
+    return;
+  }
+
+  blocks.splice(0, 0, _createHeadingBlock(truncatedTitle));
+}
+
+function _truncateRichText(text) {
+  return text.slice(0, TEXT_PROCESSING.MAX_RICH_TEXT_LENGTH);
+}
+
+function _hasHeadingTitle(blocks, title) {
+  return blocks.some(
+    block => block.type === 'heading_1' && block.heading_1?.rich_text?.[0]?.text?.content === title
+  );
+}
+
+function _createHeadingBlock(content) {
+  return {
+    object: 'block',
+    type: 'heading_1',
+    heading_1: {
+      rich_text: [
+        {
+          type: 'text',
+          text: { content },
+        },
+      ],
+    },
+  };
+}
+
+function _insertFeaturedImageBlock(blocks, metadata, includeFeaturedImage) {
+  if (!includeFeaturedImage) {
+    return;
+  }
+
+  const featuredImageUrl = metadata.featuredImage;
+  if (!featuredImageUrl) {
+    return;
+  }
+
+  if (_hasImageBlock(blocks, featuredImageUrl)) {
+    Logger.debug('[ContentBridge] 封面圖已存在，跳過插入', { action: 'bridgeContentToBlocks' });
+    return;
+  }
+
+  blocks.unshift(_createImageBlock(featuredImageUrl));
+  Logger.debug('[ContentBridge] 封面圖已插入到區塊開頭', { action: 'bridgeContentToBlocks' });
+}
+
+function _hasImageBlock(blocks, url) {
+  return blocks.some(block => block.type === 'image' && block.image?.external?.url === url);
+}
+
+function _createImageBlock(url) {
+  return {
+    object: 'block',
+    type: 'image',
+    image: {
+      type: 'external',
+      external: { url },
+    },
+  };
 }
 
 /**
@@ -202,15 +245,7 @@ function _insertMetaBlocks(blocks, metadata, options = {}) {
 function createFallbackResult(title, message) {
   return {
     title,
-    blocks: [
-      {
-        object: 'block',
-        type: 'paragraph',
-        paragraph: {
-          rich_text: [{ type: 'text', text: { content: message } }],
-        },
-      },
-    ],
+    blocks: [_createParagraphBlock(message)],
     siteIcon: null,
   };
 }
@@ -235,41 +270,36 @@ function createTextBlocks(content) {
     return [];
   }
 
-  // 按段落分割
-  const paragraphs = text.split('\n\n').filter(para => para.trim());
-  const maxLength = 2000;
+  return _splitTextIntoParagraphs(text).flatMap(paragraph =>
+    _createChunkedParagraphBlocks(paragraph)
+  );
+}
 
+function _splitTextIntoParagraphs(text) {
+  return text
+    .split('\n\n')
+    .map(para => para.trim())
+    .filter(Boolean);
+}
+
+function _createChunkedParagraphBlocks(text) {
   const blocks = [];
-  for (const para of paragraphs) {
-    const trimmed = para.trim();
-    if (!trimmed) {
-      continue;
-    }
 
-    // 處理長段落
-    if (trimmed.length <= maxLength) {
-      blocks.push({
-        object: 'block',
-        type: 'paragraph',
-        paragraph: {
-          rich_text: [{ type: 'text', text: { content: trimmed } }],
-        },
-      });
-    } else {
-      // 分割長段落
-      for (let pos = 0; pos < trimmed.length; pos += maxLength) {
-        blocks.push({
-          object: 'block',
-          type: 'paragraph',
-          paragraph: {
-            rich_text: [{ type: 'text', text: { content: trimmed.slice(pos, pos + maxLength) } }],
-          },
-        });
-      }
-    }
+  for (let pos = 0; pos < text.length; pos += TEXT_PROCESSING.MAX_RICH_TEXT_LENGTH) {
+    blocks.push(_createParagraphBlock(text.slice(pos, pos + TEXT_PROCESSING.MAX_RICH_TEXT_LENGTH)));
   }
 
   return blocks;
+}
+
+function _createParagraphBlock(content) {
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: {
+      rich_text: [{ type: 'text', text: { content } }],
+    },
+  };
 }
 
 /**

--- a/scripts/content/converters/ContentBridge.js
+++ b/scripts/content/converters/ContentBridge.js
@@ -45,7 +45,8 @@ function bridgeContentToBlocks(extractedContent, options = {}) {
     return createFallbackResult('Untitled', 'No content was extracted.');
   }
 
-  const { content, type, metadata = {}, rawArticle } = extractedContent;
+  const { content, type, metadata: extractedMetadata, rawArticle } = extractedContent;
+  const metadata = extractedMetadata ?? {};
 
   // 1. 提取標題
   const title = _extractTitle(metadata, rawArticle);
@@ -82,11 +83,11 @@ function _ensureBlocks(blocks) {
 }
 
 function _extractSiteIcon(metadata) {
-  if (metadata.siteIcon) {
+  if (metadata?.siteIcon) {
     return metadata.siteIcon;
   }
 
-  if (metadata.favicon) {
+  if (metadata?.favicon) {
     return metadata.favicon;
   }
 
@@ -95,7 +96,7 @@ function _extractSiteIcon(metadata) {
 
 function _extractTitle(metadata, rawArticle) {
   return (
-    metadata.title ||
+    metadata?.title ||
     rawArticle?.title ||
     (typeof document === 'undefined' ? '' : document.title) ||
     'Untitled'
@@ -164,11 +165,12 @@ function _insertTitleBlock(blocks, metadata, includeTitle) {
     return;
   }
 
-  if (!metadata.title) {
+  const title = metadata?.title;
+  if (!title) {
     return;
   }
 
-  const truncatedTitle = _truncateRichText(metadata.title);
+  const truncatedTitle = _truncateRichText(title);
   if (_hasHeadingTitle(blocks, truncatedTitle)) {
     return;
   }
@@ -206,7 +208,7 @@ function _insertFeaturedImageBlock(blocks, metadata, includeFeaturedImage) {
     return;
   }
 
-  const featuredImageUrl = metadata.featuredImage;
+  const featuredImageUrl = metadata?.featuredImage;
   if (!featuredImageUrl) {
     return;
   }

--- a/tests/unit/content/converters/ContentBridge.test.js
+++ b/tests/unit/content/converters/ContentBridge.test.js
@@ -86,6 +86,36 @@ describe('ContentBridge', () => {
       expect(result.title).toBe('Article Title');
     });
 
+    test('應處理 null metadata 並從 rawArticle 回退標題', () => {
+      const extractedContent = {
+        content: '<p>Test</p>',
+        type: 'html',
+        metadata: null,
+        rawArticle: { title: 'Article Title' },
+      };
+
+      const mockConverter = {
+        convert: jest.fn(() => [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'Test' } }] },
+          },
+        ]),
+      };
+
+      const result = bridgeContentToBlocks(extractedContent, {
+        htmlConverter: mockConverter,
+        includeTitle: true,
+        includeFeaturedImage: true,
+      });
+
+      expect(result.title).toBe('Article Title');
+      expect(result.siteIcon).toBeNull();
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks[0].type).toBe('paragraph');
+    });
+
     test('應調用 HTML 轉換器處理 HTML 內容', () => {
       const mockBlocks = [{ object: 'block', type: 'paragraph', paragraph: { rich_text: [] } }];
       const mockConverter = {


### PR DESCRIPTION
### 摘要
簡化內容橋接的邏輯，提升可讀性和維護性。

### 變更內容
- 將內容轉換過程中的邏輯重構為多個輔助函數，減少主函數的複雜度。
- 引入 `_ensureBlocks` 函數以確保生成的區塊有效。
- 使用 `_extractSiteIcon` 函數簡化網站圖標的提取邏輯。
- 將標題和封面圖的插入邏輯分離到 `_insertTitleBlock` 和 `_insertFeaturedImageBlock` 函數中。
- 改進段落處理邏輯，使用 `_splitTextIntoParagraphs` 和 `_createChunkedParagraphBlocks` 函數。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

