### PR TITLE
fix: correct coverage collection for pages directory

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 # Codecov Configuration
 # 文檔: https://docs.codecov.com/docs/codecov-yaml
-# 最後更新: 2025-12-20 - 清理 testable 檔案後更新
+# 最後更新: 2026-06-04 - 修正 flag paths 漏收 pages/（目錄重構後同步）
 
 # 覆蓋率設置
 coverage:
@@ -55,22 +55,18 @@ flags:
   unit:
     paths:
       - scripts/
-      - options/
-      - popup/
-      - sidepanel/
+      - pages/
     carryforward: true # 允許攜帶上次覆蓋率
 
   e2e:
     paths:
       - scripts/
-      - options/
-      - popup/
-      - sidepanel/
+      - pages/
     carryforward: true # 允許攜帶上次覆蓋率
 
 
 # 說明：
-# - 所有生產代碼位於 scripts/ 目錄
+# - 生產代碼位於 scripts/（背景 / 內容 / 工具邏輯）與 pages/（options / popup / sidepanel 等頁面 UI）
 # - tests/helpers/ 僅包含測試工具（如 mock helpers），不計入覆蓋率
 #
 # 覆蓋率歷史變更：
@@ -96,4 +92,10 @@ flags:
 #   - tests/unit/utils.test.js (256 行) 已移至 internal/archive/
 #   - 該測試測試的是已拆分的舊 scripts/utils.js
 #   - 已被 storageUtil.test.js 和 Logger.test.js 的更完善測試取代
+#
+# - 2026-06-04: 修正 flag paths 漏收 pages/ 覆蓋率
+#   - options/popup/sidepanel 已於 v2.74.0 搬至 pages/ 下，但 unit/e2e flag paths 未同步
+#   - 舊 paths（root 層 options/popup/sidepanel）不匹配 pages/**，
+#     導致 lcov 內 pages/ 檔案的覆蓋率被 Codecov flag 白名單濾掉，UI 只顯示 scripts/
+#   - 改為 scripts/ + pages/，對齊 jest.config.js 的 collectCoverageFrom
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,6 +61,7 @@ module.exports = {
     '!<rootDir>/scripts/config/extraction.js',         // 純選擇器與數值常量
     '!<rootDir>/scripts/config/highlightConstants.js', // 純數值常量
     '!<rootDir>/scripts/config/index.js',              // 純 re-export barrel file
+    '!<rootDir>/scripts/config/extension/**/*.js',     // extension-only 純常量配置與 re-export
     // Toolbar 鏈：DCE guard 位於 scripts/highlighter/windowAPI.js
     // (TOOLBAR_TEST_FIXTURE_ENABLED 與 ensureToolbar(state))，而非 Toolbar files 本身。
     // rollup/content.config.mjs 將 globalThis.__UNIT_TESTING__ 替換為 false，

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,8 +10,10 @@ sonar.javascript.file.suffixes=.js
 # 排除不需要分析的路徑
 sonar.exclusions=node_modules/**,dist/**,coverage/**,tests/**,**/*.test.js,**/*.spec.js,playwright-report/**,lib/Readability.js
 
-# 覆蓋率排除清單（對齊 Jest collectCoverageFrom）
-sonar.coverage.exclusions=scripts/config/app.js,scripts/config/icons.js,scripts/config/ui.js,scripts/config/extraction.js,scripts/config/highlightConstants.js,scripts/config/index.js,scripts/config/extension/**/*.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
+# 覆蓋率排除清單（對齊 jest.config.js 的 collectCoverageFrom）
+# 兩類排除：(1) 純常量 config；(2) prod DCE 後 unreachable 的 Toolbar 鏈（見 jest.config.js 同段註釋）。
+# 這些檔案的覆蓋率不代表 production 行為，但仍接受 SonarCloud 的 issue / code smell 分析。
+sonar.coverage.exclusions=scripts/config/app.js,scripts/config/icons.js,scripts/config/ui.js,scripts/config/extraction.js,scripts/config/highlightConstants.js,scripts/config/index.js,scripts/config/extension/**/*.js,scripts/highlighter/ui/Toolbar.js,scripts/highlighter/ui/ToolbarRuntime.js,scripts/highlighter/ui/ToolbarState.js,scripts/highlighter/ui/ToolbarUI.js,scripts/highlighter/ui/styles/toolbarStyles.js,scripts/highlighter/ui/components/ColorPicker.js,scripts/highlighter/ui/components/MiniIcon.js,scripts/highlighter/ui/components/ToolbarContainer.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
 
 # 測試覆蓋率報告路徑（jest unit only；E2E coverage 不合併進 quality gate，避免 ghost-line 污染）
 sonar.javascript.lcov.reportPaths=coverage/jest/lcov.info


### PR DESCRIPTION
### 摘要
修正 Codecov 和 SonarCloud 的覆蓋率收集範圍，確保 pages 目錄的覆蓋率正確顯示。

### 變更內容
- 更新 codecov.yml 中的 flag paths，將 unit/e2e 的路徑從 root 層的 options/popup/sidepanel 改為 scripts/ 和 pages/。
- 在 sonar-project.properties 中，補充 coverage.exclusions，避免 SonarCloud 將無 lcov 數據的死碼視為 0% 生產碼。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

