### PR TITLE
refactor: implement CSS Token-Var Bridge for toast styles

### DIFF
--- a/scripts/highlighter/ui/styles/floatingRailStyles.js
+++ b/scripts/highlighter/ui/styles/floatingRailStyles.js
@@ -19,7 +19,6 @@ const { color, spacing, radius, shadow, theme } = UI_TOKENS;
 export function getRailThemeVars() {
   return `
     :host {
-      /* 平色 token */
       --rail-color-text: ${color.text};
       --rail-color-text-muted: ${color.textMuted};
       --rail-color-white: ${color.white};
@@ -33,7 +32,6 @@ export function getRailThemeVars() {
       --rail-color-primary: ${color.primary};
       --rail-color-danger: ${color.danger};
 
-      /* 計算值：JS 預算成具名 var */
       --rail-glow-brand: ${hexToRgba(color.brand, 0.35)};
       --rail-glow-action-save: ${hexToRgba(color.actionSave, 0.35)};
       --rail-glow-action-manage: ${hexToRgba(color.actionManage, 0.35)};
@@ -45,7 +43,6 @@ export function getRailThemeVars() {
       --rail-border-white-a60: ${hexToRgba(color.white, 0.6)};
       --rail-border-white-a88: ${hexToRgba(color.white, 0.88)};
 
-      /* dual-mode 語意 token */
       --rail-surface: ${theme.light.surface};
       --rail-border: ${theme.light.border};
       --rail-icon-muted: ${theme.light.iconMuted};
@@ -321,7 +318,6 @@ export function getFloatingRailCSS() {
     }
 
     .rail-highlight-toggle[data-highlight-state="inactive"] {
-      /* Fallback first for browsers without color-mix(); supported browsers override with the color-mix() line. */
       background: var(--rail-highlight-tint, var(--rail-color-primary-a40));
       background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 40%, transparent);
       color: var(--rail-icon-muted);
@@ -330,7 +326,6 @@ export function getFloatingRailCSS() {
 
     .rail-highlight-toggle[data-highlight-state="inactive"]:hover,
     .rail-highlight-toggle[data-highlight-state="inactive"]:focus-visible {
-      /* Fallback first for browsers without color-mix(); supported browsers override with the color-mix() line. */
       background: var(--rail-highlight-tint, var(--rail-color-primary-a55));
       background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 55%, transparent);
       transform: translateY(-1px);

--- a/scripts/highlighter/ui/styles/floatingRailStyles.js
+++ b/scripts/highlighter/ui/styles/floatingRailStyles.js
@@ -9,8 +9,62 @@ import { UI_TOKENS, hexToRgba } from '../../../../styles/ui-token-constants.js';
 
 const { color, spacing, radius, shadow, theme } = UI_TOKENS;
 
+/**
+ * 取得 Floating Rail 的色彩 CSS 變數定義。
+ *
+ * 邊界規則：色彩類 token 走 var bridge，維度 token (spacing, radius, shadow) 仍走 JS 內插。
+ *
+ * @returns {string} CSS 變數字串
+ */
+export function getRailThemeVars() {
+  return `
+    :host {
+      /* 平色 token */
+      --rail-color-text: ${color.text};
+      --rail-color-text-muted: ${color.textMuted};
+      --rail-color-white: ${color.white};
+      --rail-color-brand: ${color.brand};
+      --rail-color-brand-hover: ${color.brandHover};
+      --rail-color-icon-on-accent: ${color.iconOnAccent};
+      --rail-color-action-save: ${color.actionSave};
+      --rail-color-action-save-hover: ${color.actionSaveHover};
+      --rail-color-action-manage: ${color.actionManage};
+      --rail-color-action-manage-hover: ${color.actionManageHover};
+      --rail-color-primary: ${color.primary};
+      --rail-color-danger: ${color.danger};
+
+      /* 計算值：JS 預算成具名 var */
+      --rail-glow-brand: ${hexToRgba(color.brand, 0.35)};
+      --rail-glow-action-save: ${hexToRgba(color.actionSave, 0.35)};
+      --rail-glow-action-manage: ${hexToRgba(color.actionManage, 0.35)};
+      --rail-color-primary-a40: ${hexToRgba(color.primary, 0.4)};
+      --rail-color-primary-a55: ${hexToRgba(color.primary, 0.55)};
+      --rail-ring-white-strong: ${hexToRgba(color.white, 0.45)};
+      --rail-ring-white-weak: ${hexToRgba(color.white, 0.25)};
+      --rail-shadow-black-a18: ${hexToRgba(color.black, 0.18)};
+      --rail-border-white-a60: ${hexToRgba(color.white, 0.6)};
+      --rail-border-white-a88: ${hexToRgba(color.white, 0.88)};
+
+      /* dual-mode 語意 token */
+      --rail-surface: ${theme.light.surface};
+      --rail-border: ${theme.light.border};
+      --rail-icon-muted: ${theme.light.iconMuted};
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :host {
+        --rail-surface: ${theme.dark.surface};
+        --rail-border: ${theme.dark.border};
+        --rail-icon-muted: ${theme.dark.iconMuted};
+      }
+    }
+  `;
+}
+
 export function getFloatingRailCSS() {
   return `
+    ${getRailThemeVars()}
+
     :host {
       all: initial;
       display: block;
@@ -22,7 +76,7 @@ export function getFloatingRailCSS() {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       font-size: 14px;
       line-height: 1.5;
-      color: ${color.text};
+      color: var(--rail-color-text);
     }
 
     :host *,
@@ -52,15 +106,14 @@ export function getFloatingRailCSS() {
       align-items: center;
       gap: ${spacing.xs};
       padding: ${spacing.xs};
-      background: ${theme.light.surface};
-      border: 1px solid ${theme.light.border};
+      background: var(--rail-surface);
+      border: 1px solid var(--rail-border);
       border-right: none;
       border-radius: ${radius.lg} 0 0 ${radius.lg};
       box-shadow: ${shadow.md};
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
       transition: opacity 0.2s ease, transform 0.2s ease;
-      --rail-icon-muted: ${theme.light.iconMuted};
     }
 
     .rail-close-btn {
@@ -70,8 +123,8 @@ export function getFloatingRailCSS() {
       width: 16px;
       height: 16px;
       border-radius: 50%;
-      background: ${color.text};
-      color: ${color.white};
+      background: var(--rail-color-text);
+      color: var(--rail-color-white);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -94,7 +147,7 @@ export function getFloatingRailCSS() {
     .rail-close-btn:focus-visible {
       opacity: 1 !important;
       pointer-events: auto;
-      outline: 2px solid ${color.brand};
+      outline: 2px solid var(--rail-color-brand);
       outline-offset: 1px;
     }
 
@@ -112,14 +165,6 @@ export function getFloatingRailCSS() {
       color: currentColor;
       fill: currentColor;
       stroke: currentColor;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      .rail-container {
-        background: ${theme.dark.surface};
-        border-color: ${theme.dark.border};
-        --rail-icon-muted: ${theme.dark.iconMuted};
-      }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -156,8 +201,8 @@ export function getFloatingRailCSS() {
       width: var(--rail-btn-size, 34px);
       height: var(--rail-btn-size, 34px);
       border-radius: 9px;
-      background: ${color.brand};
-      color: ${color.iconOnAccent};
+      background: var(--rail-color-brand);
+      color: var(--rail-color-icon-on-accent);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -166,23 +211,23 @@ export function getFloatingRailCSS() {
         background 0.16s ease,
         transform 0.16s ease,
         box-shadow 0.16s ease;
-      --rail-brand-fill: ${color.brand};
+      --rail-brand-fill: var(--rail-color-brand);
     }
 
     .rail-trigger:hover,
     .rail-trigger:focus-visible {
-      background: ${color.brandHover};
+      background: var(--rail-color-brand-hover);
       transform: translateY(-1px);
-      box-shadow: 0 2px 6px ${hexToRgba(color.brand, 0.35)};
+      box-shadow: 0 2px 6px var(--rail-glow-brand);
     }
 
     :host([data-dragging="true"]) .rail-trigger {
       cursor: grabbing;
-      background: ${color.brandHover};
+      background: var(--rail-color-brand-hover);
     }
 
     .rail-trigger:hover {
-      --rail-brand-fill: ${color.brandHover};
+      --rail-brand-fill: var(--rail-color-brand-hover);
     }
 
     .rail-trigger > .icon {
@@ -222,7 +267,7 @@ export function getFloatingRailCSS() {
       height: var(--rail-btn-size, 34px);
       border-radius: 9px;
       position: relative;
-      color: ${color.iconOnAccent};
+      color: var(--rail-color-icon-on-accent);
       transition:
         background 0.16s ease,
         border-color 0.16s ease,
@@ -232,27 +277,27 @@ export function getFloatingRailCSS() {
 
     .rail-action-btn[data-action="save"],
     .rail-action-btn[data-action="sync"] {
-      background: ${color.actionSave};
+      background: var(--rail-color-action-save);
     }
 
     .rail-action-btn[data-action="save"]:hover,
     .rail-action-btn[data-action="save"]:focus-visible,
     .rail-action-btn[data-action="sync"]:hover,
     .rail-action-btn[data-action="sync"]:focus-visible {
-      background: ${color.actionSaveHover};
+      background: var(--rail-color-action-save-hover);
       transform: translateY(-1px);
-      box-shadow: 0 2px 6px ${hexToRgba(color.actionSave, 0.35)};
+      box-shadow: 0 2px 6px var(--rail-glow-action-save);
     }
 
     .rail-action-btn[data-action="manage"] {
-      background: ${color.actionManage};
+      background: var(--rail-color-action-manage);
     }
 
     .rail-action-btn[data-action="manage"]:hover,
     .rail-action-btn[data-action="manage"]:focus-visible {
-      background: ${color.actionManageHover};
+      background: var(--rail-color-action-manage-hover);
       transform: translateY(-1px);
-      box-shadow: 0 2px 6px ${hexToRgba(color.actionManage, 0.35)};
+      box-shadow: 0 2px 6px var(--rail-glow-action-manage);
     }
 
     .rail-action-btn > .icon {
@@ -276,33 +321,33 @@ export function getFloatingRailCSS() {
     }
 
     .rail-highlight-toggle[data-highlight-state="inactive"] {
-      background: var(--rail-highlight-tint, ${hexToRgba(color.primary, 0.4)});
-      background: color-mix(in srgb, var(--rail-highlight-color, ${color.primary}) 40%, transparent);
-      color: var(--rail-icon-muted, ${theme.light.iconMuted});
-      box-shadow: inset 0 0 0 1px ${hexToRgba(color.white, 0.45)};
+      background: var(--rail-highlight-tint, var(--rail-color-primary-a40));
+      background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 40%, transparent);
+      color: var(--rail-icon-muted);
+      box-shadow: inset 0 0 0 1px var(--rail-ring-white-strong);
     }
 
     .rail-highlight-toggle[data-highlight-state="inactive"]:hover,
     .rail-highlight-toggle[data-highlight-state="inactive"]:focus-visible {
-      background: var(--rail-highlight-tint, ${hexToRgba(color.primary, 0.55)});
-      background: color-mix(in srgb, var(--rail-highlight-color, ${color.primary}) 55%, transparent);
+      background: var(--rail-highlight-tint, var(--rail-color-primary-a55));
+      background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 55%, transparent);
       transform: translateY(-1px);
     }
 
     .rail-highlight-toggle[data-highlight-state="active"] {
-      background: var(--rail-highlight-color, ${color.primary});
-      border-color: var(--rail-highlight-color, ${color.primary});
+      background: var(--rail-highlight-color, var(--rail-color-primary));
+      border-color: var(--rail-highlight-color, var(--rail-color-primary));
       color: rgba(0, 0, 0, 0.78);
-      box-shadow: inset 0 0 0 1px ${hexToRgba(color.white, 0.25)};
+      box-shadow: inset 0 0 0 1px var(--rail-ring-white-weak);
       transform: translateY(-1px);
     }
 
     .rail-highlight-toggle[data-highlight-state="active"]:hover,
     .rail-highlight-toggle[data-highlight-state="active"]:focus-visible {
-      background: var(--rail-highlight-color, ${color.primary});
+      background: var(--rail-highlight-color, var(--rail-color-primary));
       box-shadow:
-        inset 0 0 0 1px ${hexToRgba(color.white, 0.25)},
-        0 2px 6px ${hexToRgba(color.black, 0.18)};
+        inset 0 0 0 1px var(--rail-ring-white-weak),
+        0 2px 6px var(--rail-shadow-black-a18);
     }
 
     .rail-highlight-toggle svg {
@@ -317,8 +362,8 @@ export function getFloatingRailCSS() {
       right: calc(100% + ${spacing.sm});
       top: 50%;
       transform: translateY(-50%);
-      background: ${color.text};
-      color: ${color.white};
+      background: var(--rail-color-text);
+      color: var(--rail-color-white);
       padding: 2px ${spacing.sm};
       border-radius: ${radius.sm};
       font-size: 12px;
@@ -337,7 +382,7 @@ export function getFloatingRailCSS() {
       width: 14px;
       height: 14px;
       border-radius: 50%;
-      border: 2px solid ${hexToRgba(color.white, 0.6)};
+      border: 2px solid var(--rail-border-white-a60);
       transition:
         background 0.16s ease,
         border-color 0.16s ease,
@@ -345,7 +390,7 @@ export function getFloatingRailCSS() {
     }
 
     .rail-highlight-toggle[data-highlight-state="active"] .color-indicator {
-      border-color: ${hexToRgba(color.white, 0.88)};
+      border-color: var(--rail-border-white-a88);
       transform: scale(0.86);
     }
 
@@ -357,8 +402,8 @@ export function getFloatingRailCSS() {
       display: flex;
       gap: ${spacing.xs};
       padding: ${spacing.xs};
-      background: ${theme.light.surface};
-      border: 1px solid ${theme.light.border};
+      background: var(--rail-surface);
+      border: 1px solid var(--rail-border);
       border-radius: ${radius.md};
       box-shadow: ${shadow.sm};
       backdrop-filter: blur(12px);
@@ -366,13 +411,6 @@ export function getFloatingRailCSS() {
       opacity: 0;
       pointer-events: none;
       transition: opacity 0.15s ease;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      .color-palette {
-        background: ${theme.dark.surface};
-        border-color: ${theme.dark.border};
-      }
     }
 
     .color-palette.visible {
@@ -390,16 +428,16 @@ export function getFloatingRailCSS() {
 
     .color-swatch:hover,
     .color-swatch:focus-visible {
-      border-color: ${color.brand};
+      border-color: var(--rail-color-brand);
     }
 
     .color-swatch.selected {
-      border-color: ${color.brand};
+      border-color: var(--rail-color-brand);
     }
 
     .rail-status {
       font-size: 11px;
-      color: ${color.textMuted};
+      color: var(--rail-color-text-muted);
       text-align: center;
       max-width: 34px;
       overflow: hidden;
@@ -413,8 +451,8 @@ export function getFloatingRailCSS() {
       right: calc(100% + ${spacing.sm});
       top: 50%;
       transform: translateY(-50%) translateX(4px);
-      background: ${color.danger};
-      color: ${color.white};
+      background: var(--rail-color-danger);
+      color: var(--rail-color-white);
       padding: 4px ${spacing.sm};
       border-radius: ${radius.sm};
       font-size: 12px;

--- a/scripts/highlighter/ui/styles/floatingRailStyles.js
+++ b/scripts/highlighter/ui/styles/floatingRailStyles.js
@@ -321,6 +321,7 @@ export function getFloatingRailCSS() {
     }
 
     .rail-highlight-toggle[data-highlight-state="inactive"] {
+      /* Fallback first for browsers without color-mix(); supported browsers override with the color-mix() line. */
       background: var(--rail-highlight-tint, var(--rail-color-primary-a40));
       background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 40%, transparent);
       color: var(--rail-icon-muted);
@@ -329,6 +330,7 @@ export function getFloatingRailCSS() {
 
     .rail-highlight-toggle[data-highlight-state="inactive"]:hover,
     .rail-highlight-toggle[data-highlight-state="inactive"]:focus-visible {
+      /* Fallback first for browsers without color-mix(); supported browsers override with the color-mix() line. */
       background: var(--rail-highlight-tint, var(--rail-color-primary-a55));
       background: color-mix(in srgb, var(--rail-highlight-color, var(--rail-color-primary)) 55%, transparent);
       transform: translateY(-1px);

--- a/scripts/highlighter/ui/styles/toastStyles.js
+++ b/scripts/highlighter/ui/styles/toastStyles.js
@@ -94,21 +94,21 @@ function getToastBaseCSS() {
 function getToastStatusModifierCSS() {
   return `
         .toast--success {
-            background: var(--toast-color-success-bg);
-            color: var(--toast-color-success-text);
-            border-color: var(--toast-color-success-border);
+            background: var(--toast-color-success-bg, #dcfce7);
+            color: var(--toast-color-success-text, #166534);
+            border-color: var(--toast-color-success-border, #bbf7d0);
         }
 
         .toast--warning {
-            background: var(--toast-color-warning-bg);
-            color: var(--toast-color-warning-text);
-            border-color: var(--toast-color-warning-border);
+            background: var(--toast-color-warning-bg, #fef3c7);
+            color: var(--toast-color-warning-text, #92400e);
+            border-color: var(--toast-color-warning-border, #fcd34d);
         }
 
         .toast--error {
-            background: var(--toast-color-error-bg);
-            color: var(--toast-color-error-text);
-            border-color: var(--toast-color-error-border);
+            background: var(--toast-color-error-bg, #fee2e2);
+            color: var(--toast-color-error-text, #991b1b);
+            border-color: var(--toast-color-error-border, #fecaca);
         }
   `;
 }

--- a/scripts/highlighter/ui/styles/toastStyles.js
+++ b/scripts/highlighter/ui/styles/toastStyles.js
@@ -3,6 +3,31 @@ import { UI_TOKENS } from '../../../../styles/ui-token-constants.js';
 const { status, spacing, radius, shadow } = UI_TOKENS;
 
 /**
+ * 取得 Toast 的色彩 CSS 變數定義。
+ *
+ * 邊界規則：色彩類 token 走 var bridge，維度 token (spacing, radius, shadow) 仍走 JS 內插。
+ *
+ * @returns {string} CSS 變數字串
+ */
+export function getToastThemeVars() {
+  return `
+    :host {
+      --toast-color-success-bg: ${status.successBg};
+      --toast-color-success-text: ${status.successText};
+      --toast-color-success-border: ${status.successBorder};
+
+      --toast-color-warning-bg: ${status.warningBg};
+      --toast-color-warning-text: ${status.warningText};
+      --toast-color-warning-border: ${status.warningBorder};
+
+      --toast-color-error-bg: ${status.errorBg};
+      --toast-color-error-text: ${status.errorText};
+      --toast-color-error-border: ${status.errorBorder};
+    }
+  `;
+}
+
+/**
  * 取得 Toast 的完整 CSS 字串，供 Shadow DOM 使用。
  *
  * 設計重點：
@@ -15,6 +40,8 @@ const { status, spacing, radius, shadow } = UI_TOKENS;
  */
 export function getToastCSS() {
   return `
+        ${getToastThemeVars()}
+
         :host {
             all: initial;
             position: fixed;
@@ -76,21 +103,21 @@ export function getToastCSS() {
         }
 
         .toast--success {
-            background: ${status.successBg};
-            color: ${status.successText};
-            border-color: ${status.successBorder};
+            background: var(--toast-color-success-bg);
+            color: var(--toast-color-success-text);
+            border-color: var(--toast-color-success-border);
         }
 
         .toast--warning {
-            background: ${status.warningBg};
-            color: ${status.warningText};
-            border-color: ${status.warningBorder};
+            background: var(--toast-color-warning-bg);
+            color: var(--toast-color-warning-text);
+            border-color: var(--toast-color-warning-border);
         }
 
         .toast--error {
-            background: ${status.errorBg};
-            color: ${status.errorText};
-            border-color: ${status.errorBorder};
+            background: var(--toast-color-error-bg);
+            color: var(--toast-color-error-text);
+            border-color: var(--toast-color-error-border);
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/scripts/highlighter/ui/styles/toastStyles.js
+++ b/scripts/highlighter/ui/styles/toastStyles.js
@@ -27,21 +27,8 @@ export function getToastThemeVars() {
   `;
 }
 
-/**
- * 取得 Toast 的完整 CSS 字串，供 Shadow DOM 使用。
- *
- * 設計重點：
- * - `:host` 用 `all: initial` 隔離宿主頁面 CSS
- * - `:host` 設 `pointer-events: none`，避免覆蓋住底層內容；container 自己再開 `pointer-events: auto`
- * - 用 `transition` + `.toast--visible` modifier 控制顯示/淡出，避免 `@keyframes` 在生命週期切換時造成的 race
- * - 三組 status modifier（success/warning/error）共用 token registry
- *
- * @returns {string} CSS 字串
- */
-export function getToastCSS() {
+function getToastBaseCSS() {
   return `
-        ${getToastThemeVars()}
-
         :host {
             all: initial;
             position: fixed;
@@ -101,7 +88,11 @@ export function getToastCSS() {
             flex: 1;
             word-break: break-word;
         }
+  `;
+}
 
+function getToastStatusModifierCSS() {
+  return `
         .toast--success {
             background: var(--toast-color-success-bg);
             color: var(--toast-color-success-text);
@@ -119,13 +110,37 @@ export function getToastCSS() {
             color: var(--toast-color-error-text);
             border-color: var(--toast-color-error-border);
         }
+  `;
+}
 
+function getToastMotionCSS() {
+  return `
         @media (prefers-reduced-motion: reduce) {
             .toast-container {
                 transition: none;
                 transform: none;
             }
         }
+  `;
+}
+
+/**
+ * 取得 Toast 的完整 CSS 字串，供 Shadow DOM 使用。
+ *
+ * 設計重點：
+ * - `:host` 用 `all: initial` 隔離宿主頁面 CSS
+ * - `:host` 設 `pointer-events: none`，避免覆蓋住底層內容；container 自己再開 `pointer-events: auto`
+ * - 用 `transition` + `.toast--visible` modifier 控制顯示/淡出，避免 `@keyframes` 在生命週期切換時造成的 race
+ * - 三組 status modifier（success/warning/error）共用 token registry
+ *
+ * @returns {string} CSS 字串
+ */
+export function getToastCSS() {
+  return `
+        ${getToastThemeVars()}
+        ${getToastBaseCSS()}
+        ${getToastStatusModifierCSS()}
+        ${getToastMotionCSS()}
     `;
 }
 

--- a/tests/unit/highlighter/ui/styles/floatingRailStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/floatingRailStyles.test.js
@@ -20,20 +20,24 @@ describe('floatingRailStyles', () => {
       expect(css).toContain(UI_TOKENS.theme.dark.border);
     });
 
-    test('trigger tile 應套用 brand 色與 white icon 色', () => {
-      expect(css).toMatch(/\.rail-trigger\s*\{[\s\S]*?background:\s*#F47565/);
-      expect(css).toMatch(/\.rail-trigger\s*\{[\s\S]*?color:\s*#FFFFFF/);
+    test('trigger tile 應套用 brand 色與 white icon 色變數並以 var() 引用', () => {
+      expect(css).toMatch(/--rail-color-brand:\s*#F47565/i);
+      expect(css).toMatch(/--rail-color-icon-on-accent:\s*#FFFFFF/i);
+      expect(css).toMatch(/\.rail-trigger\s*\{[\s\S]*?background:\s*var\(--rail-color-brand\)/);
+      expect(css).toMatch(/\.rail-trigger\s*\{[\s\S]*?color:\s*var\(--rail-color-icon-on-accent\)/);
     });
 
-    test('save / sync tile 應套用 actionSave 色', () => {
+    test('save / sync tile 應套用 actionSave 色變數並以 var() 引用', () => {
+      expect(css).toMatch(/--rail-color-action-save:\s*#0A84FF/i);
       expect(css).toMatch(
-        /\.rail-action-btn\[data-action="save"\][^{]*,\s*\.rail-action-btn\[data-action="sync"\][^{]*\{[\s\S]*?background:\s*#0A84FF/
+        /\.rail-action-btn\[data-action="save"\][^{]*,\s*\.rail-action-btn\[data-action="sync"\][^{]*\{[\s\S]*?background:\s*var\(--rail-color-action-save\)/
       );
     });
 
-    test('manage tile 應套用 actionManage violet 色，避免與 light/dark 容器底色混同', () => {
+    test('manage tile 應套用 actionManage violet 色變數並以 var() 引用，避免與 light/dark 容器底色混同', () => {
+      expect(css).toMatch(/--rail-color-action-manage:\s*#8B5CF6/i);
       expect(css).toMatch(
-        /\.rail-action-btn\[data-action="manage"\]\s*\{[\s\S]*?background:\s*#8B5CF6/
+        /\.rail-action-btn\[data-action="manage"\]\s*\{[\s\S]*?background:\s*var\(--rail-color-action-manage\)/
       );
     });
 
@@ -43,8 +47,15 @@ describe('floatingRailStyles', () => {
       );
     });
 
-    test('highlight tile inactive 應使用 0.40 alpha tint 與 muted icon 色', () => {
-      expect(css).toMatch(/\[data-highlight-state="inactive"\]\s*\{[\s\S]*?background:[^;]*0\.4/);
+    test('highlight tile inactive 應使用 0.40 alpha tint 變數、muted icon 色變數與 ring 變數', () => {
+      expect(css).toMatch(/--rail-color-primary-a40:\s*rgba\(37,\s*99,\s*235,\s*0\.4\)/i);
+      expect(css).toMatch(/--rail-ring-white-strong:\s*rgba\(255,\s*255,\s*255,\s*0\.45\)/i);
+      expect(css).toMatch(
+        /\[data-highlight-state="inactive"\]\s*\{[\s\S]*?background:\s*var\(--rail-highlight-tint,\s*var\(--rail-color-primary-a40\)\)/
+      );
+      expect(css).toMatch(
+        /\[data-highlight-state="inactive"\]\s*\{[\s\S]*?box-shadow:\s*inset\s+0\s+0\s+0\s+1px\s+var\(--rail-ring-white-strong\)/
+      );
       expect(css).toMatch(
         /\[data-highlight-state="inactive"\]\s*\{[\s\S]*?color:\s*var\(--rail-icon-muted/
       );
@@ -52,15 +63,17 @@ describe('floatingRailStyles', () => {
 
     test('highlight tile active 應使用實色背景與深色 icon stroke', () => {
       expect(css).toMatch(
-        /\[data-highlight-state="active"\]\s*\{[\s\S]*?background:\s*var\(--rail-highlight-color/
+        /\[data-highlight-state="active"\]\s*\{[\s\S]*?background:\s*var\(--rail-highlight-color,\s*var\(--rail-color-primary\)\)/
       );
       expect(css).toMatch(
         /\[data-highlight-state="active"\]\s*\{[\s\S]*?color:\s*rgba\(0,\s*0,\s*0,\s*0\.78\)/
       );
     });
 
-    test('color-swatch selected 應使用 brand 色而非 text 色', () => {
-      expect(css).toMatch(/\.color-swatch\.selected\s*\{[\s\S]*?border-color:\s*#F47565/);
+    test('color-swatch selected 應使用 brand 色變數並以 var() 引用', () => {
+      expect(css).toMatch(
+        /\.color-swatch\.selected\s*\{[\s\S]*?border-color:\s*var\(--rail-color-brand\)/
+      );
     });
 
     test('應包含 .rail-error-tooltip 樣式', () => {

--- a/tests/unit/highlighter/ui/styles/toastStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toastStyles.test.js
@@ -2,6 +2,36 @@ import {
   getToastCSS,
   injectToastStylesIntoShadowRoot,
 } from '../../../../../scripts/highlighter/ui/styles/toastStyles.js';
+import { UI_TOKENS } from '../../../../../styles/ui-token-constants.js';
+
+const { status } = UI_TOKENS;
+
+const toastStatusCases = [
+  {
+    modifier: 'success',
+    statusKeys: {
+      bg: 'successBg',
+      text: 'successText',
+      border: 'successBorder',
+    },
+  },
+  {
+    modifier: 'warning',
+    statusKeys: {
+      bg: 'warningBg',
+      text: 'warningText',
+      border: 'warningBorder',
+    },
+  },
+  {
+    modifier: 'error',
+    statusKeys: {
+      bg: 'errorBg',
+      text: 'errorText',
+      border: 'errorBorder',
+    },
+  },
+];
 
 describe('toastStyles', () => {
   describe('getToastCSS', () => {
@@ -18,52 +48,29 @@ describe('toastStyles', () => {
       expect(css).toMatch(/\.toast-container\s*\{[\s\S]*?pointer-events:\s*auto/);
     });
 
-    test('success modifier 應使用 status.successBg/Text/Border 變數並以 var() 引用', () => {
-      // 驗證 :host 內的變數定義
-      expect(css).toMatch(/--toast-color-success-bg:\s*#dcfce7/i);
-      expect(css).toMatch(/--toast-color-success-text:\s*#166534/i);
-      expect(css).toMatch(/--toast-color-success-border:\s*#bbf7d0/i);
-      // 驗證類別內的 var() 引用
-      expect(css).toMatch(
-        /\.toast--success\s*\{[\s\S]*?background:\s*var\(--toast-color-success-bg\)/
-      );
-      expect(css).toMatch(
-        /\.toast--success\s*\{[\s\S]*?color:\s*var\(--toast-color-success-text\)/
-      );
-      expect(css).toMatch(
-        /\.toast--success\s*\{[\s\S]*?border-color:\s*var\(--toast-color-success-border\)/
-      );
-    });
-
-    test('warning modifier 應使用 status.warningBg/Text/Border 變數並以 var() 引用', () => {
-      // 驗證 :host 內的變數定義
-      expect(css).toMatch(/--toast-color-warning-bg:\s*#fef3c7/i);
-      expect(css).toMatch(/--toast-color-warning-text:\s*#92400e/i);
-      expect(css).toMatch(/--toast-color-warning-border:\s*#fcd34d/i);
-      // 驗證類別內的 var() 引用
-      expect(css).toMatch(
-        /\.toast--warning\s*\{[\s\S]*?background:\s*var\(--toast-color-warning-bg\)/
-      );
-      expect(css).toMatch(
-        /\.toast--warning\s*\{[\s\S]*?color:\s*var\(--toast-color-warning-text\)/
-      );
-      expect(css).toMatch(
-        /\.toast--warning\s*\{[\s\S]*?border-color:\s*var\(--toast-color-warning-border\)/
-      );
-    });
-
-    test('error modifier 應使用 status.errorBg/Text/Border 變數並以 var() 引用', () => {
-      // 驗證 :host 內的變數定義
-      expect(css).toMatch(/--toast-color-error-bg:\s*#fee2e2/i);
-      expect(css).toMatch(/--toast-color-error-text:\s*#991b1b/i);
-      expect(css).toMatch(/--toast-color-error-border:\s*#fecaca/i);
-      // 驗證類別內的 var() 引用
-      expect(css).toMatch(/\.toast--error\s*\{[\s\S]*?background:\s*var\(--toast-color-error-bg\)/);
-      expect(css).toMatch(/\.toast--error\s*\{[\s\S]*?color:\s*var\(--toast-color-error-text\)/);
-      expect(css).toMatch(
-        /\.toast--error\s*\{[\s\S]*?border-color:\s*var\(--toast-color-error-border\)/
-      );
-    });
+    test.each(toastStatusCases)(
+      '$modifier modifier 應使用對應 status.*Bg/Text/Border 變數並以 var() 引用',
+      ({ modifier, statusKeys }) => {
+        expect(css).toContain(`--toast-color-${modifier}-bg: ${status[statusKeys.bg]}`);
+        expect(css).toContain(`--toast-color-${modifier}-text: ${status[statusKeys.text]}`);
+        expect(css).toContain(`--toast-color-${modifier}-border: ${status[statusKeys.border]}`);
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg\)`
+          )
+        );
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text\)`
+          )
+        );
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border\)`
+          )
+        );
+      }
+    );
 
     test('應定義 .toast--success/.toast--warning/.toast--error 三組 modifier', () => {
       expect(css).toMatch(/\.toast--success\s*\{/);

--- a/tests/unit/highlighter/ui/styles/toastStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toastStyles.test.js
@@ -2,7 +2,6 @@ import {
   getToastCSS,
   injectToastStylesIntoShadowRoot,
 } from '../../../../../scripts/highlighter/ui/styles/toastStyles.js';
-import { UI_TOKENS } from '../../../../../styles/ui-token-constants.js';
 
 describe('toastStyles', () => {
   describe('getToastCSS', () => {
@@ -19,22 +18,51 @@ describe('toastStyles', () => {
       expect(css).toMatch(/\.toast-container\s*\{[\s\S]*?pointer-events:\s*auto/);
     });
 
-    test('success modifier 應使用 status.successBg/Text/Border', () => {
-      expect(css).toContain(UI_TOKENS.status.successBg);
-      expect(css).toContain(UI_TOKENS.status.successText);
-      expect(css).toContain(UI_TOKENS.status.successBorder);
+    test('success modifier 應使用 status.successBg/Text/Border 變數並以 var() 引用', () => {
+      // 驗證 :host 內的變數定義
+      expect(css).toMatch(/--toast-color-success-bg:\s*#dcfce7/i);
+      expect(css).toMatch(/--toast-color-success-text:\s*#166534/i);
+      expect(css).toMatch(/--toast-color-success-border:\s*#bbf7d0/i);
+      // 驗證類別內的 var() 引用
+      expect(css).toMatch(
+        /\.toast--success\s*\{[\s\S]*?background:\s*var\(--toast-color-success-bg\)/
+      );
+      expect(css).toMatch(
+        /\.toast--success\s*\{[\s\S]*?color:\s*var\(--toast-color-success-text\)/
+      );
+      expect(css).toMatch(
+        /\.toast--success\s*\{[\s\S]*?border-color:\s*var\(--toast-color-success-border\)/
+      );
     });
 
-    test('warning modifier 應使用 status.warningBg/Text/Border', () => {
-      expect(css).toContain(UI_TOKENS.status.warningBg);
-      expect(css).toContain(UI_TOKENS.status.warningText);
-      expect(css).toContain(UI_TOKENS.status.warningBorder);
+    test('warning modifier 應使用 status.warningBg/Text/Border 變數並以 var() 引用', () => {
+      // 驗證 :host 內的變數定義
+      expect(css).toMatch(/--toast-color-warning-bg:\s*#fef3c7/i);
+      expect(css).toMatch(/--toast-color-warning-text:\s*#92400e/i);
+      expect(css).toMatch(/--toast-color-warning-border:\s*#fcd34d/i);
+      // 驗證類別內的 var() 引用
+      expect(css).toMatch(
+        /\.toast--warning\s*\{[\s\S]*?background:\s*var\(--toast-color-warning-bg\)/
+      );
+      expect(css).toMatch(
+        /\.toast--warning\s*\{[\s\S]*?color:\s*var\(--toast-color-warning-text\)/
+      );
+      expect(css).toMatch(
+        /\.toast--warning\s*\{[\s\S]*?border-color:\s*var\(--toast-color-warning-border\)/
+      );
     });
 
-    test('error modifier 應使用 status.errorBg/Text/Border', () => {
-      expect(css).toContain(UI_TOKENS.status.errorBg);
-      expect(css).toContain(UI_TOKENS.status.errorText);
-      expect(css).toContain(UI_TOKENS.status.errorBorder);
+    test('error modifier 應使用 status.errorBg/Text/Border 變數並以 var() 引用', () => {
+      // 驗證 :host 內的變數定義
+      expect(css).toMatch(/--toast-color-error-bg:\s*#fee2e2/i);
+      expect(css).toMatch(/--toast-color-error-text:\s*#991b1b/i);
+      expect(css).toMatch(/--toast-color-error-border:\s*#fecaca/i);
+      // 驗證類別內的 var() 引用
+      expect(css).toMatch(/\.toast--error\s*\{[\s\S]*?background:\s*var\(--toast-color-error-bg\)/);
+      expect(css).toMatch(/\.toast--error\s*\{[\s\S]*?color:\s*var\(--toast-color-error-text\)/);
+      expect(css).toMatch(
+        /\.toast--error\s*\{[\s\S]*?border-color:\s*var\(--toast-color-error-border\)/
+      );
     });
 
     test('應定義 .toast--success/.toast--warning/.toast--error 三組 modifier', () => {

--- a/tests/unit/highlighter/ui/styles/toastStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toastStyles.test.js
@@ -33,6 +33,33 @@ const toastStatusCases = [
   },
 ];
 
+const toastStatusFallbackCases = [
+  {
+    modifier: 'success',
+    fallback: {
+      bg: '#dcfce7',
+      text: '#166534',
+      border: '#bbf7d0',
+    },
+  },
+  {
+    modifier: 'warning',
+    fallback: {
+      bg: '#fef3c7',
+      text: '#92400e',
+      border: '#fcd34d',
+    },
+  },
+  {
+    modifier: 'error',
+    fallback: {
+      bg: '#fee2e2',
+      text: '#991b1b',
+      border: '#fecaca',
+    },
+  },
+];
+
 describe('toastStyles', () => {
   describe('getToastCSS', () => {
     const css = getToastCSS();
@@ -56,17 +83,38 @@ describe('toastStyles', () => {
         expect(css).toContain(`--toast-color-${modifier}-border: ${status[statusKeys.border]}`);
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg\)`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg,`
           )
         );
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text\)`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text,`
           )
         );
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border\)`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border,`
+          )
+        );
+      }
+    );
+
+    test.each(toastStatusFallbackCases)(
+      '$modifier modifier 應在 var() 內提供 status fallback 色',
+      ({ modifier, fallback }) => {
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg,\s*${fallback.bg}\)`
+          )
+        );
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text,\s*${fallback.text}\)`
+          )
+        );
+        expect(css).toMatch(
+          new RegExp(
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border,\s*${fallback.border}\)`
           )
         );
       }


### PR DESCRIPTION
### 摘要
實作 CSS Token-Var Bridge 以改善 toast 樣式的可維護性和一致性。

### 變更內容
- 將 toast 的顏色樣式改為使用 CSS 變數，提升樣式的可重用性。
- 減少重複的樣式定義，透過變數引用來簡化 CSS。
- 測試用例更新，以確保新的變數引用正確。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

