### PR TITLE
refactor: remove redundant hex fallbacks in toast styles

### DIFF
--- a/scripts/highlighter/ui/styles/toastStyles.js
+++ b/scripts/highlighter/ui/styles/toastStyles.js
@@ -94,21 +94,21 @@ function getToastBaseCSS() {
 function getToastStatusModifierCSS() {
   return `
         .toast--success {
-            background: var(--toast-color-success-bg, #dcfce7);
-            color: var(--toast-color-success-text, #166534);
-            border-color: var(--toast-color-success-border, #bbf7d0);
+            background: var(--toast-color-success-bg);
+            color: var(--toast-color-success-text);
+            border-color: var(--toast-color-success-border);
         }
 
         .toast--warning {
-            background: var(--toast-color-warning-bg, #fef3c7);
-            color: var(--toast-color-warning-text, #92400e);
-            border-color: var(--toast-color-warning-border, #fcd34d);
+            background: var(--toast-color-warning-bg);
+            color: var(--toast-color-warning-text);
+            border-color: var(--toast-color-warning-border);
         }
 
         .toast--error {
-            background: var(--toast-color-error-bg, #fee2e2);
-            color: var(--toast-color-error-text, #991b1b);
-            border-color: var(--toast-color-error-border, #fecaca);
+            background: var(--toast-color-error-bg);
+            color: var(--toast-color-error-text);
+            border-color: var(--toast-color-error-border);
         }
   `;
 }

--- a/tests/unit/highlighter/ui/styles/toastStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toastStyles.test.js
@@ -76,8 +76,9 @@ describe('toastStyles', () => {
       '$modifier modifier 規則不得殘留 raw hex（no-raw-hex-leak，色值只存在於 :host 變數定義）',
       ({ modifier }) => {
         const ruleBody = css.match(new RegExp(String.raw`\.toast--${modifier}\s*\{([\s\S]*?)\}`));
-        expect(ruleBody).not.toBeNull();
-        expect(ruleBody[1]).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+        const modifierRuleBody = ruleBody?.[1];
+        expect(modifierRuleBody).toEqual(expect.any(String));
+        expect(modifierRuleBody).not.toMatch(/#[0-9a-fA-F]{3,6}/);
       }
     );
 

--- a/tests/unit/highlighter/ui/styles/toastStyles.test.js
+++ b/tests/unit/highlighter/ui/styles/toastStyles.test.js
@@ -33,33 +33,6 @@ const toastStatusCases = [
   },
 ];
 
-const toastStatusFallbackCases = [
-  {
-    modifier: 'success',
-    fallback: {
-      bg: '#dcfce7',
-      text: '#166534',
-      border: '#bbf7d0',
-    },
-  },
-  {
-    modifier: 'warning',
-    fallback: {
-      bg: '#fef3c7',
-      text: '#92400e',
-      border: '#fcd34d',
-    },
-  },
-  {
-    modifier: 'error',
-    fallback: {
-      bg: '#fee2e2',
-      text: '#991b1b',
-      border: '#fecaca',
-    },
-  },
-];
-
 describe('toastStyles', () => {
   describe('getToastCSS', () => {
     const css = getToastCSS();
@@ -76,47 +49,35 @@ describe('toastStyles', () => {
     });
 
     test.each(toastStatusCases)(
-      '$modifier modifier 應使用對應 status.*Bg/Text/Border 變數並以 var() 引用',
+      '$modifier modifier 應於 :host 定義 status 變數並以無 fallback 的 var() 引用',
       ({ modifier, statusKeys }) => {
         expect(css).toContain(`--toast-color-${modifier}-bg: ${status[statusKeys.bg]}`);
         expect(css).toContain(`--toast-color-${modifier}-text: ${status[statusKeys.text]}`);
         expect(css).toContain(`--toast-color-${modifier}-border: ${status[statusKeys.border]}`);
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg,`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg\)`
           )
         );
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text,`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text\)`
           )
         );
         expect(css).toMatch(
           new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border,`
+            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border\)`
           )
         );
       }
     );
 
-    test.each(toastStatusFallbackCases)(
-      '$modifier modifier 應在 var() 內提供 status fallback 色',
-      ({ modifier, fallback }) => {
-        expect(css).toMatch(
-          new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?background:\s*var\(--toast-color-${modifier}-bg,\s*${fallback.bg}\)`
-          )
-        );
-        expect(css).toMatch(
-          new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?color:\s*var\(--toast-color-${modifier}-text,\s*${fallback.text}\)`
-          )
-        );
-        expect(css).toMatch(
-          new RegExp(
-            String.raw`\.toast--${modifier}\s*\{[\s\S]*?border-color:\s*var\(--toast-color-${modifier}-border,\s*${fallback.border}\)`
-          )
-        );
+    test.each(toastStatusCases)(
+      '$modifier modifier 規則不得殘留 raw hex（no-raw-hex-leak，色值只存在於 :host 變數定義）',
+      ({ modifier }) => {
+        const ruleBody = css.match(new RegExp(String.raw`\.toast--${modifier}\s*\{([\s\S]*?)\}`));
+        expect(ruleBody).not.toBeNull();
+        expect(ruleBody[1]).not.toMatch(/#[0-9a-fA-F]{3,6}/);
       }
     );
 


### PR DESCRIPTION
### 摘要
移除 toast 樣式中的冗餘十六進制備用顏色，確保缺失的自定義屬性能夠明確報錯。

### 變更內容
- 刪除 toast 狀態修飾符中的十六進制備用顏色。
- 確保使用 `var()` 引用自定義顏色，無備用顏色。
- 添加測試以確保樣式中不再包含原始十六進制顏色。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

