### PR TITLE
fix: use optional chaining in sanitizer URI check

### DIFF
--- a/scripts/content/sanitizers/htmlSanitizer.js
+++ b/scripts/content/sanitizers/htmlSanitizer.js
@@ -97,7 +97,7 @@ function isEmptyHtmlInput(html) {
 }
 
 function isUnsafeDataUri(value) {
-  return Boolean(value && value.toLowerCase().startsWith('data:') && !SAFE_URI_REGEXP.test(value));
+  return Boolean(value?.toLowerCase().startsWith('data:') && !SAFE_URI_REGEXP.test(value));
 }
 
 function removeUnsafeDataUriAttribute(node, attributeName) {


### PR DESCRIPTION
### 摘要
修正 HTML 清理器中的 URI 檢查，使用可選鏈接以增強安全性。

### 變更內容
- 在 `isUnsafeDataUri` 函數中，使用可選鏈接來檢查 `value` 是否存在，避免在 `value` 為 `null` 或 `undefined` 時引發錯誤。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

