### PR TITLE
refactor: simplify window API structure

### DIFF
--- a/scripts/highlighter/index.js
+++ b/scripts/highlighter/index.js
@@ -26,11 +26,11 @@ import { mountWindowAPI } from './windowAPI.js';
 function remountWindowAPI(manager, toolbar, storage) {
   // toast 由 manager.setDependencies 注入，這裡統一從 manager 讀取，
   // 避免每個 call site 各自把 toast 拼進 state object。
-  mountWindowAPI(
+  mountWindowAPI({
     manager,
     toolbar,
     storage,
-    {
+    fns: {
       init: opts => {
         const nextManager = initHighlighter(opts);
         remountWindowAPI(nextManager, null, nextManager.storage);
@@ -42,8 +42,8 @@ function remountWindowAPI(manager, toolbar, storage) {
         return nextState;
       },
     },
-    manager.toast
-  );
+    toast: manager.toast,
+  });
 }
 
 /**

--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -122,6 +122,7 @@ function isLegacyUiHiddenOrCollapsed(legacyUi) {
 }
 
 function buildHighlighterV2API({ manager, toolbar, restoreManager, toast, fns, state }) {
+  const apiFns = fns ?? {};
   const api = {
     manager,
     toolbar,
@@ -152,11 +153,11 @@ function buildHighlighterV2API({ manager, toolbar, restoreManager, toast, fns, s
   };
 
   // 可選函數（將 initHighlighter / initHighlighterWithToolbar 從 index.js 導入）
-  if (fns.init) {
-    api.init = fns.init;
+  if (apiFns.init) {
+    api.init = apiFns.init;
   }
-  if (fns.initWithToolbar) {
-    api.initWithToolbar = fns.initWithToolbar;
+  if (apiFns.initWithToolbar) {
+    api.initWithToolbar = apiFns.initWithToolbar;
   }
 
   return api;

--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -121,7 +121,7 @@ function isLegacyUiHiddenOrCollapsed(legacyUi) {
   return LEGACY_INACTIVE_UI_STATES.has(legacyUi.stateManager?.currentState);
 }
 
-function buildHighlighterV2API(manager, toolbar, restoreManager, toast, fns, state) {
+function buildHighlighterV2API({ manager, toolbar, restoreManager, toast, fns, state }) {
   const api = {
     manager,
     toolbar,
@@ -212,15 +212,16 @@ function buildLegacyHighlighterAPI(manager, restoreManager, state) {
 /**
  * 將 Highlighter V2 API 掛載到 globalThis
  *
- * @param {import('./core/HighlightManager.js').HighlightManager} manager
- * @param {import('./ui/Toolbar.js').Toolbar|null} toolbar
- * @param {import('./core/HighlightStorage.js').HighlightStorage} storage
- * @param {{ init?: Function, initWithToolbar?: Function }} [fns={}] - 可選函數導入層，避免循環依賴
- * @param {import('./ui/Toast.js').Toast|null} [toast=null] - 可選的 Toast 實例；
+ * @param {object} options
+ * @param {import('./core/HighlightManager.js').HighlightManager} options.manager
+ * @param {import('./ui/Toolbar.js').Toolbar|null} [options.toolbar=null]
+ * @param {import('./core/HighlightStorage.js').HighlightStorage} options.storage
+ * @param {{ init?: Function, initWithToolbar?: Function }} [options.fns={}] - 可選函數導入層，避免循環依賴
+ * @param {import('./ui/Toast.js').Toast|null} [options.toast=null] - 可選的 Toast 實例；
  *   若提供，會暴露在 `HighlighterV2.toast` 供 dev tools / cleanup 使用，
  *   業務邏輯（addHighlight / removeHighlight）已透過 manager 注入直接觸發。
  */
-export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null) {
+export function mountWindowAPI({ manager, toolbar = null, storage, fns = {}, toast = null }) {
   const restoreManager = storage;
   const state = {
     currentToolbar: toolbar,
@@ -230,14 +231,14 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null
   };
 
   // 新版 HighlighterV2 API
-  globalThis.HighlighterV2 = buildHighlighterV2API(
+  globalThis.HighlighterV2 = buildHighlighterV2API({
     manager,
     toolbar,
     restoreManager,
     toast,
     fns,
-    state
-  );
+    state,
+  });
 
   // 🔑 向後兼容：設置舊版 notionHighlighter API
   globalThis.notionHighlighter = buildLegacyHighlighterAPI(manager, restoreManager, state);

--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -28,6 +28,7 @@ import Logger from '../utils/Logger.js';
 // `Toolbar` import + `ensureToolbar` body only ship in test bundles. See
 // [docs/plans/2026-05-14-windowapi-legacy-compat-hardening-plan.md](../../docs/plans/2026-05-14-windowapi-legacy-compat-hardening-plan.md).
 const TOOLBAR_TEST_FIXTURE_ENABLED = globalThis.__UNIT_TESTING__ !== false;
+const LEGACY_INACTIVE_UI_STATES = new Set(['hidden', 'collapsed']);
 
 function ensureToolbar(state) {
   if (!TOOLBAR_TEST_FIXTURE_ENABLED) {
@@ -84,28 +85,44 @@ function getLegacyUiController(state) {
   return null;
 }
 
-/**
- * 將 Highlighter V2 API 掛載到 globalThis
- *
- * @param {import('./core/HighlightManager.js').HighlightManager} manager
- * @param {import('./ui/Toolbar.js').Toolbar|null} toolbar
- * @param {import('./core/HighlightStorage.js').HighlightStorage} storage
- * @param {{ init?: Function, initWithToolbar?: Function }} [fns={}] - 可選函數導入層，避免循環依賴
- * @param {import('./ui/Toast.js').Toast|null} [toast=null] - 可選的 Toast 實例；
- *   若提供，會暴露在 `HighlighterV2.toast` 供 dev tools / cleanup 使用，
- *   業務邏輯（addHighlight / removeHighlight）已透過 manager 注入直接觸發。
- */
-export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null) {
-  const restoreManager = storage;
-  const state = {
-    currentToolbar: toolbar,
-    isCreatingToolbar: false,
-    manager,
-    storage,
-  };
+function resolveToolbarActiveState(state) {
+  const toolbarState = state.currentToolbar?.stateManager?.currentState;
+  if (typeof toolbarState !== 'string') {
+    return null;
+  }
+  return toolbarState !== 'hidden';
+}
 
-  // 新版 HighlighterV2 API
-  globalThis.HighlighterV2 = {
+function warnMissingActiveUi() {
+  Logger.warn('[Highlighter] isActive 在無 UI 時被調用', {
+    action: 'isActive',
+    reason: 'toolbar_disabled_and_rail_missing',
+  });
+}
+
+function isRailActive(rail) {
+  if (rail.host?.style?.display === 'none') {
+    return false;
+  }
+
+  const railState = rail.stateManager?.currentState;
+  if (typeof railState !== 'string') {
+    return false;
+  }
+
+  return !LEGACY_INACTIVE_UI_STATES.has(railState);
+}
+
+function isLegacyUiHiddenOrCollapsed(legacyUi) {
+  if (legacyUi.host?.style?.display === 'none') {
+    return true;
+  }
+
+  return LEGACY_INACTIVE_UI_STATES.has(legacyUi.stateManager?.currentState);
+}
+
+function buildHighlighterV2API(manager, toolbar, restoreManager, toast, fns, state) {
+  const api = {
     manager,
     toolbar,
     restoreManager,
@@ -132,13 +149,21 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null
     getInstance: () => manager,
     getToolbar: () => state.currentToolbar,
     getRestoreManager: () => restoreManager,
-    // 可選函數（將 initHighlighter / initHighlighterWithToolbar 從 index.js 導入）
-    ...(fns.init ? { init: fns.init } : {}),
-    ...(fns.initWithToolbar ? { initWithToolbar: fns.initWithToolbar } : {}),
   };
 
-  // 🔑 向後兼容：設置舊版 notionHighlighter API
-  globalThis.notionHighlighter = {
+  // 可選函數（將 initHighlighter / initHighlighterWithToolbar 從 index.js 導入）
+  if (fns.init) {
+    api.init = fns.init;
+  }
+  if (fns.initWithToolbar) {
+    api.initWithToolbar = fns.initWithToolbar;
+  }
+
+  return api;
+}
+
+function buildLegacyHighlighterAPI(manager, restoreManager, state) {
+  return {
     manager,
     restoreManager,
     show: () => {
@@ -151,28 +176,18 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null
       legacyUi?.collapse?.();
     },
     isActive: () => {
-      const toolbarState = state.currentToolbar?.stateManager?.currentState;
-      if (typeof toolbarState === 'string') {
-        return toolbarState !== 'hidden';
+      const toolbarActiveState = resolveToolbarActiveState(state);
+      if (toolbarActiveState !== null) {
+        return toolbarActiveState;
       }
 
       const rail = globalThis.HighlighterV2?.rail;
       if (!rail) {
-        Logger.warn('[Highlighter] isActive 在無 UI 時被調用', {
-          action: 'isActive',
-          reason: 'toolbar_disabled_and_rail_missing',
-        });
+        warnMissingActiveUi();
         return false;
       }
 
-      const railState = rail.stateManager?.currentState;
-      const isHidden = rail.host?.style?.display === 'none';
-      return (
-        !isHidden &&
-        typeof railState === 'string' &&
-        railState !== 'collapsed' &&
-        railState !== 'hidden'
-      );
+      return isRailActive(rail);
     },
     toggle: () => {
       const legacyUi = getLegacyUiController(state);
@@ -180,20 +195,52 @@ export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null
         return;
       }
 
-      const toolbarState = legacyUi.stateManager?.currentState;
-      const isRailHidden = legacyUi.host?.style?.display === 'none';
-
-      if (toolbarState === 'hidden' || toolbarState === 'collapsed' || isRailHidden) {
+      if (isLegacyUiHiddenOrCollapsed(legacyUi)) {
         legacyUi.show?.();
-      } else {
-        legacyUi.hide?.();
+        return;
       }
+
+      legacyUi.hide?.();
     },
     collectHighlights: () => manager.collectHighlightsForNotion(),
     clearAll: (options = {}) => manager.clearAll(options),
     getCount: () => manager.getCount(),
     forceRestoreHighlights: () => restoreManager.restore(),
   };
+}
+
+/**
+ * 將 Highlighter V2 API 掛載到 globalThis
+ *
+ * @param {import('./core/HighlightManager.js').HighlightManager} manager
+ * @param {import('./ui/Toolbar.js').Toolbar|null} toolbar
+ * @param {import('./core/HighlightStorage.js').HighlightStorage} storage
+ * @param {{ init?: Function, initWithToolbar?: Function }} [fns={}] - 可選函數導入層，避免循環依賴
+ * @param {import('./ui/Toast.js').Toast|null} [toast=null] - 可選的 Toast 實例；
+ *   若提供，會暴露在 `HighlighterV2.toast` 供 dev tools / cleanup 使用，
+ *   業務邏輯（addHighlight / removeHighlight）已透過 manager 注入直接觸發。
+ */
+export function mountWindowAPI(manager, toolbar, storage, fns = {}, toast = null) {
+  const restoreManager = storage;
+  const state = {
+    currentToolbar: toolbar,
+    isCreatingToolbar: false,
+    manager,
+    storage,
+  };
+
+  // 新版 HighlighterV2 API
+  globalThis.HighlighterV2 = buildHighlighterV2API(
+    manager,
+    toolbar,
+    restoreManager,
+    toast,
+    fns,
+    state
+  );
+
+  // 🔑 向後兼容：設置舊版 notionHighlighter API
+  globalThis.notionHighlighter = buildLegacyHighlighterAPI(manager, restoreManager, state);
 
   // 🔑 全域函數別名（向後兼容）
   globalThis.initHighlighter = () => {

--- a/scripts/highlighter/windowAPI.js
+++ b/scripts/highlighter/windowAPI.js
@@ -90,35 +90,28 @@ function resolveToolbarActiveState(state) {
   if (typeof toolbarState !== 'string') {
     return null;
   }
-  return toolbarState !== 'hidden';
+  return !LEGACY_INACTIVE_UI_STATES.has(toolbarState);
 }
 
 function warnMissingActiveUi() {
   Logger.warn('[Highlighter] isActive 在無 UI 時被調用', {
     action: 'isActive',
     reason: 'toolbar_disabled_and_rail_missing',
+    result: 'blocked',
   });
 }
 
-function isRailActive(rail) {
-  if (rail.host?.style?.display === 'none') {
-    return false;
-  }
-
-  const railState = rail.stateManager?.currentState;
-  if (typeof railState !== 'string') {
-    return false;
-  }
-
-  return !LEGACY_INACTIVE_UI_STATES.has(railState);
-}
-
-function isLegacyUiHiddenOrCollapsed(legacyUi) {
+function isLegacyUiActive(legacyUi) {
   if (legacyUi.host?.style?.display === 'none') {
-    return true;
+    return false;
   }
 
-  return LEGACY_INACTIVE_UI_STATES.has(legacyUi.stateManager?.currentState);
+  const uiState = legacyUi.stateManager?.currentState;
+  if (typeof uiState !== 'string') {
+    return false;
+  }
+
+  return !LEGACY_INACTIVE_UI_STATES.has(uiState);
 }
 
 function buildHighlighterV2API({ manager, toolbar, restoreManager, toast, fns, state }) {
@@ -188,7 +181,7 @@ function buildLegacyHighlighterAPI(manager, restoreManager, state) {
         return false;
       }
 
-      return isRailActive(rail);
+      return isLegacyUiActive(rail);
     },
     toggle: () => {
       const legacyUi = getLegacyUiController(state);
@@ -196,12 +189,12 @@ function buildLegacyHighlighterAPI(manager, restoreManager, state) {
         return;
       }
 
-      if (isLegacyUiHiddenOrCollapsed(legacyUi)) {
-        legacyUi.show?.();
+      if (isLegacyUiActive(legacyUi)) {
+        legacyUi.hide?.();
         return;
       }
 
-      legacyUi.hide?.();
+      legacyUi.show?.();
     },
     collectHighlights: () => manager.collectHighlightsForNotion(),
     clearAll: (options = {}) => manager.clearAll(options),

--- a/tests/unit/highlighter/core/HighlightManager.deleteRecursionGuard.test.js
+++ b/tests/unit/highlighter/core/HighlightManager.deleteRecursionGuard.test.js
@@ -98,7 +98,7 @@ describe('HighlightManager delete recursion guard', () => {
       rangeInfo: {},
     });
 
-    mountWindowAPI(manager, null, storage);
+    mountWindowAPI({ manager, toolbar: null, storage });
   });
 
   afterEach(() => {

--- a/tests/unit/highlighter/highlighter-index.test.js
+++ b/tests/unit/highlighter/highlighter-index.test.js
@@ -285,8 +285,8 @@ describe('Highlighter Index', () => {
 
         expect(windowAPIMock.mountWindowAPI).toHaveBeenCalled();
 
-        const mountCallArgs = windowAPIMock.mountWindowAPI.mock.calls[0];
-        const funcs = mountCallArgs[3];
+        const mountOptions = windowAPIMock.mountWindowAPI.mock.calls[0][0];
+        const funcs = mountOptions.fns;
 
         funcs.init();
         expect(windowAPIMock.mountWindowAPI).toHaveBeenCalledTimes(2);

--- a/tests/unit/highlighter/windowAPI.clearPageHighlights.test.js
+++ b/tests/unit/highlighter/windowAPI.clearPageHighlights.test.js
@@ -61,7 +61,7 @@ describe('windowAPI.clearPageHighlights — skipStorage contract', () => {
   });
 
   test('globalThis.clearPageHighlights() 應走 skipStorage 路徑、不觸發 storage.save', () => {
-    mountWindowAPI(manager, null, mockStorage);
+    mountWindowAPI({ manager, toolbar: null, storage: mockStorage });
 
     globalThis.clearPageHighlights();
 
@@ -71,7 +71,7 @@ describe('windowAPI.clearPageHighlights — skipStorage contract', () => {
   });
 
   test('notionHighlighter.clearAll() 預設行為（無參）仍會觸發 storage.save', () => {
-    mountWindowAPI(manager, null, mockStorage);
+    mountWindowAPI({ manager, toolbar: null, storage: mockStorage });
 
     globalThis.notionHighlighter.clearAll();
 
@@ -81,7 +81,7 @@ describe('windowAPI.clearPageHighlights — skipStorage contract', () => {
   });
 
   test('notionHighlighter.clearAll({ skipStorage: true }) 應跳過 storage.save', () => {
-    mountWindowAPI(manager, null, mockStorage);
+    mountWindowAPI({ manager, toolbar: null, storage: mockStorage });
 
     globalThis.notionHighlighter.clearAll({ skipStorage: true });
 

--- a/tests/unit/highlighter/windowAPI.test.js
+++ b/tests/unit/highlighter/windowAPI.test.js
@@ -76,6 +76,20 @@ describe('windowAPI', () => {
     expect(tbInstance.minimize).toHaveBeenCalled();
   });
 
+  test('isActive() 應將 toolbar collapsed 視為 inactive', () => {
+    mountWithMocks();
+
+    globalThis.notionHighlighter.show();
+    const tbInstance = globalThis.HighlighterV2.getToolbar();
+    tbInstance.stateManager.currentState = 'collapsed';
+
+    expect(globalThis.notionHighlighter.isActive()).toBe(false);
+
+    tbInstance.stateManager.currentState = 'visible';
+
+    expect(globalThis.notionHighlighter.isActive()).toBe(true);
+  });
+
   test('ensureToolbar 防止並行創建', () => {
     mountWithMocks();
     // Simulate concurrent creation in ensureToolbar
@@ -241,6 +255,7 @@ describe('windowAPI', () => {
         expect.objectContaining({
           action: 'isActive',
           reason: 'toolbar_disabled_and_rail_missing',
+          result: 'blocked',
         })
       );
     });
@@ -314,6 +329,14 @@ describe('windowAPI', () => {
       globalThis.notionHighlighter.toggle();
 
       expect(railShow).toHaveBeenCalledTimes(2);
+      expect(railHide).not.toHaveBeenCalled();
+
+      globalThis.HighlighterV2.rail.stateManager = {};
+      globalThis.HighlighterV2.rail.host.style.display = 'block';
+
+      globalThis.notionHighlighter.toggle();
+
+      expect(railShow).toHaveBeenCalledTimes(3);
       expect(railHide).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/highlighter/windowAPI.test.js
+++ b/tests/unit/highlighter/windowAPI.test.js
@@ -15,6 +15,10 @@ jest.mock('../../../scripts/highlighter/ui/Toolbar.js', () => ({
 describe('windowAPI', () => {
   let mockManager, mockStorage;
 
+  function mountWithMocks() {
+    mountWindowAPI({ manager: mockManager, toolbar: null, storage: mockStorage });
+  }
+
   beforeEach(() => {
     mockManager = {
       collectHighlightsForNotion: jest.fn().mockReturnValue(['mock-highlight']),
@@ -35,7 +39,7 @@ describe('windowAPI', () => {
   });
 
   test('mountWindowAPI 應掛載 API 並提供輔助方法', () => {
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
 
     expect(globalThis.HighlighterV2).toBeDefined();
     expect(globalThis.notionHighlighter).toBeDefined();
@@ -46,7 +50,7 @@ describe('windowAPI', () => {
   });
 
   test('ensureToolbar 和 notionHighlighter 方法應能正確運作 (toggle/hide/minimize)', () => {
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
 
     expect(() => globalThis.notionHighlighter.minimize()).not.toThrow();
 
@@ -65,7 +69,7 @@ describe('windowAPI', () => {
   });
 
   test('ensureToolbar 防止並行創建', () => {
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
     // Simulate concurrent creation in ensureToolbar
     Toolbar.mockImplementationOnce(() => {
       // While creating, try to call toggle which calls ensureToolbar again
@@ -89,7 +93,7 @@ describe('windowAPI', () => {
   });
 
   test('notionHighlighter 其他委派方法', () => {
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
     globalThis.notionHighlighter.collectHighlights();
     expect(mockManager.collectHighlightsForNotion).toHaveBeenCalled();
 
@@ -103,7 +107,7 @@ describe('windowAPI', () => {
   });
 
   test('全球向後兼容別名方法', () => {
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
 
     // Uncovered: 149-152 initHighlighter
     globalThis.initHighlighter();
@@ -130,7 +134,7 @@ describe('windowAPI', () => {
     // So we just simulate them not existing or existing but without notionHighlighter
 
     // We mount it but then wipe the global
-    mountWindowAPI(mockManager, null, mockStorage);
+    mountWithMocks();
     const notionHL = globalThis.notionHighlighter;
     delete globalThis.notionHighlighter;
 
@@ -147,6 +151,10 @@ describe('windowAPI', () => {
     let prodMountWindowAPI;
     let prodManager;
     let prodStorage;
+
+    function prodMountWithMocks() {
+      prodMountWindowAPI({ manager: prodManager, toolbar: null, storage: prodStorage });
+    }
 
     beforeEach(() => {
       jest.resetModules();
@@ -189,7 +197,7 @@ describe('windowAPI', () => {
     });
 
     test('show() 在 toolbar 與 rail 皆缺席時應 Logger.warn 一次並帶 metadata', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       // 確保 rail 不存在
       delete globalThis.HighlighterV2.rail;
 
@@ -210,7 +218,7 @@ describe('windowAPI', () => {
     });
 
     test('isActive() 在 toolbar state 與 rail 皆缺席時應 Logger.warn 一次並回 false', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       delete globalThis.HighlighterV2.rail;
 
       const result = globalThis.notionHighlighter.isActive();
@@ -230,7 +238,7 @@ describe('windowAPI', () => {
     });
 
     test('isActive() 在 rail 存在時不應觸發 warn', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       globalThis.HighlighterV2.rail = {
         stateManager: { currentState: 'visible' },
         host: { style: { display: 'block' } },
@@ -246,7 +254,7 @@ describe('windowAPI', () => {
     });
 
     test('isActive() 在 rail collapsed 或 hidden 時應回 false', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       globalThis.HighlighterV2.rail = {
         stateManager: { currentState: 'collapsed' },
         host: { style: { display: 'block' } },
@@ -260,7 +268,7 @@ describe('windowAPI', () => {
     });
 
     test('isActive() 在 rail display none 或 state 缺失時應回 false', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       globalThis.HighlighterV2.rail = {
         stateManager: { currentState: 'visible' },
         host: { style: { display: 'none' } },
@@ -277,7 +285,7 @@ describe('windowAPI', () => {
     });
 
     test('toggle() 在 rail collapsed 或 display none 時應呼叫 show()', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       const railShow = jest.fn();
       const railHide = jest.fn();
       globalThis.HighlighterV2.rail = {
@@ -302,7 +310,7 @@ describe('windowAPI', () => {
     });
 
     test('toggle() 在 rail visible 時應呼叫 hide()', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       const railShow = jest.fn();
       const railHide = jest.fn();
       globalThis.HighlighterV2.rail = {
@@ -319,7 +327,7 @@ describe('windowAPI', () => {
     });
 
     test('minimize() 在 rail-only 環境下應呼叫 rail.collapse()', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
       const railCollapse = jest.fn();
       globalThis.HighlighterV2.rail = {
         collapse: railCollapse,
@@ -334,7 +342,7 @@ describe('windowAPI', () => {
 
     test('Branch A indirect alive: notionHighlighter.collectHighlights() 應委派到 manager', () => {
       prodManager.collectHighlightsForNotion.mockReturnValue([{ id: 'mock' }]);
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
 
       const result = globalThis.notionHighlighter.collectHighlights();
 
@@ -343,7 +351,7 @@ describe('windowAPI', () => {
     });
 
     test('Branch A indirect alive: notionHighlighter.clearAll() 應委派到 manager', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
 
       globalThis.notionHighlighter.clearAll();
 
@@ -352,7 +360,7 @@ describe('windowAPI', () => {
 
     test('Branch A direct alive: globalThis.collectHighlights() 應透過 alias 委派到 manager (executeScript page-context contract)', () => {
       prodManager.collectHighlightsForNotion.mockReturnValue([{ id: 'via-alias' }]);
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
 
       const result = globalThis.collectHighlights();
 
@@ -361,7 +369,7 @@ describe('windowAPI', () => {
     });
 
     test('Branch A direct alive: globalThis.clearPageHighlights() 應透過 alias 委派到 manager (executeScript page-context contract)', () => {
-      prodMountWindowAPI(prodManager, null, prodStorage);
+      prodMountWithMocks();
 
       globalThis.clearPageHighlights();
 

--- a/tests/unit/highlighter/windowAPI.test.js
+++ b/tests/unit/highlighter/windowAPI.test.js
@@ -245,6 +245,79 @@ describe('windowAPI', () => {
       expect(matched).toBeUndefined();
     });
 
+    test('isActive() 在 rail collapsed 或 hidden 時應回 false', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+      globalThis.HighlighterV2.rail = {
+        stateManager: { currentState: 'collapsed' },
+        host: { style: { display: 'block' } },
+      };
+
+      expect(globalThis.notionHighlighter.isActive()).toBe(false);
+
+      globalThis.HighlighterV2.rail.stateManager.currentState = 'hidden';
+
+      expect(globalThis.notionHighlighter.isActive()).toBe(false);
+    });
+
+    test('isActive() 在 rail display none 或 state 缺失時應回 false', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+      globalThis.HighlighterV2.rail = {
+        stateManager: { currentState: 'visible' },
+        host: { style: { display: 'none' } },
+      };
+
+      expect(globalThis.notionHighlighter.isActive()).toBe(false);
+
+      globalThis.HighlighterV2.rail = {
+        stateManager: {},
+        host: { style: { display: 'block' } },
+      };
+
+      expect(globalThis.notionHighlighter.isActive()).toBe(false);
+    });
+
+    test('toggle() 在 rail collapsed 或 display none 時應呼叫 show()', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+      const railShow = jest.fn();
+      const railHide = jest.fn();
+      globalThis.HighlighterV2.rail = {
+        show: railShow,
+        hide: railHide,
+        stateManager: { currentState: 'collapsed' },
+        host: { style: { display: 'block' } },
+      };
+
+      globalThis.notionHighlighter.toggle();
+
+      expect(railShow).toHaveBeenCalledTimes(1);
+      expect(railHide).not.toHaveBeenCalled();
+
+      globalThis.HighlighterV2.rail.stateManager.currentState = 'visible';
+      globalThis.HighlighterV2.rail.host.style.display = 'none';
+
+      globalThis.notionHighlighter.toggle();
+
+      expect(railShow).toHaveBeenCalledTimes(2);
+      expect(railHide).not.toHaveBeenCalled();
+    });
+
+    test('toggle() 在 rail visible 時應呼叫 hide()', () => {
+      prodMountWindowAPI(prodManager, null, prodStorage);
+      const railShow = jest.fn();
+      const railHide = jest.fn();
+      globalThis.HighlighterV2.rail = {
+        show: railShow,
+        hide: railHide,
+        stateManager: { currentState: 'visible' },
+        host: { style: { display: 'block' } },
+      };
+
+      globalThis.notionHighlighter.toggle();
+
+      expect(railHide).toHaveBeenCalledTimes(1);
+      expect(railShow).not.toHaveBeenCalled();
+    });
+
     test('minimize() 在 rail-only 環境下應呼叫 rail.collapse()', () => {
       prodMountWindowAPI(prodManager, null, prodStorage);
       const railCollapse = jest.fn();

--- a/tests/unit/highlighter/windowAPI.test.js
+++ b/tests/unit/highlighter/windowAPI.test.js
@@ -49,6 +49,14 @@ describe('windowAPI', () => {
     expect(globalThis.HighlighterV2.getToolbar()).toBeNull();
   });
 
+  test('mountWindowAPI 在 fns 為 null 時仍應正常掛載', () => {
+    mountWindowAPI({ manager: mockManager, toolbar: null, storage: mockStorage, fns: null });
+
+    expect(globalThis.HighlighterV2).toBeDefined();
+    expect(globalThis.HighlighterV2.init).toBeUndefined();
+    expect(globalThis.HighlighterV2.initWithToolbar).toBeUndefined();
+  });
+
   test('ensureToolbar 和 notionHighlighter 方法應能正確運作 (toggle/hide/minimize)', () => {
     mountWithMocks();
 


### PR DESCRIPTION
### 摘要
重構窗口 API，簡化其結構和使用方式。

### 變更內容
- 將 `mountWindowAPI` 函數的參數從多個獨立參數改為單一物件參數，提升可讀性。
- 將相關的掛載選項進行分組，減少 API 的複雜性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

