### PR TITLE
refactor: flatten config facade

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,10 +56,8 @@ module.exports = {
     '<rootDir>/scripts/**/*.js',
     '<rootDir>/pages/**/*.js',
     '!<rootDir>/scripts/config/app.js',                // 純常量配置
-    '!<rootDir>/scripts/config/icons.js',              // 純 SVG 字串常量
     '!<rootDir>/scripts/config/ui.js',                 // 純 CSS 選擇器與類名常量
     '!<rootDir>/scripts/config/extraction.js',         // 純選擇器與數值常量
-    '!<rootDir>/scripts/config/highlightConstants.js', // 純數值常量
     '!<rootDir>/scripts/config/index.js',              // 純 re-export barrel file
     '!<rootDir>/scripts/config/extension/**/*.js',     // extension-only 純常量配置與 re-export
     // Toolbar 鏈：DCE guard 位於 scripts/highlighter/windowAPI.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,9 +55,6 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/scripts/**/*.js',
     '<rootDir>/pages/**/*.js',
-    '!<rootDir>/scripts/config/app.js',                // 純常量配置
-    '!<rootDir>/scripts/config/ui.js',                 // 純 CSS 選擇器與類名常量
-    '!<rootDir>/scripts/config/extraction.js',         // 純選擇器與數值常量
     '!<rootDir>/scripts/config/index.js',              // 純 re-export barrel file
     '!<rootDir>/scripts/config/extension/**/*.js',     // extension-only 純常量配置與 re-export
     // Toolbar 鏈：DCE guard 位於 scripts/highlighter/windowAPI.js

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -4,7 +4,7 @@ import { createSafeIcon } from '../../scripts/utils/securityUtils.js';
 import { sanitizeApiError } from '../../scripts/utils/ApiErrorSanitizer.js';
 import { ErrorHandler } from '../../scripts/utils/ErrorHandler.js';
 import { UI_MESSAGES } from '../../scripts/config/shared/messages.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { AuthMode } from '../../scripts/config/extension/authMode.js';
 import {
   getActiveNotionToken,

--- a/pages/options/MigrationTool.js
+++ b/pages/options/MigrationTool.js
@@ -3,8 +3,7 @@
  * 負責舊版標註數據的遷移 UI 與協調
  */
 /* global chrome */
-import { UI_ICONS } from '../../scripts/config/icons.js';
-import { COMMON_CSS_CLASSES } from '../../scripts/config/shared/ui.js';
+import { UI_ICONS, COMMON_CSS_CLASSES } from '../../scripts/config/shared/ui.js';
 import { RUNTIME_ACTIONS } from '../../scripts/config/shared/runtimeActions.js';
 import { ERROR_MESSAGES, UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 import Logger from '../../scripts/utils/Logger.js';

--- a/pages/options/SearchableDatabaseSelector.js
+++ b/pages/options/SearchableDatabaseSelector.js
@@ -8,7 +8,7 @@ import { createSafeIcon } from '../../scripts/utils/securityUtils.js';
 import { sanitizeApiError } from '../../scripts/utils/ApiErrorSanitizer.js';
 import { sanitizeUrlForLogging } from '../../scripts/utils/LogSanitizer.js';
 import { ErrorHandler } from '../../scripts/utils/ErrorHandler.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 
 const { DATA_SOURCE } = UI_MESSAGES;

--- a/pages/options/StorageManager.js
+++ b/pages/options/StorageManager.js
@@ -14,7 +14,7 @@ import {
 } from '../../scripts/utils/securityUtils.js';
 import { sanitizeApiError } from '../../scripts/utils/ApiErrorSanitizer.js';
 import { ErrorHandler } from '../../scripts/utils/ErrorHandler.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 import {
   sanitizeBackupData,

--- a/pages/options/UIManager.js
+++ b/pages/options/UIManager.js
@@ -8,9 +8,8 @@ import {
   separateIconAndText,
   createSafeIcon,
 } from '../../scripts/utils/securityUtils.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
 import { NOTION_API } from '../../scripts/config/extension/notionApi.js';
-import { UI_STATUS_TYPES } from '../../scripts/config/shared/ui.js';
+import { UI_ICONS, UI_STATUS_TYPES } from '../../scripts/config/shared/ui.js';
 
 /**
  * 選項頁面的 UI 選擇器常數

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -12,7 +12,7 @@ import { MigrationTool } from './MigrationTool.js';
 import { AuthMode } from '../../scripts/config/extension/authMode.js';
 import { BUILD_ENV } from '../../scripts/config/env/index.js';
 import { UI_MESSAGES, ERROR_MESSAGES } from '../../scripts/config/shared/messages.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { RUNTIME_ACTIONS } from '../../scripts/config/shared/runtimeActions.js';
 import { injectIcons } from '../../scripts/utils/uiUtils.js';
 import Logger from '../../scripts/utils/Logger.js';

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -24,7 +24,7 @@ import {
   formatSaveSuccessMessage,
 } from './popupUI.js';
 import { injectIcons } from '../../scripts/utils/uiUtils.js';
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import {
   checkSettings,
   checkPageStatus,
@@ -40,7 +40,7 @@ import {
 import Logger from '../../scripts/utils/Logger.js';
 import { BUILD_ENV } from '../../scripts/config/env/index.js';
 import { RUNTIME_ACTIONS } from '../../scripts/config/shared/runtimeActions.js';
-import { isSavedStatusResponse } from '../../scripts/config/saveStatus.js';
+import { isSavedStatusResponse } from '../../scripts/config/shared/saveStatus.js';
 import { ErrorHandler } from '../../scripts/utils/ErrorHandler.js';
 import { ERROR_MESSAGES, UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 import { sanitizeApiError } from '../../scripts/utils/ApiErrorSanitizer.js';

--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -4,7 +4,7 @@
  * 提供純函數來更新 Popup UI 狀態，便於單元測試。
  * 這些函數不直接依賴 Chrome API，僅操作 DOM 元素。
  */
-import { UI_ICONS } from '../../scripts/config/icons.js';
+import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 import { resolveAccountDisplayProfile } from '../../scripts/utils/accountDisplayUtils.js';
 

--- a/scripts/background/handlers/saveHandlers.js
+++ b/scripts/background/handlers/saveHandlers.js
@@ -26,7 +26,7 @@ import { ErrorHandler } from '../../utils/ErrorHandler.js';
 import { CONTENT_QUALITY } from '../../config/shared/content.js';
 import { ERROR_MESSAGES } from '../../config/messages/errorMessages.js';
 import { RUNTIME_ACTIONS } from '../../config/shared/runtimeActions.js';
-import { SAVE_STATUS_KINDS, createSaveStatusResponse } from '../../config/saveStatus.js';
+import { SAVE_STATUS_KINDS, createSaveStatusResponse } from '../../config/shared/saveStatus.js';
 import { isRestrictedInjectionUrl } from '../services/InjectionService.js';
 import { resolveSaveStatus } from '../services/SaveStatusCoordinator.js';
 import {

--- a/scripts/background/services/SaveStatusCoordinator.js
+++ b/scripts/background/services/SaveStatusCoordinator.js
@@ -1,5 +1,5 @@
 import { HANDLER_CONSTANTS } from '../../config/shared/core.js';
-import { SAVE_STATUS_KINDS, createSaveStatusResponse } from '../../config/saveStatus.js';
+import { SAVE_STATUS_KINDS, createSaveStatusResponse } from '../../config/shared/saveStatus.js';
 
 function defaultLogger() {
   return {

--- a/scripts/background/utils/BlockBuilder.js
+++ b/scripts/background/utils/BlockBuilder.js
@@ -11,7 +11,7 @@
 import { TEXT_PROCESSING } from '../../config/shared/content.js';
 import { EXTRACTION_FALLBACK_MESSAGES } from '../../config/messages/extractionFallbackMessages.js';
 import { NOTION_API } from '../../config/extension/notionApi.js';
-import { NOTION_CODE_LANGUAGE_PLAIN_TEXT } from '../../config/notionCodeLanguages.js';
+import { NOTION_CODE_LANGUAGE_PLAIN_TEXT } from '../../config/shared/notionCodeLanguages.js';
 
 /**
  * 文本內容最大長度（從統一配置獲取）

--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -14,7 +14,7 @@
 import {
   HIGHLIGHT_COLOR_WHITELIST,
   HIGHLIGHT_MATCH_SCORING,
-} from '../../config/highlightConstants.js';
+} from '../../config/shared/highlightConstants.js';
 
 // ============================================================================
 // 常量定義

--- a/scripts/config/highlightConstants.js
+++ b/scripts/config/highlightConstants.js
@@ -1,1 +1,0 @@
-export * from './shared/highlightConstants.js';

--- a/scripts/config/icons.js
+++ b/scripts/config/icons.js
@@ -1,1 +1,0 @@
-export { UI_ICONS } from './shared/ui.js';

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -7,12 +7,6 @@
  * 以確保 Content Script bundle 不會誤帶入 extension pages / Background 專用常量。
  */
 
-// Highlight 專用常量
-export * from './highlightConstants.js';
-
-// Notion Code 語言白名單與 fallback 常數
-export * from './notionCodeLanguages.js';
-
 // Content-safe shared configs (core, storage, ui, messaging, content)
 export * from './shared/index.js';
 

--- a/scripts/config/notionCodeLanguages.js
+++ b/scripts/config/notionCodeLanguages.js
@@ -1,1 +1,0 @@
-export * from './shared/notionCodeLanguages.js';

--- a/scripts/config/saveStatus.js
+++ b/scripts/config/saveStatus.js
@@ -1,1 +1,0 @@
-export * from './shared/saveStatus.js';

--- a/scripts/content/converters/DomConverter.js
+++ b/scripts/content/converters/DomConverter.js
@@ -21,7 +21,7 @@ import {
   NOTION_CODE_LANGUAGE_OBJECTIVE_C,
   NOTION_CODE_LANGUAGE_PLAIN_TEXT,
   NOTION_SUPPORTED_LANGUAGES,
-} from '../../config/notionCodeLanguages.js';
+} from '../../config/shared/notionCodeLanguages.js';
 import { sanitizeUrlForLogging } from '../../utils/LogSanitizer.js';
 
 /**

--- a/scripts/highlighter/utils/validation.js
+++ b/scripts/highlighter/utils/validation.js
@@ -3,7 +3,7 @@
  * 提供數據驗證相關的工具函式
  */
 
-import { HIGHLIGHT_COLOR_WHITELIST } from '../../config/highlightConstants.js';
+import { HIGHLIGHT_COLOR_WHITELIST } from '../../config/shared/highlightConstants.js';
 
 /**
  * 檢查字串是否非空

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=node_modules/**,dist/**,coverage/**,tests/**,**/*.test.js,**/*.
 # 覆蓋率排除清單（對齊 jest.config.js 的 collectCoverageFrom）
 # 兩類排除：(1) 純常量 config；(2) prod DCE 後 unreachable 的 Toolbar 鏈（見 jest.config.js 同段註釋）。
 # 這些檔案的覆蓋率不代表 production 行為，但仍接受 SonarCloud 的 issue / code smell 分析。
-sonar.coverage.exclusions=scripts/config/app.js,scripts/config/ui.js,scripts/config/extraction.js,scripts/config/index.js,scripts/config/extension/**/*.js,scripts/highlighter/ui/Toolbar.js,scripts/highlighter/ui/ToolbarRuntime.js,scripts/highlighter/ui/ToolbarState.js,scripts/highlighter/ui/ToolbarUI.js,scripts/highlighter/ui/styles/toolbarStyles.js,scripts/highlighter/ui/components/ColorPicker.js,scripts/highlighter/ui/components/MiniIcon.js,scripts/highlighter/ui/components/ToolbarContainer.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
+sonar.coverage.exclusions=scripts/config/index.js,scripts/config/extension/**/*.js,scripts/highlighter/ui/Toolbar.js,scripts/highlighter/ui/ToolbarRuntime.js,scripts/highlighter/ui/ToolbarState.js,scripts/highlighter/ui/ToolbarUI.js,scripts/highlighter/ui/styles/toolbarStyles.js,scripts/highlighter/ui/components/ColorPicker.js,scripts/highlighter/ui/components/MiniIcon.js,scripts/highlighter/ui/components/ToolbarContainer.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
 
 # 測試覆蓋率報告路徑（jest unit only；E2E coverage 不合併進 quality gate，避免 ghost-line 污染）
 sonar.javascript.lcov.reportPaths=coverage/jest/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=node_modules/**,dist/**,coverage/**,tests/**,**/*.test.js,**/*.
 # 覆蓋率排除清單（對齊 jest.config.js 的 collectCoverageFrom）
 # 兩類排除：(1) 純常量 config；(2) prod DCE 後 unreachable 的 Toolbar 鏈（見 jest.config.js 同段註釋）。
 # 這些檔案的覆蓋率不代表 production 行為，但仍接受 SonarCloud 的 issue / code smell 分析。
-sonar.coverage.exclusions=scripts/config/app.js,scripts/config/icons.js,scripts/config/ui.js,scripts/config/extraction.js,scripts/config/highlightConstants.js,scripts/config/index.js,scripts/config/extension/**/*.js,scripts/highlighter/ui/Toolbar.js,scripts/highlighter/ui/ToolbarRuntime.js,scripts/highlighter/ui/ToolbarState.js,scripts/highlighter/ui/ToolbarUI.js,scripts/highlighter/ui/styles/toolbarStyles.js,scripts/highlighter/ui/components/ColorPicker.js,scripts/highlighter/ui/components/MiniIcon.js,scripts/highlighter/ui/components/ToolbarContainer.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
+sonar.coverage.exclusions=scripts/config/app.js,scripts/config/ui.js,scripts/config/extraction.js,scripts/config/index.js,scripts/config/extension/**/*.js,scripts/highlighter/ui/Toolbar.js,scripts/highlighter/ui/ToolbarRuntime.js,scripts/highlighter/ui/ToolbarState.js,scripts/highlighter/ui/ToolbarUI.js,scripts/highlighter/ui/styles/toolbarStyles.js,scripts/highlighter/ui/components/ColorPicker.js,scripts/highlighter/ui/components/MiniIcon.js,scripts/highlighter/ui/components/ToolbarContainer.js,**/*.test.js,**/*.spec.js,tests/**,node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
 
 # 測試覆蓋率報告路徑（jest unit only；E2E coverage 不合併進 quality gate，避免 ghost-line 污染）
 sonar.javascript.lcov.reportPaths=coverage/jest/lcov.info

--- a/tests/unit/background/utils/BlockBuilder.test.js
+++ b/tests/unit/background/utils/BlockBuilder.test.js
@@ -29,7 +29,7 @@ const {
 } = require('../../../../scripts/background/utils/BlockBuilder');
 const {
   NOTION_CODE_LANGUAGE_PLAIN_TEXT,
-} = require('../../../../scripts/config/notionCodeLanguages.js');
+} = require('../../../../scripts/config/shared/notionCodeLanguages.js');
 const {
   EXTRACTION_FALLBACK_MESSAGES,
 } = require('../../../../scripts/config/messages/extractionFallbackMessages.js');

--- a/tests/unit/config/coverageExclusionsContract.test.js
+++ b/tests/unit/config/coverageExclusionsContract.test.js
@@ -41,9 +41,6 @@ describe('coverage exclusion contract', () => {
     const jestExclusions = readJestCoverageExclusions();
     const sonarExclusions = readSonarCoverageExclusions();
     const productionCoverageExclusions = [
-      'scripts/config/app.js',
-      'scripts/config/ui.js',
-      'scripts/config/extraction.js',
       'scripts/config/index.js',
       'scripts/config/extension/**/*.js',
       'scripts/highlighter/ui/Toolbar.js',

--- a/tests/unit/config/coverageExclusionsContract.test.js
+++ b/tests/unit/config/coverageExclusionsContract.test.js
@@ -42,10 +42,8 @@ describe('coverage exclusion contract', () => {
     const sonarExclusions = readSonarCoverageExclusions();
     const productionCoverageExclusions = [
       'scripts/config/app.js',
-      'scripts/config/icons.js',
       'scripts/config/ui.js',
       'scripts/config/extraction.js',
-      'scripts/config/highlightConstants.js',
       'scripts/config/index.js',
       'scripts/config/extension/**/*.js',
       'scripts/highlighter/ui/Toolbar.js',

--- a/tests/unit/config/saveStatus.test.js
+++ b/tests/unit/config/saveStatus.test.js
@@ -1,7 +1,7 @@
 import {
   isSavedStatusResponse,
   createSaveStatusResponse,
-} from '../../../scripts/config/saveStatus.js';
+} from '../../../scripts/config/shared/saveStatus.js';
 
 describe('saveStatus 邊界情境', () => {
   test('isSavedStatusResponse 對 null 狀態應回傳 false', () => {


### PR DESCRIPTION
### 摘要
重構配置系統，移除多餘的頂層重導，直接導入共享的標準源。

### 變更內容
- 移除四個不必要的頂層重導檔案：`icons.js`、`highlightConstants.js`、`notionCodeLanguages.js`、`saveStatus.js`。
- 更新15個調用者，改為直接導入`config/shared/*.js`。
- 清理指向已不存在檔案的覆蓋率排除設定。

### 測試方式
所有相關模組的測試均已通過，無需額外測試。

### 潛在風險
無顯著風險。

