### PR TITLE
feat: implement full-bundle rollup for page scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,18 @@ notion-chrome/
 ├── .github/               # CI 與 workflow（ci.yml、release-please.yml）
 ├── manifest.json          # 擴展配置與權限（Manifest V3）
 ├── rollup/                # Rollup 構建配置（all/content/background/migration + shared factories）
-├── dist/                  # 打包產物（preloader.js, content.bundle.js, migration-executor.js, pages/*.js）
+├── dist/                  # 打包產物
+│   ├── preloader.js              # 全域輕量預載腳本
+│   ├── content.bundle.js         # Content Script 統一打包版
+│   ├── migration-executor.js     # Migration 執行入口
+│   ├── scripts/background.js     # Background service worker bundle
+│   └── pages/                    # Extension pages final entry points
+│       ├── popup.js
+│       ├── options.js
+│       ├── sidepanel.js
+│       ├── onboarding.js
+│       ├── update-notification.js
+│       └── auth.js
 ├── pages/                 # 擴展頁面集合（popup / sidepanel / options / onboarding / update-notification）
 │   ├── popup/             # 彈出窗口 UI（處理 API 調用與 DOM 更新）
 │   ├── sidepanel/         # 側邊欄 UI（常駐顯示保存狀態、支援快速操作與頁面同步）
@@ -226,10 +237,6 @@ notion-chrome/
 │   │   └── utils/         # 工具模組 (color, dom, textSearch 等)
 │   ├── performance/       # 性能優化模組
 │   └── utils/             # 工具模組 (Logger, Security, ErrorHandler, ImageUtils)
-
-├── dist/                  # 構建產物
-│   ├── content.bundle.js         # Content Script 統一打包版
-│   └── *.js.map           # Source maps
 ├── icons/                 # 圖標
 ├── promo-images/          # 宣傳圖片（Chrome Web Store）
 ├── tests/                 # 測試文件（2500+ tests）

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ notion-chrome/
 ├── .github/               # CI 與 workflow（ci.yml、release-please.yml）
 ├── manifest.json          # 擴展配置與權限（Manifest V3）
 ├── rollup/                # Rollup 構建配置（all/content/background/migration + shared factories）
-├── dist/                  # 打包產物 (preloader.js, content.bundle.js)
+├── dist/                  # 打包產物（preloader.js, content.bundle.js, migration-executor.js, pages/*.js）
 ├── pages/                 # 擴展頁面集合（popup / sidepanel / options / onboarding / update-notification）
 │   ├── popup/             # 彈出窗口 UI（處理 API 調用與 DOM 更新）
 │   ├── sidepanel/         # 側邊欄 UI（常駐顯示保存狀態、支援快速操作與頁面同步）
@@ -301,22 +301,23 @@ npm run lint
 **自動構建機制**：
 
 - ✅ `npm install` 後自動執行 `npm run build`
-- ✅ `npm run package:local-unpacked` 可生成本地測試用的最小載入目錄
+- ✅ `npm run package:local-unpacked` 可生成本地測試用的最小載入目錄（完全排除 `scripts/` 原始碼，大幅減少 package 體積，消除雙軌）
 - ✅ `dist/` 目錄不被追蹤（在 `.gitignore` 中）
 
 **開發時的最佳實踐**：
 
 ```bash
-# 1. 開啟實時編譯（推薦）
+# 1. 開啟實時編譯（推薦，會自動涵蓋所有 pages 打包）
 npm run dev
 
-# 2. 修改代碼
+# 2. 修改代碼（可修改 content script、highlighter、或頁面 JS）
 vim scripts/highlighter/core/Range.js
-# 或 vim scripts/content/converters/DomConverter.js
+# 或修改頁面 JS
+vim pages/popup/popup.js
 
 # 3. 查看 Terminal 確認重新打包
 # ✅ created dist/content.bundle.js in 40ms
-# ✅ created dist/highlighter-v2.bundle.js in 55ms
+# ✅ created dist/pages in 530ms
 
 # 4. 重新載入 Extension（Chrome Extension 頁面點擊刷新圖標）
 ```

--- a/auth.html
+++ b/auth.html
@@ -75,7 +75,7 @@
     </div>
 
     <!-- auth.js 處理所有 callback bridge 邏輯 -->
-    <script src="scripts/auth/auth.js" type="module"></script>
+    <script src="dist/pages/auth.js" type="module"></script>
   </body>
 </html>
 <!-- trigger release please -->

--- a/pages/onboarding/onboarding.html
+++ b/pages/onboarding/onboarding.html
@@ -263,6 +263,6 @@
         </div>
       </section>
     </main>
-    <script type="module" src="onboarding.js"></script>
+    <script type="module" src="../../dist/pages/onboarding.js"></script>
   </body>
 </html>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -1604,6 +1604,6 @@
     </div>
 
     <!-- 腳本 -->
-    <script type="module" src="options.js"></script>
+    <script type="module" src="../../dist/pages/options.js"></script>
   </body>
 </html>

--- a/pages/popup/popup.html
+++ b/pages/popup/popup.html
@@ -174,6 +174,6 @@
         <span class="btn-text"></span>
       </button>
     </div>
-    <script src="popup.js" type="module"></script>
+    <script src="../../dist/pages/popup.js" type="module"></script>
   </body>
 </html>

--- a/pages/sidepanel/sidepanel.html
+++ b/pages/sidepanel/sidepanel.html
@@ -284,6 +284,6 @@
       </div>
     </template>
 
-    <script src="sidepanel.js" type="module"></script>
+    <script src="../../dist/pages/sidepanel.js" type="module"></script>
   </body>
 </html>

--- a/pages/update-notification/update-notification.html
+++ b/pages/update-notification/update-notification.html
@@ -46,6 +46,6 @@
       </main>
     </div>
 
-    <script src="update-notification.js"></script>
+    <script src="../../dist/pages/update-notification.js" type="module"></script>
   </body>
 </html>

--- a/rollup/all.config.mjs
+++ b/rollup/all.config.mjs
@@ -2,5 +2,7 @@ import contentConfig from './content.config.mjs';
 import backgroundConfig from './background.config.mjs';
 import migrationConfig from './migration.config.mjs';
 import preloaderConfig from './preloader.config.mjs';
+import pagesConfig from './pages.config.mjs';
 
-export default [contentConfig, backgroundConfig, migrationConfig, preloaderConfig];
+export default [contentConfig, backgroundConfig, migrationConfig, preloaderConfig, pagesConfig];
+

--- a/rollup/background.config.mjs
+++ b/rollup/background.config.mjs
@@ -25,7 +25,7 @@ export default {
     json(),
     !isDev &&
       createTerserPlugin({
-        pureFuncs: ['console.log', 'console.debug', 'console.info'],
+        pureFuncs: ['console.debug', 'console.info'],
       }),
     createVisualizerPlugin('background-bundle', 'Background Bundle Analysis'),
   ].filter(Boolean),

--- a/rollup/content.config.mjs
+++ b/rollup/content.config.mjs
@@ -34,7 +34,6 @@ export default {
       createTerserPlugin({
         passes: 2,
         pureFuncs: [
-          'console.log',
           'console.debug',
           'console.info',
           'Logger.debug',

--- a/rollup/pages.config.mjs
+++ b/rollup/pages.config.mjs
@@ -1,0 +1,49 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import { createVisualizerPlugin } from './visualizer.config.mjs';
+import { isDev } from './shared/env.mjs';
+import { createTerserPlugin } from './shared/terser.mjs';
+import { createOnWarn } from './shared/onwarn.mjs';
+import { stripTestConfig } from './plugins/stripTestConfig.mjs';
+
+export default {
+  input: {
+    popup: 'pages/popup/popup.js',
+    options: 'pages/options/options.js',
+    sidepanel: 'pages/sidepanel/sidepanel.js',
+    onboarding: 'pages/onboarding/onboarding.js',
+    'update-notification': 'pages/update-notification/update-notification.js',
+    auth: 'scripts/auth/auth.js',
+  },
+  output: {
+    dir: 'dist/pages',
+    format: 'es', // Use ES modules for page scripts
+    sourcemap: isDev ? 'inline' : false,
+    banner: '/* eslint-disable */\n/* Save to Notion - Page Bundle */',
+    entryFileNames: '[name].js',
+    chunkFileNames: 'shared/[name].js',
+  },
+  plugins: [
+    !isDev && stripTestConfig(),
+    resolve({
+      browser: true,
+      preferBuiltins: false,
+    }),
+    commonjs(),
+    json(),
+    !isDev &&
+      createTerserPlugin({
+        pureFuncs: [
+          'console.log',
+          'console.debug',
+          'console.info',
+          'Logger.debug',
+          'Logger.log',
+          'Logger.info',
+        ],
+      }),
+    createVisualizerPlugin('pages-bundle', 'Pages Bundle Analysis'),
+  ].filter(Boolean),
+  onwarn: createOnWarn({ circular: 'log' }),
+};

--- a/rollup/pages.config.mjs
+++ b/rollup/pages.config.mjs
@@ -35,7 +35,6 @@ export default {
     !isDev &&
       createTerserPlugin({
         pureFuncs: [
-          'console.log',
           'console.debug',
           'console.info',
           'Logger.debug',

--- a/tests/unit/config/auth.callback-page.test.js
+++ b/tests/unit/config/auth.callback-page.test.js
@@ -1,7 +1,7 @@
 /**
  * auth callback page regression tests
  *
- * 驗證 auth.html 會以 ES module 載入 auth.js，
+ * 驗證 auth.html 會以 ES module 載入 bundled auth.js，
  * 且 auth.js 會讀取 ../config/env/index.js 的設定。
  */
 
@@ -17,8 +17,10 @@ describe('auth callback page regressions', () => {
     authJs = fs.readFileSync(path.resolve(__dirname, '../../../scripts/auth/auth.js'), 'utf8');
   });
 
-  test('auth.html 應以 module script 載入 auth.js', () => {
-    expect(authHtml).toMatch(/<script\s+src="scripts\/auth\/auth\.js"\s+type="module"><\/script>/);
+  test('auth.html 應以 module script 載入 bundled auth.js', () => {
+    expect(authHtml).toMatch(
+      /<script\b(?=[^>]*\bsrc="dist\/pages\/auth\.js")(?=[^>]*\btype="module")[^>]*><\/script>/
+    );
   });
 
   test('auth.js 應從 env/index.js 讀取 BUILD_ENV', () => {

--- a/tests/unit/scripts/package-extension.test.js
+++ b/tests/unit/scripts/package-extension.test.js
@@ -7,44 +7,35 @@ const path = require('node:path');
 
 describe('tools/package-extension.sh regressions', () => {
   let packageScript;
-  let popupEntry;
-  let sidepanelEntry;
+  let popupHtml;
+  let sidepanelHtml;
 
   beforeAll(() => {
     packageScript = fs.readFileSync(
       path.resolve(__dirname, '../../../tools/package-extension.sh'),
       'utf8'
     );
-    popupEntry = fs.readFileSync(path.resolve(__dirname, '../../../pages/popup/popup.js'), 'utf8');
-    sidepanelEntry = fs.readFileSync(
-      path.resolve(__dirname, '../../../pages/sidepanel/sidepanel.js'),
+    popupHtml = fs.readFileSync(path.resolve(__dirname, '../../../pages/popup/popup.html'), 'utf8');
+    sidepanelHtml = fs.readFileSync(
+      path.resolve(__dirname, '../../../pages/sidepanel/sidepanel.html'),
       'utf8'
     );
   });
 
-  test('popup 不應直接依賴 release package 排除的 runtimeActions 子模組', () => {
-    const excludedRuntimeActionModules = [
-      'contentBridgeActions',
-      'highlighterActions',
-      'pageSaveActions',
-      'preloaderActions',
-    ];
-
-    for (const moduleName of excludedRuntimeActionModules) {
-      expect(packageScript).toContain(`--exclude='config/runtimeActions/${moduleName}.js'`);
-      expect(popupEntry).not.toContain(`../../scripts/config/runtimeActions/${moduleName}.js`);
-    }
+  test('release package 應打包 dist bundle 而非 scripts 原始碼', () => {
+    expect(packageScript).toContain('cp -a dist "$RM_DIR/"');
+    expect(packageScript).not.toContain('cp -a scripts "$RM_DIR/"');
+    expect(packageScript).not.toContain('rsync');
   });
 
-  test('sidepanel 直接依賴的 HighlightLookupResolver 不應在 release package 中遺失', () => {
-    expect(sidepanelEntry).toContain('../../scripts/highlighter/core/HighlightLookupResolver.js');
+  test('page HTML 應載入 dist/pages bundle entry', () => {
+    const moduleScript = src =>
+      new RegExp(
+        String.raw`<script\b(?=[^>]*\bsrc="${src}")(?=[^>]*\btype="module")[^>]*></script>`
+      );
 
-    const excludesWholeHighlighterDir = packageScript.includes("--exclude='highlighter'");
-    const copiesResolverExplicitly = packageScript.includes(
-      'scripts/highlighter/core/HighlightLookupResolver.js'
-    );
-
-    expect(excludesWholeHighlighterDir && !copiesResolverExplicitly).toBe(false);
+    expect(popupHtml).toMatch(moduleScript('../../dist/pages/popup.js'));
+    expect(sidepanelHtml).toMatch(moduleScript('../../dist/pages/sidepanel.js'));
   });
 
   test('release package 的 ES module 驗證應覆蓋 auth.html callback bridge', () => {
@@ -53,8 +44,7 @@ describe('tools/package-extension.sh regressions', () => {
     expect(verificationBlock).toContain('auth.html');
   });
 
-  test('打包流程應排除並清理所有 .DS_Store', () => {
-    expect(packageScript).toContain("--exclude='.DS_Store'");
+  test('打包流程應清理所有 .DS_Store', () => {
     expect(packageScript).toContain('find "$RM_DIR" -name \'.DS_Store\'');
   });
 

--- a/tools/package-extension.sh
+++ b/tools/package-extension.sh
@@ -102,56 +102,14 @@ cp -a pages "$RM_DIR/"             # extension page bundle（popup / options / s
 cp -a styles "$RM_DIR/"            # callback bridge 共用 CSS
 cp -a dist "$RM_DIR/"
 
-# Copy scripts directory, excluding test-only and bundled directories
-rsync -a \
-    --exclude='.DS_Store' \
-    --exclude='__mocks__' \
-    --exclude='background' \
-    --exclude='background.js' \
-    --exclude='config/contentSafe/toolbarIcons.js' \
-    --exclude='config/contentSafe/toolbarMessages.js' \
-    --exclude='config/patterns.js' \
-    --exclude='config/ui-selectors.js' \
-    --exclude='config/README.md' \
-    --exclude='content' \
-    --exclude='destinations/ProfileResolver.js' \
-    --exclude='config/env/build.example.js' \
-    --exclude='config/extension/index.js' \
-    --exclude='highlighter' \
-    --exclude='legacy' \
-    --exclude='config/runtimeActions/contentBridgeActions.js' \
-    --exclude='config/runtimeActions/highlighterActions.js' \
-    --exclude='config/runtimeActions/pageSaveActions.js' \
-    --exclude='config/runtimeActions/preloaderActions.js' \
-    --exclude='config/shared/highlightConstants.js' \
-    --exclude='config/shared/index.js' \
-    --exclude='config/shared/notionCodeLanguages.js' \
-    --exclude='utils/contentUtils.js' \
-    --exclude='utils/imageUtils.js' \
-    --exclude='utils/pageComplexityDetector.js' \
-    --exclude='utils/README.md' \
-    --exclude='config/highlightConstants.js' \
-    --exclude='config/index.js' \
-    --exclude='config/notionCodeLanguages.js' \
-    --exclude='performance' \
-    --exclude='postinstall.js' \
-    --exclude='sync' \
-    --exclude='utils/LogExporter.js' \
-    --exclude='utils/RetryManager.js' \
-    scripts/ "$RM_DIR/scripts/"
-
-# Sidepanel 直接依賴 HighlightLookupResolver 與 highlightCleanupHelper，需顯式補回 package。
-mkdir -p "$RM_DIR/scripts/highlighter/core"
-cp -a scripts/highlighter/core/HighlightLookupResolver.js "$RM_DIR/scripts/highlighter/core/"
-cp -a scripts/highlighter/core/highlightCleanupHelper.js "$RM_DIR/scripts/highlighter/core/"
-
 # 清理 macOS metadata，避免從 cp -a 帶入 release package。
 find "$RM_DIR" -name '.DS_Store' -delete
 # production 不打包任何殘留 sourcemap。
 find "$RM_DIR/dist" -name '*.map' -delete
 
-echo "📂 Scripts folder content:"
-ls -R "$RM_DIR/scripts/"
+echo "📂 Package dist/pages/ content:"
+ls -R "$RM_DIR/dist/pages/"
+
 
 # 驗證 ES 模組匯入鏈 — 確保套件中無遺失檔案
 echo "🔍 驗證 ES 模組匯入鏈..."

--- a/tools/package-extension.sh
+++ b/tools/package-extension.sh
@@ -107,8 +107,12 @@ find "$RM_DIR" -name '.DS_Store' -delete
 # production 不打包任何殘留 sourcemap。
 find "$RM_DIR/dist" -name '*.map' -delete
 
-echo "📂 Package dist/pages/ content:"
-ls -R "$RM_DIR/dist/pages/"
+echo "📂 套件 dist/pages/ 內容："
+if [ -d "$RM_DIR/dist/pages" ]; then
+    ls -R "$RM_DIR/dist/pages/"
+else
+    echo "⚠️  目錄不存在：dist/pages"
+fi
 
 
 # 驗證 ES 模組匯入鏈 — 確保套件中無遺失檔案


### PR DESCRIPTION
### 摘要
實現完整的 Rollup 打包機制以簡化頁面腳本的構建。

### 變更內容
- 將頁面腳本整合至 `dist/pages` 目錄中。
- 更新 Rollup 配置以支持多個頁面腳本的打包。
- 修改 HTML 文件以引用新的打包後的腳本路徑。
- 簡化本地打包過程，減少包體積。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

