### PR TITLE
feat: Enhance error serialization for IPC with custom properties

### DIFF
--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -127,8 +127,9 @@ function _serializePlainObjectForIpc(object, seen) {
 
   const serialized = {};
   seen.set(object, serialized);
-  for (const [key, value] of Object.entries(object)) {
+  for (const key of Object.keys(object)) {
     try {
+      const value = object[key];
       serialized[key] = _serializeValueForIpc(value, seen);
     } catch {
       serialized[key] = UNSERIALIZABLE_OBJECT_PLACEHOLDER;
@@ -148,6 +149,12 @@ function _serializePlainObjectForIpc(object, seen) {
 function _serializeValueForIpc(value, seen) {
   if (value instanceof Error) {
     return _serializeErrorForIpc(value, seen);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value instanceof RegExp) {
+    return value.toString();
   }
   // Function / Symbol 無法通過 Chrome IPC (structuredClone / JSON)，需提前轉換
   if (typeof value === 'function') {

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -36,6 +36,9 @@ const DEBUG_LEVEL_LOG_CONFIG = {
 
 const DEFAULT_BUFFER_CAPACITY = 500;
 
+const UNSERIALIZABLE_OBJECT_PLACEHOLDER = '[Unserializable Object]';
+const SERIALIZED_ERROR_RESERVED_KEYS = new Set(['message', 'stack', 'name']);
+
 // 全域錯誤前綴常量（用於 initGlobalErrorHandlers 和 error 方法的過濾邏輯）
 const GLOBAL_ERROR_PREFIXES = {
   UNCAUGHT_EXCEPTION: '[Uncaught Exception]',
@@ -55,6 +58,114 @@ const _pendingLogs = []; // 待發送的日誌佇列（mutation only，不重賦
 let _flushTimer = null; // 發送計時器
 
 /**
+ * 序列化 Error 物件，保留標準欄位與自訂 own properties。
+ *
+ * @param {Error} error - 原始 Error 物件
+ * @param {WeakMap<object, any>} seen - 已處理物件映射，用於保留循環引用
+ * @returns {object|string} 序列化後的 Error 資料
+ * @private
+ */
+function _serializeErrorForIpc(error, seen) {
+  if (seen.has(error)) {
+    return seen.get(error);
+  }
+
+  const serialized = {
+    message: error.message,
+    stack: error.stack,
+    name: error.name,
+  };
+  seen.set(error, serialized);
+
+  for (const key of Object.getOwnPropertyNames(error)) {
+    if (SERIALIZED_ERROR_RESERVED_KEYS.has(key)) {
+      continue;
+    }
+    try {
+      serialized[key] = _serializeValueForIpc(error[key], seen);
+    } catch {
+      serialized[key] = UNSERIALIZABLE_OBJECT_PLACEHOLDER;
+    }
+  }
+
+  return serialized;
+}
+
+/**
+ * 序列化陣列，並保留循環引用拓撲。
+ *
+ * @param {Array} array - 原始陣列
+ * @param {WeakMap<object, any>} seen - 已處理物件映射
+ * @returns {Array} 序列化後的陣列
+ * @private
+ */
+function _serializeArrayForIpc(array, seen) {
+  if (seen.has(array)) {
+    return seen.get(array);
+  }
+
+  const serialized = [];
+  seen.set(array, serialized);
+  for (const item of array) {
+    serialized.push(_serializeValueForIpc(item, seen));
+  }
+  return serialized;
+}
+
+/**
+ * 序列化一般物件，並保留循環引用拓撲。
+ *
+ * @param {object} object - 原始物件
+ * @param {WeakMap<object, any>} seen - 已處理物件映射
+ * @returns {object} 序列化後的物件
+ * @private
+ */
+function _serializePlainObjectForIpc(object, seen) {
+  if (seen.has(object)) {
+    return seen.get(object);
+  }
+
+  const serialized = {};
+  seen.set(object, serialized);
+  for (const [key, value] of Object.entries(object)) {
+    try {
+      serialized[key] = _serializeValueForIpc(value, seen);
+    } catch {
+      serialized[key] = UNSERIALIZABLE_OBJECT_PLACEHOLDER;
+    }
+  }
+  return serialized;
+}
+
+/**
+ * 遞迴序列化日誌值，確保可透過 Chrome IPC 傳遞。
+ *
+ * @param {any} value - 原始值
+ * @param {WeakMap<object, any>} seen - 已處理物件映射
+ * @returns {any} 序列化後的安全值
+ * @private
+ */
+function _serializeValueForIpc(value, seen) {
+  if (value instanceof Error) {
+    return _serializeErrorForIpc(value, seen);
+  }
+  // Function / Symbol 無法通過 Chrome IPC (structuredClone / JSON)，需提前轉換
+  if (typeof value === 'function') {
+    return '[Function]';
+  }
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return _serializeArrayForIpc(value, seen);
+  }
+  if (typeof value === 'object' && value !== null) {
+    return _serializePlainObjectForIpc(value, seen);
+  }
+  return value;
+}
+
+/**
  * 序列化單一日誌參數，確保可透過 Chrome IPC 傳遞
  *
  * @param {any} arg - 原始參數
@@ -63,22 +174,9 @@ let _flushTimer = null; // 發送計時器
  */
 function _serializeSingleArg(arg) {
   try {
-    if (arg instanceof Error) {
-      return { message: arg.message, stack: arg.stack, name: arg.name };
-    }
-    // Function / Symbol 無法通過 Chrome IPC (structuredClone / JSON)，需提前轉換
-    if (typeof arg === 'function') {
-      return '[Function]';
-    }
-    if (typeof arg === 'symbol') {
-      return arg.toString();
-    }
-    if (typeof arg === 'object' && arg !== null) {
-      return structuredClone(arg);
-    }
-    return arg;
+    return _serializeValueForIpc(arg, new WeakMap());
   } catch {
-    return '[Unserializable Object]';
+    return UNSERIALIZABLE_OBJECT_PLACEHOLDER;
   }
 }
 

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -419,39 +419,37 @@ function initGlobalErrorHandlers() {
   }
 
   // 1. 監聽未捕獲的異常 (Synchronous + Asynchronous)
-  if (globalThis.self) {
-    self.addEventListener('error', event => {
-      try {
-        const { message, filename, lineno, colno, error } = event;
-        Logger.error(`${GLOBAL_ERROR_PREFIXES.UNCAUGHT_EXCEPTION} ${message}`, {
-          filename,
-          lineno,
-          colno,
-          stack: error?.stack,
-        });
-      } catch (error) {
-        console.error('Failed to log uncaught exception:', error);
-      }
-    });
+  globalThis.self?.addEventListener('error', event => {
+    try {
+      const { message, filename, lineno, colno, error } = event;
+      Logger.error(`${GLOBAL_ERROR_PREFIXES.UNCAUGHT_EXCEPTION} ${message}`, {
+        filename,
+        lineno,
+        colno,
+        stack: error?.stack,
+      });
+    } catch (error) {
+      console.error('Failed to log uncaught exception:', error);
+    }
+  });
 
-    // 2. 監聽未處理的 Promise Rejection
-    self.addEventListener('unhandledrejection', event => {
-      try {
-        const reason = event.reason;
-        const msg = reason instanceof Error ? reason.message : String(reason);
-        const stack = reason instanceof Error ? reason.stack : null;
-        // 正確處理 null：typeof null === 'object' 為 true，需要額外檢查
-        const reasonField = reason !== null && typeof reason === 'object' ? reason : String(reason);
+  // 2. 監聽未處理的 Promise Rejection
+  globalThis.self?.addEventListener('unhandledrejection', event => {
+    try {
+      const reason = event.reason;
+      const msg = reason instanceof Error ? reason.message : String(reason);
+      const stack = reason instanceof Error ? reason.stack : null;
+      // 正確處理 null：typeof null === 'object' 為 true，需要額外檢查
+      const reasonField = reason !== null && typeof reason === 'object' ? reason : String(reason);
 
-        Logger.error(`${GLOBAL_ERROR_PREFIXES.UNHANDLED_REJECTION} ${msg}`, {
-          reason: reasonField,
-          stack,
-        });
-      } catch (error) {
-        console.error('Failed to log unhandled rejection:', error);
-      }
-    });
-  }
+      Logger.error(`${GLOBAL_ERROR_PREFIXES.UNHANDLED_REJECTION} ${msg}`, {
+        reason: reasonField,
+        stack,
+      });
+    } catch (error) {
+      console.error('Failed to log unhandled rejection:', error);
+    }
+  });
 }
 
 /**

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -139,14 +139,34 @@ function _serializePlainObjectForIpc(object, seen) {
 }
 
 /**
- * 遞迴序列化日誌值，確保可透過 Chrome IPC 傳遞。
+ * 序列化非物件類型的日誌值（如 function、symbol）。
  *
  * @param {any} value - 原始值
- * @param {WeakMap<object, any>} seen - 已處理物件映射
  * @returns {any} 序列化後的安全值
  * @private
  */
-function _serializeValueForIpc(value, seen) {
+function _serializeNonObjectValueForIpc(value) {
+  if (typeof value === 'function') {
+    return '[Function]';
+  }
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+  return value;
+}
+
+/**
+ * 序列化物件類型的日誌值（如 Error、Date、RegExp、陣列與一般物件）。
+ *
+ * @param {any} value - 原始物件
+ * @param {WeakMap<object, any>} seen - 已處理物件映射
+ * @returns {any} 序列化後的安全物件
+ * @private
+ */
+function _serializeObjectValueForIpc(value, seen) {
+  if (value === null) {
+    return value;
+  }
   if (value instanceof Error) {
     return _serializeErrorForIpc(value, seen);
   }
@@ -156,20 +176,25 @@ function _serializeValueForIpc(value, seen) {
   if (value instanceof RegExp) {
     return value.toString();
   }
-  // Function / Symbol 無法通過 Chrome IPC (structuredClone / JSON)，需提前轉換
-  if (typeof value === 'function') {
-    return '[Function]';
-  }
-  if (typeof value === 'symbol') {
-    return value.toString();
-  }
   if (Array.isArray(value)) {
     return _serializeArrayForIpc(value, seen);
   }
-  if (typeof value === 'object' && value !== null) {
-    return _serializePlainObjectForIpc(value, seen);
+  return _serializePlainObjectForIpc(value, seen);
+}
+
+/**
+ * 遞迴序列化日誌值，確保可透過 Chrome IPC 傳遞。
+ *
+ * @param {any} value - 原始值
+ * @param {WeakMap<object, any>} seen - 已處理物件映射
+ * @returns {any} 序列化後的安全值
+ * @private
+ */
+function _serializeValueForIpc(value, seen) {
+  if (typeof value !== 'object') {
+    return _serializeNonObjectValueForIpc(value);
   }
-  return value;
+  return _serializeObjectValueForIpc(value, seen);
 }
 
 /**

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -476,6 +476,42 @@ describe('Logger', () => {
       expect(sentArgs[0]).toEqual({ func: '[Function]' });
     });
 
+    test('應該遞迴保留 Date 與 RegExp 的可診斷值', () => {
+      const occurredAt = new Date('2026-06-08T10:11:12.000Z');
+      const matcher = /save-to-notion/gi;
+
+      Logger.warn('Built-in object test', {
+        occurredAt,
+        matcher,
+      });
+
+      const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
+      expect(sentArgs[0]).toEqual({
+        occurredAt: '2026-06-08T10:11:12.000Z',
+        matcher: '/save-to-notion/gi',
+      });
+    });
+
+    test('getter 屬性拋錯時應只 fallback 該欄位並保留其他欄位', () => {
+      const logContext = {
+        stable: 'kept',
+        nested: { ok: true },
+        get broken() {
+          throw new Error('getter failed');
+        },
+      };
+
+      Logger.warn('Throwing getter test', logContext);
+
+      expect(globalThis.chrome.runtime.sendMessage).toHaveBeenCalledTimes(1);
+      const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
+      expect(sentArgs[0]).toEqual({
+        stable: 'kept',
+        nested: { ok: true },
+        broken: '[Unserializable Object]',
+      });
+    });
+
     test('應該將 function 參數序列化為 "[Function]"', () => {
       Logger.warn('Function test', () => {});
 

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -407,6 +407,44 @@ describe('Logger', () => {
       );
     });
 
+    test('應該保留 Error 對象的自訂屬性', () => {
+      const testError = new Error('API failed');
+      testError.code = 'ERR_API';
+      testError.statusCode = 503;
+      testError.metadata = { retryable: true };
+
+      Logger.warn('Error occurred', testError);
+
+      const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
+      expect(sentArgs[0]).toEqual(
+        expect.objectContaining({
+          message: 'API failed',
+          name: 'Error',
+          code: 'ERR_API',
+          statusCode: 503,
+          metadata: { retryable: true },
+        })
+      );
+    });
+
+    test('應該遞迴保留物件內 Error 的自訂屬性', () => {
+      const testError = new Error('Nested failure');
+      testError.code = 'ERR_NESTED';
+      testError.statusCode = 429;
+
+      Logger.warn('Nested Error occurred', { error: testError });
+
+      const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
+      expect(sentArgs[0].error).toEqual(
+        expect.objectContaining({
+          message: 'Nested failure',
+          name: 'Error',
+          code: 'ERR_NESTED',
+          statusCode: 429,
+        })
+      );
+    });
+
     test('應該正確處理純量參數 (數字, 字串)', () => {
       // warn/error 使用即時發送路徑（sendToBackground），適合此測試
       // info/log/debug 使用批量模式（_queueForBackground），不會立即觸發 sendMessage
@@ -429,13 +467,13 @@ describe('Logger', () => {
       expect(cloned.myself).toBe(cloned);
     });
 
-    test('當 structuredClone 無法處理對象時應該 fallback 為 "[Unserializable Object]"', () => {
+    test('當對象包含無法透過 IPC 傳遞的值時應該遞迴 fallback 該欄位', () => {
       const unserializable = { func: () => {} };
 
       Logger.warn('Clone fail test', unserializable);
 
       const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
-      expect(sentArgs[0]).toBe('[Unserializable Object]');
+      expect(sentArgs[0]).toEqual({ func: '[Function]' });
     });
 
     test('應該將 function 參數序列化為 "[Function]"', () => {
@@ -559,14 +597,14 @@ describe('Logger', () => {
       expect(cloned.myself).toBe(cloned);
     });
 
-    test('_queueForBackground 在 structuredClone 無法處理對象時會 fallback', () => {
+    test('_queueForBackground 對物件內無法透過 IPC 傳遞的值會遞迴 fallback 該欄位', () => {
       const unserializable = { func: () => {} };
 
       Logger.info('Unserializable test', unserializable);
       jest.advanceTimersByTime(500);
 
       const sentLogs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].logs;
-      expect(sentLogs[0].args[0]).toBe('[Unserializable Object]');
+      expect(sentLogs[0].args[0]).toEqual({ func: '[Function]' });
     });
 
     test('在 sendMessage 失敗時應優雅忽略', () => {

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -525,6 +525,21 @@ describe('Logger', () => {
       const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
       expect(sentArgs[0]).toBe('Symbol(mySymbol)');
     });
+
+    test('應該遞迴序列化陣列中的特殊值', () => {
+      const occurredAt = new Date('2026-06-08T10:11:12.000Z');
+      const matcher = /logger/gi;
+
+      Logger.warn('Array special values test', [occurredAt, matcher, () => {}, Symbol('flag')]);
+
+      const sentArgs = globalThis.chrome.runtime.sendMessage.mock.calls[0][0].args;
+      expect(sentArgs[0]).toEqual([
+        '2026-06-08T10:11:12.000Z',
+        '/logger/gi',
+        '[Function]',
+        'Symbol(flag)',
+      ]);
+    });
   });
 
   describe('語法糖方法 (success, start, ready)', () => {


### PR DESCRIPTION
### 摘要
增強日誌序列化功能以支持自訂屬性，確保在 IPC 傳遞時不丟失重要資訊。

### 變更內容
- 新增序列化錯誤物件的功能，保留自訂屬性。
- 改進日誌參數的序列化邏輯，能夠遞迴處理物件內的錯誤。
- 更新單元測試以驗證新功能，確保錯誤物件的自訂屬性能夠正確傳遞。
- 使用可選鏈接來簡化錯誤監聽器的邏輯。

### 測試方式
已更新單元測試以驗證序列化功能的正確性。

### 潛在風險
無顯著風險。

