### PR TITLE
fix: use optional chaining in logger debug storage

### DIFF
--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -497,6 +497,22 @@ function isDebugStorageChange(changes, area) {
 }
 
 /**
+ * 記錄 debug storage 套用狀態
+ *
+ * @param {string} source - debug 狀態來源
+ * @private
+ */
+function logDebugStorageState(source) {
+  // 在控制台輸出狀態變更，方便調試
+  console.info('調試模式狀態變更', {
+    action: 'initDebugState',
+    source,
+    debugEnabled: _debugEnabled,
+    status: _debugEnabled ? 'ENABLED' : 'DISABLED',
+  });
+}
+
+/**
  * 應用 debug storage 的 newValue
  *
  * @param {any} value - 變更值
@@ -504,11 +520,7 @@ function isDebugStorageChange(changes, area) {
  */
 function applyDebugStorageValue(value) {
   _debugEnabled = Boolean(value);
-  // 在控制台輸出狀態變更，方便調試
-  console.info('調試模式狀態變更', {
-    action: 'initDebugState',
-    status: _debugEnabled ? 'ENABLED' : 'DISABLED',
-  });
+  logDebugStorageState('storage change');
 }
 
 /**
@@ -525,6 +537,7 @@ function applyInitialDebugStorageValue(result) {
 
   if (result?.enableDebugLogs !== undefined) {
     _debugEnabled = Boolean(result.enableDebugLogs);
+    logDebugStorageState('initial storage');
   }
 }
 

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -544,7 +544,7 @@ function registerDebugStorageSync() {
 
   // 初始讀取
   chrome.storage.sync.get(['enableDebugLogs'], result => {
-    if (result && result.enableDebugLogs !== undefined) {
+    if (result?.enableDebugLogs !== undefined) {
       _debugEnabled = Boolean(result.enableDebugLogs);
     }
   });

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -512,6 +512,36 @@ function applyDebugStorageValue(value) {
 }
 
 /**
+ * 套用初始 debug storage 設定
+ *
+ * @param {object | undefined} result - chrome.storage.sync.get 回傳結果
+ * @private
+ */
+function applyInitialDebugStorageValue(result) {
+  // 忽略 lastError
+  if (chrome.runtime.lastError) {
+    return;
+  }
+
+  if (result?.enableDebugLogs !== undefined) {
+    _debugEnabled = Boolean(result.enableDebugLogs);
+  }
+}
+
+/**
+ * 處理 debug storage 變更
+ *
+ * @param {object} changes - chrome.storage.onChanged 變更集
+ * @param {string} area - storage area
+ * @private
+ */
+function handleDebugStorageChange(changes, area) {
+  if (isDebugStorageChange(changes, area)) {
+    applyDebugStorageValue(changes.enableDebugLogs.newValue);
+  }
+}
+
+/**
  * 從 Manifest 初始化 Debug 狀態
  *
  * @private
@@ -543,24 +573,11 @@ function registerDebugStorageSync() {
   }
 
   // 初始讀取
-  chrome.storage.sync.get(['enableDebugLogs'], result => {
-    // 忽略 lastError
-    if (chrome.runtime.lastError) {
-      return;
-    }
-
-    if (result?.enableDebugLogs !== undefined) {
-      _debugEnabled = Boolean(result.enableDebugLogs);
-    }
-  });
+  chrome.storage.sync.get(['enableDebugLogs'], applyInitialDebugStorageValue);
 
   // 監聽變更（防禦性檢查 onChanged 是否存在）
   if (chrome.storage.onChanged) {
-    chrome.storage.onChanged.addListener((changes, area) => {
-      if (isDebugStorageChange(changes, area)) {
-        applyDebugStorageValue(changes.enableDebugLogs.newValue);
-      }
-    });
+    chrome.storage.onChanged.addListener(handleDebugStorageChange);
   }
 }
 

--- a/scripts/utils/Logger.js
+++ b/scripts/utils/Logger.js
@@ -544,6 +544,11 @@ function registerDebugStorageSync() {
 
   // 初始讀取
   chrome.storage.sync.get(['enableDebugLogs'], result => {
+    // 忽略 lastError
+    if (chrome.runtime.lastError) {
+      return;
+    }
+
     if (result?.enableDebugLogs !== undefined) {
       _debugEnabled = Boolean(result.enableDebugLogs);
     }

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -292,6 +292,17 @@ describe('Logger', () => {
       expect(globalThis.chrome.storage.onChanged.addListener).toHaveBeenCalled();
     });
 
+    test('初始 storage 設定應該記錄套用的 debug 狀態', () => {
+      expect(consoleSpy.info).toHaveBeenCalledWith(
+        '調試模式狀態變更',
+        expect.objectContaining({
+          action: 'initDebugState',
+          source: 'initial storage',
+          debugEnabled: true,
+        })
+      );
+    });
+
     test('onChanged 回調應該更新 debugEnabled 狀態', () => {
       // 捕獲傳遞給 addListener 的回調函數
       const onChangedCallback = globalThis.chrome.storage.onChanged.addListener.mock.calls[0][0];

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -332,6 +332,46 @@ describe('Logger', () => {
     });
   });
 
+  describe('Storage 初始化錯誤防禦', () => {
+    test('storage.sync.get callback 遇到 runtime.lastError 時應讀取並忽略結果', () => {
+      let lastErrorWasRead = false;
+      const runtime = {
+        id: 'test-extension-id',
+        getManifest: jest.fn().mockReturnValue({
+          version: '2.0.0',
+          version_name: '2.0.0',
+        }),
+        sendMessage: jest.fn(),
+      };
+      Object.defineProperty(runtime, 'lastError', {
+        get() {
+          lastErrorWasRead = true;
+          return { message: 'Extension context invalidated.' };
+        },
+      });
+
+      globalThis.chrome = {
+        runtime,
+        storage: {
+          sync: {
+            get: jest.fn((_keys, callback) => {
+              callback({ enableDebugLogs: true });
+            }),
+          },
+          onChanged: {
+            addListener: jest.fn(),
+          },
+        },
+      };
+
+      loadInDevelopmentMode(() => require('../../../scripts/utils/Logger.js'));
+      Logger = globalThis.window.Logger;
+
+      expect(lastErrorWasRead).toBe(true);
+      expect(Logger.debugEnabled).toBe(false);
+    });
+  });
+
   describe('消息格式化', () => {
     beforeEach(() => {
       globalThis.chrome = undefined;


### PR DESCRIPTION
### 摘要
修正日誌調試存儲中的條件檢查，使用可選鏈接以提高代碼穩定性。

### 變更內容
- 將 `if (result && result.enableDebugLogs !== undefined)` 更改為 `if (result?.enableDebugLogs !== undefined)`，以簡化條件檢查。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

