### PR TITLE
fix: clear highlights using tab URL for content requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ scripts/config/env/build.js
 # 替換歷史逐檔規則為目錄級 ignore,確保新增構建產物不會漏 ignore。
 release-package/
 .antigravitycli/5c437353-ee07-48da-939d-8ad77dc27875.json
+.agents/evals/complexity-reduction/eval.yaml
+.agents/evals/complexity-reduction/tasks/negative-trigger-1.yaml
+.agents/evals/complexity-reduction/tasks/positive-trigger-1.yaml
+.agents/evals/complexity-reduction/tasks/positive-trigger-2.yaml

--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -488,32 +488,82 @@ async function cleanupBundleAfterReadyTimeout(injectionService, tabId, action) {
   }
 }
 
+/**
+ * 建構驗證失敗的 context
+ *
+ * @param {string} action
+ * @param {object} sender
+ * @param {string} validationError
+ * @returns {object}
+ */
+
+function buildValidationFailureContext(action, sender, validationError) {
+  return {
+    ok: false,
+    kind: 'validation',
+    validationError,
+    guardMeta: buildContentScriptGuardMeta({ action, sender, validationError }),
+  };
+}
+
+/**
+ * 建構缺少標籤頁的 context
+ *
+ * @param {string} action
+ * @returns {object}
+ */
+
+function buildNoTabContext(action) {
+  Logger.warn('缺少標籤頁上下文', { action, result: 'failed', reason: 'no_tab' });
+  return { ok: false, kind: 'no_tab' };
+}
+
+/**
+ * 建構受限頁面的 context
+ *
+ * @param {string} action
+ * @param {string} tabUrl
+ * @param {boolean} logRestricted
+ * @returns {object}
+ */
+
+function buildRestrictedContext(action, tabUrl, logRestricted) {
+  if (logRestricted) {
+    Logger.warn('受限頁面無法使用標註', {
+      action,
+      url: sanitizeUrlForLogging(tabUrl),
+      result: 'blocked',
+      reason: 'restricted_url',
+    });
+  }
+  return { ok: false, kind: 'restricted' };
+}
+
+/**
+ * 驗證並接受 content script 的注入上下文
+ *
+ * @param {object} sender
+ * @param {string} action
+ * @param {object} options
+ * @param {boolean} options.logRestricted - 是否記錄受限頁面警告
+ * @returns {object} 驗證結果 context
+ */
+
 function acceptContentScriptInjectionContext(sender, action, { logRestricted = false } = {}) {
   const validationError = validateContentScriptRequest(sender);
   if (validationError) {
-    return {
-      ok: false,
-      kind: 'validation',
-      validationError,
-      guardMeta: buildContentScriptGuardMeta({ action, sender, validationError }),
-    };
+    return buildValidationFailureContext(action, sender, validationError);
   }
+
   if (!sender.tab?.id) {
-    Logger.warn('缺少標籤頁上下文', { action, result: 'failed', reason: 'no_tab' });
-    return { ok: false, kind: 'no_tab' };
+    return buildNoTabContext(action);
   }
+
   const { id: tabId, url: tabUrl } = sender.tab;
   if (tabUrl && isRestrictedInjectionUrl(tabUrl)) {
-    if (logRestricted) {
-      Logger.warn('受限頁面無法使用標註', {
-        action,
-        url: sanitizeUrlForLogging(tabUrl),
-        result: 'blocked',
-        reason: 'restricted_url',
-      });
-    }
-    return { ok: false, kind: 'restricted' };
+    return buildRestrictedContext(action, tabUrl, logRestricted);
   }
+
   return { ok: true, tabId, tabUrl };
 }
 

--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -73,6 +73,75 @@ async function ensureBundleReady(tabId, maxRetries = HANDLER_CONSTANTS.BUNDLE_RE
 }
 
 /**
+ * 判斷頁面資料是否包含有效的 notionPageId
+ *
+ * @param {object} pageData
+ * @returns {boolean}
+ */
+function hasSavedPage(pageData) {
+  return pageData?.notionPageId;
+}
+
+/**
+ * 判斷是否應回退查詢原始 URL
+ *
+ * @param {boolean} migrated - URL 是否已成功遷移
+ * @param {string} normUrl - 正規化 URL
+ * @param {string} originalUrl - 原始 URL
+ * @returns {boolean}
+ */
+function shouldFallbackToOriginalUrl(migrated, normUrl, originalUrl) {
+  return !migrated && normUrl !== originalUrl;
+}
+
+/**
+ * 查詢 URL 對應的已存頁面資料
+ *
+ * @param {string} url
+ * @param {object} storageService
+ * @returns {Promise<object|null>}
+ */
+async function queryPageDataByUrl(url, storageService) {
+  const pageData = await storageService.getSavedPageData(url);
+  return hasSavedPage(pageData) ? pageData : null;
+}
+
+/**
+ * 嘗試從指定 URL 查詢頁面並回傳成功結果
+ *
+ * @param {string} url
+ * @param {object} storageService
+ * @returns {Promise<object|null>} 成功時回傳 {found: true, savedData, resolvedUrl}，失敗時 null
+ */
+async function tryResolveFromUrl(url, storageService) {
+  const savedData = await queryPageDataByUrl(url, storageService);
+  if (savedData) {
+    return { found: true, savedData, resolvedUrl: url };
+  }
+  return null;
+}
+
+/**
+ * 以雙查安全網策略解析頁面：優先 stable URL，失敗時回退 original URL
+ *
+ * @param {string} normUrl - 正規化 URL
+ * @param {string} originalUrl - 原始 URL
+ * @param {boolean} migrated - URL 是否已成功遷移
+ * @param {object} storageService
+ * @returns {Promise<object|null>}
+ */
+async function resolveWithFallback(normUrl, originalUrl, migrated, storageService) {
+  const stableResult = await tryResolveFromUrl(normUrl, storageService);
+  if (stableResult) {
+    return stableResult;
+  }
+  if (shouldFallbackToOriginalUrl(migrated, normUrl, originalUrl)) {
+    return await tryResolveFromUrl(originalUrl, storageService);
+  }
+  return null;
+}
+
+/**
  * 定位待更新標註的已存頁面
  *
  * 統一解析 tab URL（含自動遷移），並以「stable URL → 原始 URL」雙查安全網
@@ -98,23 +167,8 @@ async function resolveSavedPageForHighlightUpdate({
     migrated,
   } = await tabService.resolveTabUrl(activeTab.id, activeTab.url || '', migrationService);
 
-  // stable URL 命中即採用：早返同時定出 savedData 與 resolvedUrl，
-  // 省去 foundViaStableUrl 旗標與末端三元
-  const stableData = await storageService.getSavedPageData(normUrl);
-  if (stableData?.notionPageId) {
-    return { found: true, savedData: stableData, resolvedUrl: normUrl };
-  }
-
-  // 雙查安全網：遷移失敗且 stable/原始 URL 分歧時，回退查詢原始 URL
-  const shouldRetryOriginalUrl = !migrated && normUrl !== originalUrl;
-  if (shouldRetryOriginalUrl) {
-    const originalData = await storageService.getSavedPageData(originalUrl);
-    if (originalData?.notionPageId) {
-      return { found: true, savedData: originalData, resolvedUrl: originalUrl };
-    }
-  }
-
-  return { found: false };
+  const result = await resolveWithFallback(normUrl, originalUrl, migrated, storageService);
+  return result || { found: false };
 }
 
 /**

--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -457,6 +457,13 @@ function pickClearGuardReason(isContentScript) {
   return isContentScript ? 'invalid_content_script_request' : 'invalid_internal_request';
 }
 
+function resolveClearStorageUrl(isContentScript, sender, request) {
+  if (!isContentScript || !sender?.tab?.url) {
+    return request.url;
+  }
+  return sender.tab.url;
+}
+
 function validateClearRequest(sender, request) {
   const isContentScript = Boolean(sender?.tab);
   const validate = pickClearRequestValidator(isContentScript);
@@ -476,7 +483,8 @@ function validateClearRequest(sender, request) {
   if (!request.url) {
     return { ok: false, kind: 'missing_url' };
   }
-  return { ok: true, url: request.url, targetTabId: sender?.tab?.id || request.tabId };
+  const storageUrl = resolveClearStorageUrl(isContentScript, sender, request);
+  return { ok: true, url: storageUrl, targetTabId: sender?.tab?.id || request.tabId };
 }
 
 function rejectShowOrUserActivateContext(ctx, sendResponse) {

--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -118,55 +118,67 @@ async function resolveSavedPageForHighlightUpdate({
 }
 
 /**
- * 核對 Notion 更新失敗是否代表遠端頁面已被刪除，並據此清理本地綁定
+ * 判斷是否應核對遠端頁面刪除狀態
  *
- * 僅處理「fetch_blocks 階段的 OBJECT_NOT_FOUND」失敗，其他情況回傳 null 交由
- * 呼叫端依正常流程繼續。採兩段式確認：首次僅標記 pending，再次才清除本地綁定；
- * 清除失敗時 re-arm pending token 供下次 sync 立即重試。
+ * @param {object} result - notionService 回傳結果
+ * @returns {boolean}
+ */
+function shouldReconcilePageDeletion(result) {
+  return (
+    !result.success &&
+    result.error === 'OBJECT_NOT_FOUND' &&
+    result.details?.phase === 'fetch_blocks'
+  );
+}
+
+/**
+ * 建構待確認刪除的 response
+ *
+ * @param {object} result - 原始 result 物件
+ * @returns {object}
+ */
+function buildPendingDeletionResponse(result) {
+  return {
+    ...result,
+    errorCode: 'PAGE_DELETION_PENDING',
+    error: BACKGROUND_MESSAGES.POPUP.DELETION_PENDING,
+  };
+}
+
+/**
+ * 建構已確認刪除的 response
+ *
+ * @param {object} result - 原始 result 物件
+ * @returns {object}
+ */
+function buildConfirmedDeletionResponse(result) {
+  return {
+    ...result,
+    errorCode: 'PAGE_DELETED',
+    error: BACKGROUND_MESSAGES.POPUP.DELETED_PAGE,
+  };
+}
+
+/**
+ * 處理已確認的遠端頁面刪除
  *
  * @param {object} params
- * @param {object} params.result - notionService.updateHighlightsSection 回傳結果
- * @param {string} params.pageId - 本地綁定的 Notion pageId
+ * @param {object} params.result - 原始 result 物件
+ * @param {string} params.pageId - Notion pageId
  * @param {string} params.resolvedUrl - 已解析的頁面 URL
+ * @param {string} params.shortPageId - pageId 短碼（前 4 個字符）
  * @param {object} params.tabService
  * @param {object} params.storageService
- * @returns {Promise<object|null>} 需直接回傳給用戶的 response，或 null 表示非刪除情境
+ * @returns {Promise<object>}
  */
-async function reconcileRemotePageMissing({
+async function handleConfirmedDeletion({
   result,
   pageId,
   resolvedUrl,
+  shortPageId,
   tabService,
   storageService,
 }) {
-  const isFetchBlocksObjectNotFound =
-    !result.success &&
-    result.error === 'OBJECT_NOT_FOUND' &&
-    result.details?.phase === 'fetch_blocks';
-  if (!isFetchBlocksObjectNotFound) {
-    return null;
-  }
-
-  // pageId 經上游 resolveSavedPageForHighlightUpdate 的 found-guard 後保證為非空字串
-  // （與下方 confirmRemotePageMissing(pageId) 的直接使用一致），log 短碼不需 optional/fallback
-  const shortPageId = pageId.slice(0, 4);
-  const deletionCheck = tabService.confirmRemotePageMissing(pageId);
-
-  if (!deletionCheck.shouldDelete) {
-    Logger.warn('同步標註時首次發現遠端頁面疑似已刪除，暫不清除本地 notion 綁定', {
-      action: 'performHighlightUpdate',
-      url: sanitizeUrlForLogging(resolvedUrl),
-      pageId: shortPageId,
-      result: 'pending',
-    });
-
-    return {
-      ...result,
-      errorCode: 'PAGE_DELETION_PENDING',
-      error: BACKGROUND_MESSAGES.POPUP.DELETION_PENDING,
-    };
-  }
-
   Logger.warn('同步標註時確認遠端頁面已刪除，清除本地 notion 綁定', {
     action: 'performHighlightUpdate',
     url: sanitizeUrlForLogging(resolvedUrl),
@@ -207,11 +219,57 @@ async function reconcileRemotePageMissing({
     tabService.confirmRemotePageMissing(pageId);
   }
 
-  return {
-    ...result,
-    errorCode: 'PAGE_DELETED',
-    error: BACKGROUND_MESSAGES.POPUP.DELETED_PAGE,
-  };
+  return buildConfirmedDeletionResponse(result);
+}
+
+/**
+ * 核對 Notion 更新失敗是否代表遠端頁面已被刪除，並據此清理本地綁定
+ *
+ * 僅處理「fetch_blocks 階段的 OBJECT_NOT_FOUND」失敗，其他情況回傳 null 交由
+ * 呼叫端依正常流程繼續。採兩段式確認：首次僅標記 pending，再次才清除本地綁定；
+ * 清除失敗時 re-arm pending token 供下次 sync 立即重試。
+ *
+ * @param {object} params
+ * @param {object} params.result - notionService.updateHighlightsSection 回傳結果
+ * @param {string} params.pageId - 本地綁定的 Notion pageId
+ * @param {string} params.resolvedUrl - 已解析的頁面 URL
+ * @param {object} params.tabService
+ * @param {object} params.storageService
+ * @returns {Promise<object|null>} 需直接回傳給用戶的 response，或 null 表示非刪除情境
+ */
+async function reconcileRemotePageMissing({
+  result,
+  pageId,
+  resolvedUrl,
+  tabService,
+  storageService,
+}) {
+  if (!shouldReconcilePageDeletion(result)) {
+    return null;
+  }
+
+  const shortPageId = pageId.slice(0, 4);
+  const deletionCheck = tabService.confirmRemotePageMissing(pageId);
+
+  if (!deletionCheck.shouldDelete) {
+    Logger.warn('同步標註時首次發現遠端頁面疑似已刪除，暫不清除本地 notion 綁定', {
+      action: 'performHighlightUpdate',
+      url: sanitizeUrlForLogging(resolvedUrl),
+      pageId: shortPageId,
+      result: 'pending',
+    });
+
+    return buildPendingDeletionResponse(result);
+  }
+
+  return await handleConfirmedDeletion({
+    result,
+    pageId,
+    resolvedUrl,
+    shortPageId,
+    tabService,
+    storageService,
+  });
 }
 
 /**

--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -185,6 +185,40 @@ function shouldReconcilePageDeletion(result) {
   );
 }
 
+const USER_RESPONSE_FIELDS = [
+  'success',
+  'status',
+  'errorCode',
+  'error',
+  'id',
+  'url',
+  'count',
+  'highlightCount',
+  'highlightsUpdated',
+];
+
+/**
+ * 從 internal result 建立可回傳給 UI/content script 的 public response。
+ *
+ * @param {object} result - 原始 result 物件
+ * @param {object} overrides - 對外 response override 欄位
+ * @returns {object}
+ */
+function buildPublicDeletionResponse(result, overrides = {}) {
+  const response = {};
+
+  for (const field of USER_RESPONSE_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(result, field)) {
+      response[field] = result[field];
+    }
+  }
+
+  return {
+    ...response,
+    ...overrides,
+  };
+}
+
 /**
  * 建構待確認刪除的 response
  *
@@ -192,11 +226,10 @@ function shouldReconcilePageDeletion(result) {
  * @returns {object}
  */
 function buildPendingDeletionResponse(result) {
-  return {
-    ...result,
+  return buildPublicDeletionResponse(result, {
     errorCode: 'PAGE_DELETION_PENDING',
     error: BACKGROUND_MESSAGES.POPUP.DELETION_PENDING,
-  };
+  });
 }
 
 /**
@@ -206,11 +239,10 @@ function buildPendingDeletionResponse(result) {
  * @returns {object}
  */
 function buildConfirmedDeletionResponse(result) {
-  return {
-    ...result,
+  return buildPublicDeletionResponse(result, {
     errorCode: 'PAGE_DELETED',
     error: BACKGROUND_MESSAGES.POPUP.DELETED_PAGE,
-  };
+  });
 }
 
 /**
@@ -254,10 +286,9 @@ async function handleConfirmedDeletion({
       result: 'cleanup_skipped',
     });
 
-    return {
-      ...result,
+    return buildPublicDeletionResponse(result, {
       error: ERROR_MESSAGES.USER_MESSAGES.CHECK_PAGE_EXISTENCE_FAILED,
-    };
+    });
   }
 
   if (!clearResult.cleared) {

--- a/tests/unit/background/handlers/highlightHandlers.test.js
+++ b/tests/unit/background/handlers/highlightHandlers.test.js
@@ -212,6 +212,8 @@ describe('highlightHandlers', () => {
           errorCode: 'PAGE_DELETION_PENDING',
         })
       );
+      const response = sendResponse.mock.calls[0][0];
+      expect(response).not.toHaveProperty('details');
     });
 
     it('第二次命中 object_not_found 時應清除本地 notion 綁定並回傳 PAGE_DELETED', async () => {
@@ -250,6 +252,8 @@ describe('highlightHandlers', () => {
           errorCode: 'PAGE_DELETED',
         })
       );
+      const response = sendResponse.mock.calls[0][0];
+      expect(response).not.toHaveProperty('details');
     });
 
     it('cleanup retry 最終失敗時仍應回傳 PAGE_DELETED', async () => {
@@ -300,6 +304,8 @@ describe('highlightHandlers', () => {
           errorCode: 'PAGE_DELETED',
         })
       );
+      const response = sendResponse.mock.calls[0][0];
+      expect(response).not.toHaveProperty('details');
     });
 
     it('cleanup skipped 時不應回傳 PAGE_DELETED 或重新標記 deletionPending', async () => {
@@ -346,6 +352,8 @@ describe('highlightHandlers', () => {
           errorCode: 'PAGE_DELETED',
         })
       );
+      const response = sendResponse.mock.calls[0][0];
+      expect(response).not.toHaveProperty('details');
     });
 
     it('應該在沒有新高亮時直接返回成功', async () => {

--- a/tests/unit/background/handlers/highlightHandlers.test.js
+++ b/tests/unit/background/handlers/highlightHandlers.test.js
@@ -1072,6 +1072,30 @@ describe('highlightHandlers', () => {
       });
     });
 
+    it('content script request URL 是 shortlink 時，應以實際 tab URL 清除 permalink storage', async () => {
+      const sendResponse = jest.fn();
+      const permalinkUrl = 'https://www.rapbull.net/posts/3033/slug';
+      const shortlinkUrl = 'https://www.rapbull.net/?p=3033';
+      const sender = { id: 'test-id', tab: { id: 1, url: permalinkUrl } };
+      const request = { url: shortlinkUrl };
+
+      mockServices.storageService.updateHighlights.mockResolvedValue();
+
+      await handlers[RUNTIME_ACTIONS.CLEAR_HIGHLIGHTS](request, sender, sendResponse);
+
+      expect(mockServices.storageService.getHighlights).toHaveBeenCalledWith(permalinkUrl);
+      expect(mockServices.storageService.updateHighlights).toHaveBeenCalledWith(permalinkUrl, []);
+      expect(mockServices.storageService.updateHighlights).not.toHaveBeenCalledWith(
+        shortlinkUrl,
+        []
+      );
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: true,
+        clearedCount: 2,
+        visualCleared: true,
+      });
+    });
+
     it('頁面視覺清除失敗時仍應回報 storage 清除成功', async () => {
       const sendResponse = jest.fn();
       const sender = { id: 'test-id', tab: { id: 1, url: 'https://example.com' } };


### PR DESCRIPTION
### 摘要
清除標註時，使用實際的 tab URL 來處理短連結的 permalink 存儲。

### 變更內容
- 修正清除標註的邏輯，確保在短連結請求時使用實際的 tab URL。
- 重構多個函數以降低複雜度，提升可讀性和維護性。
- 增加了對於頁面刪除狀態的核對邏輯，確保在更新標註時能正確處理遠端頁面刪除情況。

### 測試方式
已新增測試案例以驗證短連結請求的清除邏輯。

### 潛在風險
無顯著風險。

