### PR TITLE
fix: use Object.hasOwn in highlight handler

### DIFF
--- a/scripts/background/handlers/highlightHandlers.js
+++ b/scripts/background/handlers/highlightHandlers.js
@@ -208,7 +208,7 @@ function buildPublicDeletionResponse(result, overrides = {}) {
   const response = {};
 
   for (const field of USER_RESPONSE_FIELDS) {
-    if (Object.prototype.hasOwnProperty.call(result, field)) {
+    if (Object.hasOwn(result, field)) {
       response[field] = result[field];
     }
   }


### PR DESCRIPTION
### 摘要
修正高亮處理器中使用的屬性檢查方法。

### 變更內容
- 將 `Object.prototype.hasOwnProperty.call` 替換為 `Object.hasOwn` 以提高代碼的可讀性和效率。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

