### PR TITLE
fix: accept long text highlights with context mismatch

### DIFF
--- a/scripts/background/utils/highlightStyleMerger.js
+++ b/scripts/background/utils/highlightStyleMerger.js
@@ -318,12 +318,24 @@ function hasRangeContext(prefix, suffix) {
  * 無上下文資訊時直接接受;有上下文資訊時要求 prefix/suffix 至少部分重合,
  * 否則視為跨段落殘留誤命中而拒絕。
  *
+ * 特殊處理：當匹配文字本身很長（>= 50 字符）時，文字的長度和唯一性本身
+ * 已是強有力的證據，即使上下文不完全匹配也接受。這避免了因 DOM 結構差異、
+ * 標點符號轉換等導致的上下文提取不一致而錯誤拒絕正確匹配。
+ *
  * @param {{ text: string, charMap: Array<{start: number, end: number}> }} indexedFullText - 正規化文字索引
  * @param {{ start: number, end: number, normalizedStart: number, normalizedEnd: number }} candidate - 候選匹配
  * @param {{ prefix: string, suffix: string, hasContext: boolean }} context - 消歧義上下文
  * @returns {object|null} 接受時為候選匹配，拒絕時為 null
  */
 function resolveSingleCandidate(indexedFullText, candidate, context) {
+  const matchLength = candidate.normalizedEnd - candidate.normalizedStart;
+  const isLongText = matchLength >= 50;
+
+  // 長文字的唯一性本身就是強證據，直接接受
+  if (isLongText) {
+    return candidate;
+  }
+
   if (!context.hasContext) {
     return candidate;
   }

--- a/tests/unit/background/utils/highlightStyleMerger.test.js
+++ b/tests/unit/background/utils/highlightStyleMerger.test.js
@@ -183,6 +183,20 @@ describe('findHighlightPosition', () => {
     expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(-1);
   });
 
+  test('長文字（>= 50 字符）即使 context 不匹配也應接受唯一候選', () => {
+    const longText =
+      'The spotlight belonged exclusively to Jensen Huang and Elon Musk—the two brightest rockstars in the tech pantheon.';
+    const richTextArray = [makeRT(`At the event, ${longText} It was quite a show.`)];
+    const hl = {
+      text: longText,
+      // 故意提供不匹配的 context（模擬 DOM 結構差異導致的上下文提取不一致）
+      rangeInfo: { prefix: 'wrong prefix ', suffix: ' wrong suffix' },
+    };
+    const fullText = buildFullText(richTextArray);
+    // 應該成功找到位置，因為文字長度 >= 50 且是唯一候選
+    expect(findHighlightPosition(richTextArray, hl, fullText)).toBe(14);
+  });
+
   test('有 context 且單一候選，雖然 prefix/suffix 只是部分匹配（但評分 > 0）應返回正確位置', () => {
     const richTextArray = [makeRT('a reason Markdown is being discussed.')];
     const hl = {


### PR DESCRIPTION
### 摘要
修正英文網頁長句子標註顏色丟失的問題，即使上下文不匹配也接受長文字的唯一候選。

### 變更內容
- 當匹配文字長度大於或等於 50 字符時，直接接受候選，跳過上下文驗證。
- 短文字的處理邏輯保持不變，以確保消歧義能力。
- 添加測試案例以覆蓋長文字場景，確保功能正常。

### 測試方式
已添加測試案例覆蓋長文字場景，並確保所有既有測試通過。

### 潛在風險
無顯著風險。

