### PR TITLE
refactor: reduce popup controller complexity

### DIFF
--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -120,9 +120,15 @@ async function initializePageStatus(elements) {
 
 async function registerActiveTabTracking() {
   let currentTab = await getActiveTab();
-  chrome.tabs.onActivated.addListener(async () => {
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    currentTab = tabs[0] ?? null;
+  const trackedWindowId = currentTab?.windowId;
+  chrome.tabs.onActivated.addListener(activeInfo => {
+    if (trackedWindowId !== undefined && activeInfo.windowId !== trackedWindowId) {
+      return;
+    }
+    currentTab = {
+      id: activeInfo.tabId,
+      windowId: activeInfo.windowId,
+    };
   });
   return {
     getCurrentTab: () => currentTab,
@@ -147,20 +153,30 @@ async function handleAccountLoginClick(elements) {
 }
 
 async function handleAccountButtonClick(elements) {
-  const accountState = BUILD_ENV.ENABLE_ACCOUNT
-    ? await getPopupAccountState()
-    : { enabled: false, isLoggedIn: false };
-
-  if (!accountState.enabled) {
+  if (elements.accountButton?.disabled) {
     return;
   }
 
-  if (accountState.isLoggedIn) {
-    await handleAccountManagementClick(elements);
-    return;
-  }
+  setButtonState(elements.accountButton, true);
 
-  await handleAccountLoginClick(elements);
+  try {
+    const accountState = BUILD_ENV.ENABLE_ACCOUNT
+      ? await getPopupAccountState()
+      : { enabled: false, isLoggedIn: false };
+
+    if (!accountState.enabled) {
+      return;
+    }
+
+    if (accountState.isLoggedIn) {
+      await handleAccountManagementClick(elements);
+      return;
+    }
+
+    await handleAccountLoginClick(elements);
+  } finally {
+    setButtonState(elements.accountButton, false);
+  }
 }
 
 function registerPopupEventListeners(elements, context) {

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -66,37 +66,25 @@ async function initAccountSection(elements) {
   setAccountSectionVisible(elements, false);
 }
 
-// Export initialization function for testing
-export async function initPopup() {
-  Logger.start('[Popup] Initializing...');
-
-  // 注入 SVG 圖標
-  injectIcons(UI_ICONS);
-
-  // 獲取所有 DOM 元素
-  const elements = getElements();
-  initializePopupStaticText(elements);
-  await initAccountSection(elements);
-
-  // 檢查設置
-  const settings = await checkSettings();
-  if (!settings.valid) {
-    // 根據實際缺失的設定顯示對應的提示訊息
-    let msg = UI_MESSAGES.SETUP.MISSING_CONFIG;
-    if (settings.missingReason === 'missing_data_source') {
-      msg = ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE;
-    } else if (settings.missingReason === 'missing_auth') {
-      msg = ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED;
-    } else if (!settings.dataSourceId) {
-      msg = ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE;
-    }
-    setStatus(elements, msg);
-    setButtonState(elements.saveButton, true);
-    setButtonState(elements.highlightButton, true);
-    return;
+function resolveMissingSettingsMessage(settings) {
+  if (settings.missingReason === 'missing_data_source') {
+    return ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE;
   }
+  if (settings.missingReason === 'missing_auth') {
+    return ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED;
+  }
+  if (!settings.dataSourceId) {
+    return ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE;
+  }
+  return UI_MESSAGES.SETUP.MISSING_CONFIG;
+}
 
-  // 檢查頁面狀態並更新 UI（使用 TTL cache 避免不必要的 API 呼叫）
+function disablePrimaryPopupActions(elements) {
+  setButtonState(elements.saveButton, true);
+  setButtonState(elements.highlightButton, true);
+}
+
+async function initializeDestinationSelectorState(elements) {
   let selectedDestinationProfileId = null;
   let destinationProfiles = [];
   try {
@@ -107,7 +95,10 @@ export async function initPopup() {
   } catch (error) {
     Logger.warn('[Popup] Failed to initialize destination selector', { error });
   }
+  return { selectedDestinationProfileId, destinationProfiles };
+}
 
+async function initializePageStatus(elements) {
   try {
     const pageStatus = await checkPageStatus();
 
@@ -121,23 +112,60 @@ export async function initPopup() {
     }
   } catch (error) {
     Logger.error('Failed to initialize popup:', error);
-    // 將實際錯誤經過 sanitizeApiError 清洗後再格式化，提供更精確的錯誤提示
     const safeMessage = sanitizeApiError(error, 'popup_init');
     const msg = ErrorHandler.formatUserMessage(safeMessage);
     setStatus(elements, msg, '#d63384');
   }
+}
 
-  // 預取目前分頁資訊，供 manage button 同步呼叫 sidePanel.open() 使用
-  // 使用 let 以便 tabs.onActivated 監聽器可以更新它
+async function registerActiveTabTracking() {
   let currentTab = await getActiveTab();
-
-  // ========== 事件監聽器 ==========
-
-  // 當使用者切換分頁時更新 currentTab，避免舊的 tabId 導致 sidePanel 開到錯誤的分頁
   chrome.tabs.onActivated.addListener(async () => {
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
     currentTab = tabs[0] ?? null;
   });
+  return {
+    getCurrentTab: () => currentTab,
+  };
+}
+
+async function handleAccountManagementClick(elements) {
+  const result = await openAccountManagement();
+  if (!result?.success) {
+    setAccountStatusError(
+      elements,
+      result?.error || UI_MESSAGES.ACCOUNT.ACCOUNT_MANAGEMENT_OPEN_FAILED
+    );
+  }
+}
+
+async function handleAccountLoginClick(elements) {
+  const result = await startAccountLogin();
+  if (!result?.success) {
+    setAccountStatusError(elements, result?.error || UI_MESSAGES.ACCOUNT.LOGIN_PAGE_OPEN_FAILED);
+  }
+}
+
+async function handleAccountButtonClick(elements) {
+  const accountState = BUILD_ENV.ENABLE_ACCOUNT
+    ? await getPopupAccountState()
+    : { enabled: false, isLoggedIn: false };
+
+  if (!accountState.enabled) {
+    return;
+  }
+
+  if (accountState.isLoggedIn) {
+    await handleAccountManagementClick(elements);
+    return;
+  }
+
+  await handleAccountLoginClick(elements);
+}
+
+function registerPopupEventListeners(elements, context) {
+  let { selectedDestinationProfileId } = context;
+  const { destinationProfiles, getCurrentTab } = context;
 
   // 保存按鈕
   elements.saveButton.addEventListener('click', async () => {
@@ -249,11 +277,9 @@ export async function initPopup() {
   });
 
   // 管理標註按鈕 (開啟 Side Panel)
-  // 注意：sidePanel.open() 必須在使用者手勢上下文中同步呼叫，
-  // 因此直接在 Popup 頁面呼叫，不經由 background 轉發，
-  // 並使用初始化時預取的 currentTab.id（由 tabs.onActivated 保持最新）。
   if (elements.manageButton) {
     elements.manageButton.addEventListener('click', () => {
+      const currentTab = getCurrentTab();
       if (currentTab?.id) {
         chrome.sidePanel.open({ tabId: currentTab.id });
         window.close();
@@ -266,34 +292,45 @@ export async function initPopup() {
 
   if (elements.accountButton) {
     elements.accountButton.addEventListener('click', async () => {
-      const accountState = BUILD_ENV.ENABLE_ACCOUNT
-        ? await getPopupAccountState()
-        : { enabled: false, isLoggedIn: false };
-
-      if (!accountState.enabled) {
-        return;
-      }
-
-      if (accountState.isLoggedIn) {
-        const result = await openAccountManagement();
-        if (!result?.success) {
-          setAccountStatusError(
-            elements,
-            result?.error || UI_MESSAGES.ACCOUNT.ACCOUNT_MANAGEMENT_OPEN_FAILED
-          );
-        }
-        return;
-      }
-
-      const result = await startAccountLogin();
-      if (!result?.success) {
-        setAccountStatusError(
-          elements,
-          result?.error || UI_MESSAGES.ACCOUNT.LOGIN_PAGE_OPEN_FAILED
-        );
-      }
+      await handleAccountButtonClick(elements);
     });
   }
+}
+
+// Export initialization function for testing
+export async function initPopup() {
+  Logger.start('[Popup] Initializing...');
+
+  // 注入 SVG 圖標
+  injectIcons(UI_ICONS);
+
+  // 獲取所有 DOM 元素
+  const elements = getElements();
+  initializePopupStaticText(elements);
+  await initAccountSection(elements);
+
+  // 檢查設置
+  const settings = await checkSettings();
+  if (!settings.valid) {
+    setStatus(elements, resolveMissingSettingsMessage(settings));
+    disablePrimaryPopupActions(elements);
+    return;
+  }
+
+  // 檢查頁面狀態並更新 UI（使用 TTL cache 避免不必要的 API 呼叫）
+  const destinationState = await initializeDestinationSelectorState(elements);
+  const selectedDestinationProfileId = destinationState.selectedDestinationProfileId;
+  const destinationProfiles = destinationState.destinationProfiles;
+
+  await initializePageStatus(elements);
+
+  const tabTracker = await registerActiveTabTracking();
+
+  registerPopupEventListeners(elements, {
+    selectedDestinationProfileId,
+    destinationProfiles,
+    getCurrentTab: tabTracker.getCurrentTab,
+  });
 }
 
 // Initialize when DOM is ready

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -84,6 +84,28 @@ function disablePrimaryPopupActions(elements) {
   setButtonState(elements.highlightButton, true);
 }
 
+function createSanitizedFailureContext(action, error) {
+  return {
+    action,
+    result: 'failure',
+    sanitizedError: sanitizeApiError(error, action),
+  };
+}
+
+function createPageStatusLogContext(pageStatus) {
+  const context = {
+    action: 'initializePageStatus',
+    result: 'success',
+  };
+
+  if (pageStatus?.notionPageId) {
+    context.pageStatusId = pageStatus.notionPageId;
+  }
+
+  context.statusCode = pageStatus?.statusCode ?? pageStatus?.statusKind ?? 'unknown';
+  return context;
+}
+
 async function initializeDestinationSelectorState(elements) {
   let selectedDestinationProfileId = null;
   let destinationProfiles = [];
@@ -93,7 +115,10 @@ async function initializeDestinationSelectorState(elements) {
     destinationProfiles = destinationState.profiles || [];
     renderDestinationSelector(elements, destinationState);
   } catch (error) {
-    Logger.warn('[Popup] Failed to initialize destination selector', { error });
+    Logger.warn(
+      '[Popup] Failed to initialize destination selector',
+      createSanitizedFailureContext('initDestinationSelector', error)
+    );
   }
   return { selectedDestinationProfileId, destinationProfiles };
 }
@@ -108,11 +133,15 @@ async function initializePageStatus(elements) {
       } else {
         updateUIForUnsavedPage(elements, pageStatus);
       }
-      Logger.success('[Popup] Initialization complete', { pageStatus });
+      Logger.success('[Popup] Initialization complete', createPageStatusLogContext(pageStatus));
     }
   } catch (error) {
-    Logger.error('Failed to initialize popup:', error);
     const safeMessage = sanitizeApiError(error, 'popup_init');
+    Logger.error('Failed to initialize popup:', {
+      action: 'initializePageStatus',
+      result: 'failure',
+      sanitizedError: safeMessage,
+    });
     const msg = ErrorHandler.formatUserMessage(safeMessage);
     setStatus(elements, msg, '#d63384');
   }
@@ -317,36 +346,47 @@ function registerPopupEventListeners(elements, context) {
 export async function initPopup() {
   Logger.start('[Popup] Initializing...');
 
-  // 注入 SVG 圖標
-  injectIcons(UI_ICONS);
+  let elements;
+  try {
+    // 注入 SVG 圖標
+    injectIcons(UI_ICONS);
 
-  // 獲取所有 DOM 元素
-  const elements = getElements();
-  initializePopupStaticText(elements);
-  await initAccountSection(elements);
+    // 獲取所有 DOM 元素
+    elements = getElements();
+    initializePopupStaticText(elements);
+    await initAccountSection(elements);
 
-  // 檢查設置
-  const settings = await checkSettings();
-  if (!settings.valid) {
-    setStatus(elements, resolveMissingSettingsMessage(settings));
-    disablePrimaryPopupActions(elements);
-    return;
+    // 檢查設置
+    const settings = await checkSettings();
+    if (!settings.valid) {
+      setStatus(elements, resolveMissingSettingsMessage(settings));
+      disablePrimaryPopupActions(elements);
+      return;
+    }
+
+    // 檢查頁面狀態並更新 UI（使用 TTL cache 避免不必要的 API 呼叫）
+    const destinationState = await initializeDestinationSelectorState(elements);
+    const selectedDestinationProfileId = destinationState.selectedDestinationProfileId;
+    const destinationProfiles = destinationState.destinationProfiles;
+
+    await initializePageStatus(elements);
+
+    const tabTracker = await registerActiveTabTracking();
+
+    registerPopupEventListeners(elements, {
+      selectedDestinationProfileId,
+      destinationProfiles,
+      getCurrentTab: tabTracker.getCurrentTab,
+    });
+  } catch (error) {
+    const context = createSanitizedFailureContext('initPopup', error);
+    Logger.error('[Popup] Initialization failed', context);
+
+    if (elements) {
+      setStatus(elements, ErrorHandler.formatUserMessage(context.sanitizedError), '#d63384');
+      disablePrimaryPopupActions(elements);
+    }
   }
-
-  // 檢查頁面狀態並更新 UI（使用 TTL cache 避免不必要的 API 呼叫）
-  const destinationState = await initializeDestinationSelectorState(elements);
-  const selectedDestinationProfileId = destinationState.selectedDestinationProfileId;
-  const destinationProfiles = destinationState.destinationProfiles;
-
-  await initializePageStatus(elements);
-
-  const tabTracker = await registerActiveTabTracking();
-
-  registerPopupEventListeners(elements, {
-    selectedDestinationProfileId,
-    destinationProfiles,
-    getCurrentTab: tabTracker.getCurrentTab,
-  });
 }
 
 // Initialize when DOM is ready

--- a/tests/unit/popup/popupController.test.js
+++ b/tests/unit/popup/popupController.test.js
@@ -279,6 +279,58 @@ describe('popup.js Controller', () => {
     expect(updateUIForSavedPage).not.toHaveBeenCalled();
   });
 
+  it('初始化保存目標失敗時應只記錄 sanitized logging context', async () => {
+    setup();
+    const rawError = new Error(
+      'backend leaked token secret_abc and url https://example.com/private?token=secret'
+    );
+    getDestinationState.mockRejectedValue(rawError);
+
+    await initPopup();
+
+    expect(Logger.warn).toHaveBeenCalledWith('[Popup] Failed to initialize destination selector', {
+      action: 'initDestinationSelector',
+      result: 'failure',
+      sanitizedError: 'UNKNOWN_ERROR',
+    });
+    expect(Logger.warn).not.toHaveBeenCalledWith(
+      '[Popup] Failed to initialize destination selector',
+      { error: rawError }
+    );
+  });
+
+  it('初始化保存狀態成功時應避免記錄 raw pageStatus payload', async () => {
+    setup();
+    checkPageStatus.mockResolvedValue({
+      success: true,
+      statusKind: 'saved',
+      isSaved: true,
+      canSave: false,
+      canSyncHighlights: true,
+      notionPageId: 'notion-page-123',
+      notionUrl: 'https://notion.so/private?token=secret',
+      stableUrl: 'https://example.com/private?email=user@example.com',
+      title: 'Sensitive page title',
+    });
+
+    await initPopup();
+
+    expect(Logger.success).toHaveBeenCalledWith('[Popup] Initialization complete', {
+      action: 'initializePageStatus',
+      result: 'success',
+      pageStatusId: 'notion-page-123',
+      statusCode: 'saved',
+    });
+
+    const successCall = Logger.success.mock.calls.find(
+      ([message]) => message === '[Popup] Initialization complete'
+    );
+    expect(successCall?.[1]).not.toHaveProperty('pageStatus');
+    expect(JSON.stringify(successCall?.[1])).not.toContain('Sensitive page title');
+    expect(JSON.stringify(successCall?.[1])).not.toContain('token=secret');
+    expect(JSON.stringify(successCall?.[1])).not.toContain('user@example.com');
+  });
+
   it('當缺少 API Key 時應正確處理', async () => {
     const { mockElements } = setup();
     checkSettings.mockResolvedValue({
@@ -293,6 +345,26 @@ describe('popup.js Controller', () => {
     expect(setStatus).toHaveBeenCalledWith(
       mockElements,
       expect.stringContaining(ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED)
+    );
+    expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
+    expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);
+  });
+
+  it('initPopup 頂層初始化失敗時應顯示 fallback UI 並禁用主要操作', async () => {
+    const { mockElements } = setup();
+    checkSettings.mockRejectedValue(new Error('settings load leaked secret_token'));
+
+    await expect(initPopup()).resolves.toBeUndefined();
+
+    expect(Logger.error).toHaveBeenCalledWith('[Popup] Initialization failed', {
+      action: 'initPopup',
+      result: 'failure',
+      sanitizedError: 'UNKNOWN_ERROR',
+    });
+    expect(setStatus).toHaveBeenCalledWith(
+      mockElements,
+      expect.stringContaining('發生未知錯誤'),
+      '#d63384'
     );
     expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
     expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);

--- a/tests/unit/popup/popupController.test.js
+++ b/tests/unit/popup/popupController.test.js
@@ -90,17 +90,33 @@ async function triggerEvent(element, eventType = 'click') {
   await handler({ target: element });
 }
 
+function createDeferred() {
+  let resolveDeferred;
+  let rejectDeferred;
+  const promise = new Promise((resolve, reject) => {
+    resolveDeferred = resolve;
+    rejectDeferred = reject;
+  });
+  return { promise, resolve: resolveDeferred, reject: rejectDeferred };
+}
+
+async function flushAsyncHandlers() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('popup.js Controller', () => {
   const setup = () => {
     const mockElements = {
-      saveButton: { addEventListener: jest.fn(), style: {}, dataset: {} },
-      highlightButton: { addEventListener: jest.fn(), style: {}, dataset: {} },
-      manageButton: { addEventListener: jest.fn(), style: {}, dataset: {} },
+      saveButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
+      highlightButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
+      manageButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
       openNotionButton: {
         addEventListener: jest.fn(),
         getAttribute: jest.fn(),
         style: {},
         dataset: { url: 'https://notion.so/new' },
+        disabled: false,
       },
       accountSection: { style: { display: 'none' } },
       accountButton: {
@@ -108,6 +124,7 @@ describe('popup.js Controller', () => {
         style: {},
         dataset: {},
         querySelector: jest.fn(),
+        disabled: false,
       },
       accountSummary: { textContent: '' },
       accountEmail: { textContent: '', style: {} },
@@ -125,6 +142,11 @@ describe('popup.js Controller', () => {
     };
 
     getElements.mockReturnValue(mockElements);
+    setButtonState.mockImplementation((button, disabled) => {
+      if (button) {
+        button.disabled = disabled;
+      }
+    });
 
     // Default mocks
     checkSettings.mockResolvedValue({ valid: true });
@@ -572,17 +594,30 @@ describe('popup.js Controller', () => {
       expect(globalThis.window.close).toHaveBeenCalled();
     });
 
-    it('tabs.onActivated 觸發後應使用最新 currentTab 開啟側邊欄', async () => {
+    it('tabs.onActivated 觸發後應直接使用 activeInfo.tabId 開啟側邊欄', async () => {
       const { mockElements } = setup();
-      getActiveTab.mockResolvedValue({ id: 777, url: 'https://example.com/old' });
-      globalThis.chrome.tabs.query.mockResolvedValue([{ id: 888, url: 'https://example.com/new' }]);
+      getActiveTab.mockResolvedValue({ id: 777, windowId: 10, url: 'https://example.com/old' });
+      await initPopup();
+      globalThis.chrome.tabs.query.mockClear();
+
+      const [onActivatedHandler] = globalThis.chrome.tabs.onActivated.addListener.mock.calls[0];
+      await onActivatedHandler({ tabId: 888, windowId: 10 });
+      await triggerEvent(mockElements.manageButton);
+
+      expect(globalThis.chrome.tabs.query).not.toHaveBeenCalled();
+      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: 888 });
+    });
+
+    it('tabs.onActivated 觸發於其他 window 時不應覆蓋 popup 的 currentTab', async () => {
+      const { mockElements } = setup();
+      getActiveTab.mockResolvedValue({ id: 777, windowId: 10, url: 'https://example.com/old' });
       await initPopup();
 
       const [onActivatedHandler] = globalThis.chrome.tabs.onActivated.addListener.mock.calls[0];
-      await onActivatedHandler();
+      await onActivatedHandler({ tabId: 888, windowId: 20 });
       await triggerEvent(mockElements.manageButton);
 
-      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: 888 });
+      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: 777 });
     });
 
     it('當前分頁不可用時，點擊 manageButton 應顯示錯誤', async () => {
@@ -635,6 +670,30 @@ describe('popup.js Controller', () => {
 
       expect(startAccountLogin).toHaveBeenCalled();
       expect(openAccountManagement).not.toHaveBeenCalled();
+    });
+
+    it('accountButton 非同步操作期間應禁用並阻止重複點擊', async () => {
+      const { mockElements } = setup();
+      const loginStart = createDeferred();
+      startAccountLogin.mockReturnValue(loginStart.promise);
+      await initPopup();
+
+      const firstClick = triggerEvent(mockElements.accountButton);
+      await flushAsyncHandlers();
+
+      expect(setButtonState).toHaveBeenCalledWith(mockElements.accountButton, true);
+      expect(mockElements.accountButton.disabled).toBe(true);
+
+      const secondClick = triggerEvent(mockElements.accountButton);
+      await flushAsyncHandlers();
+
+      expect(startAccountLogin).toHaveBeenCalledTimes(1);
+
+      loginStart.resolve({ success: true });
+      await Promise.all([firstClick, secondClick]);
+
+      expect(setButtonState).toHaveBeenLastCalledWith(mockElements.accountButton, false);
+      expect(mockElements.accountButton.disabled).toBe(false);
     });
 
     it('已登入時點擊 accountButton 應開啟帳號管理', async () => {

--- a/tests/unit/popup/popupController.test.js
+++ b/tests/unit/popup/popupController.test.js
@@ -722,5 +722,55 @@ describe('popup.js Controller', () => {
 
       expect(setAccountStatusError).toHaveBeenCalledWith(mockElements, '無法開啟帳號管理頁');
     });
+
+    it('點擊 destinationToggle 時應切換 menu 顯示與 aria-expanded', async () => {
+      const { mockElements } = setup();
+      mockElements.destinationToggle.setAttribute = jest.fn();
+      await initPopup();
+
+      await triggerEvent(mockElements.destinationToggle);
+      expect(mockElements.destinationMenu.style.display).toBe('block');
+      expect(mockElements.destinationToggle.setAttribute).toHaveBeenCalledWith(
+        'aria-expanded',
+        'true'
+      );
+
+      await triggerEvent(mockElements.destinationToggle);
+      expect(mockElements.destinationMenu.style.display).toBe('none');
+      expect(mockElements.destinationToggle.setAttribute).toHaveBeenCalledWith(
+        'aria-expanded',
+        'false'
+      );
+    });
+
+    it('點擊 destinationMenu profile item 時應更新 selected profile 並重渲染 selector', async () => {
+      const { mockElements } = setup();
+      getDestinationState.mockResolvedValue({
+        profiles: [
+          { id: 'default', name: 'Default' },
+          { id: 'work', name: 'Work' },
+        ],
+        selectedProfileId: 'default',
+        entitlement: { maxProfiles: 2 },
+      });
+      await initPopup();
+
+      const handler = mockElements.destinationMenu.addEventListener.mock.calls.find(
+        call => call[0] === 'click'
+      )[1];
+      await handler({ target: { dataset: { profileId: 'work' } } });
+
+      expect(renderDestinationSelector).toHaveBeenLastCalledWith(mockElements, {
+        profiles: [
+          { id: 'default', name: 'Default' },
+          { id: 'work', name: 'Work' },
+        ],
+        selectedProfileId: 'work',
+      });
+
+      savePage.mockResolvedValue({ success: false, error: 'Save failed' });
+      await triggerEvent(mockElements.saveButton);
+      expect(savePage).toHaveBeenCalledWith('work');
+    });
   });
 });

--- a/tests/unit/popup/popupController.test.js
+++ b/tests/unit/popup/popupController.test.js
@@ -105,83 +105,87 @@ async function flushAsyncHandlers() {
   await Promise.resolve();
 }
 
+function createPopupButton(overrides = {}) {
+  return { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false, ...overrides };
+}
+
+function createPopupMockElements() {
+  return {
+    saveButton: createPopupButton(),
+    highlightButton: createPopupButton(),
+    manageButton: createPopupButton(),
+    openNotionButton: createPopupButton({
+      getAttribute: jest.fn(),
+      dataset: { url: 'https://notion.so/new' },
+    }),
+    accountSection: { style: { display: 'none' } },
+    accountButton: createPopupButton({
+      querySelector: jest.fn(),
+    }),
+    accountSummary: { textContent: '' },
+    accountEmail: { textContent: '', style: {} },
+    accountStatus: { textContent: '', style: {} },
+    destinationSection: { style: {} },
+    destinationCurrent: { textContent: '', dataset: {}, style: {} },
+    destinationToggle: createPopupButton(),
+    destinationMenu: { addEventListener: jest.fn(), style: {} },
+    status: { textContent: '', style: {} },
+    clearHighlightsButton: null,
+    modal: null,
+    modalMessage: null,
+    modalConfirm: null,
+    modalCancel: null,
+  };
+}
+
+function configureDefaultPopupMocks(mockElements) {
+  getElements.mockReturnValue(mockElements);
+  setButtonState.mockImplementation((button, disabled) => {
+    if (button) {
+      button.disabled = disabled;
+    }
+  });
+
+  checkSettings.mockResolvedValue({ valid: true });
+  checkPageStatus.mockResolvedValue({
+    success: true,
+    statusKind: 'saved',
+    isSaved: true,
+    canSave: false,
+    canSyncHighlights: true,
+  });
+  getPopupAccountState.mockResolvedValue({
+    enabled: true,
+    isLoggedIn: false,
+    profile: null,
+    transientRefreshError: false,
+  });
+  getDestinationState.mockResolvedValue({
+    profiles: [{ id: 'default', name: 'Default' }],
+    selectedProfileId: 'default',
+    entitlement: { maxProfiles: 1 },
+  });
+}
+
+function installChromePopupMocks() {
+  globalThis.chrome = {
+    tabs: {
+      query: jest.fn().mockResolvedValue([{ id: 123, url: 'https://example.com' }]),
+      sendMessage: jest.fn().mockResolvedValue({}),
+      onActivated: { addListener: jest.fn() },
+    },
+    sidePanel: {
+      open: jest.fn(),
+    },
+  };
+  globalThis.window.close = jest.fn();
+}
+
 describe('popup.js Controller', () => {
   const setup = () => {
-    const mockElements = {
-      saveButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
-      highlightButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
-      manageButton: { addEventListener: jest.fn(), style: {}, dataset: {}, disabled: false },
-      openNotionButton: {
-        addEventListener: jest.fn(),
-        getAttribute: jest.fn(),
-        style: {},
-        dataset: { url: 'https://notion.so/new' },
-        disabled: false,
-      },
-      accountSection: { style: { display: 'none' } },
-      accountButton: {
-        addEventListener: jest.fn(),
-        style: {},
-        dataset: {},
-        querySelector: jest.fn(),
-        disabled: false,
-      },
-      accountSummary: { textContent: '' },
-      accountEmail: { textContent: '', style: {} },
-      accountStatus: { textContent: '', style: {} },
-      destinationSection: { style: {} },
-      destinationCurrent: { textContent: '', dataset: {}, style: {} },
-      destinationToggle: { addEventListener: jest.fn(), style: {}, dataset: {} },
-      destinationMenu: { addEventListener: jest.fn(), style: {} },
-      status: { textContent: '', style: {} },
-      clearHighlightsButton: null,
-      modal: null,
-      modalMessage: null,
-      modalConfirm: null,
-      modalCancel: null,
-    };
-
-    getElements.mockReturnValue(mockElements);
-    setButtonState.mockImplementation((button, disabled) => {
-      if (button) {
-        button.disabled = disabled;
-      }
-    });
-
-    // Default mocks
-    checkSettings.mockResolvedValue({ valid: true });
-    checkPageStatus.mockResolvedValue({
-      success: true,
-      statusKind: 'saved',
-      isSaved: true,
-      canSave: false,
-      canSyncHighlights: true,
-    });
-    getPopupAccountState.mockResolvedValue({
-      enabled: true,
-      isLoggedIn: false,
-      profile: null,
-      transientRefreshError: false,
-    });
-    getDestinationState.mockResolvedValue({
-      profiles: [{ id: 'default', name: 'Default' }],
-      selectedProfileId: 'default',
-      entitlement: { maxProfiles: 1 },
-    });
-
-    // Mock global chrome
-    globalThis.chrome = {
-      tabs: {
-        query: jest.fn().mockResolvedValue([{ id: 123, url: 'https://example.com' }]),
-        sendMessage: jest.fn().mockResolvedValue({}),
-        onActivated: { addListener: jest.fn() },
-      },
-      sidePanel: {
-        open: jest.fn(),
-      },
-    };
-    globalThis.window.close = jest.fn();
-
+    const mockElements = createPopupMockElements();
+    configureDefaultPopupMocks(mockElements);
+    installChromePopupMocks();
     return { mockElements };
   };
 
@@ -331,24 +335,66 @@ describe('popup.js Controller', () => {
     expect(JSON.stringify(successCall?.[1])).not.toContain('user@example.com');
   });
 
-  it('當缺少 API Key 時應正確處理', async () => {
-    const { mockElements } = setup();
-    checkSettings.mockResolvedValue({
-      valid: false,
-      apiKey: undefined,
-      dataSourceId: undefined,
-      missingReason: 'missing_auth',
-    });
+  it.each([
+    {
+      name: '當缺少 API Key 時應正確處理',
+      settings: {
+        valid: false,
+        apiKey: undefined,
+        dataSourceId: undefined,
+        missingReason: 'missing_auth',
+      },
+      expectedMessage: ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED,
+      expectPrimaryActionsDisabled: true,
+    },
+    {
+      name: '當已有 API Key 但缺少 Data Source ID 時應正確處理',
+      settings: {
+        valid: false,
+        apiKey: 'test-api-key',
+        dataSourceId: undefined,
+        missingReason: 'missing_data_source',
+      },
+      expectedMessage: ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE,
+      expectPrimaryActionsDisabled: true,
+    },
+    {
+      name: '當 OAuth 已連接但缺少保存目標時應顯示保存目標提示而非 API Key 提示',
+      settings: {
+        valid: false,
+        apiKey: undefined,
+        dataSourceId: undefined,
+        missingReason: 'missing_data_source',
+        authMode: 'oauth',
+        hasOAuthToken: true,
+      },
+      expectedMessage: ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE,
+      unexpectedMessage: ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED,
+    },
+  ])(
+    '$name',
+    async ({ settings, expectedMessage, unexpectedMessage, expectPrimaryActionsDisabled }) => {
+      const { mockElements } = setup();
+      checkSettings.mockResolvedValue(settings);
 
-    await initPopup();
+      await initPopup();
 
-    expect(setStatus).toHaveBeenCalledWith(
-      mockElements,
-      expect.stringContaining(ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED)
-    );
-    expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
-    expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);
-  });
+      expect(setStatus).toHaveBeenCalledWith(
+        mockElements,
+        expect.stringContaining(expectedMessage)
+      );
+      if (unexpectedMessage) {
+        expect(setStatus).not.toHaveBeenCalledWith(
+          mockElements,
+          expect.stringContaining(unexpectedMessage)
+        );
+      }
+      if (expectPrimaryActionsDisabled) {
+        expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
+        expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);
+      }
+    }
+  );
 
   it('initPopup 頂層初始化失敗時應顯示 fallback UI 並禁用主要操作', async () => {
     const { mockElements } = setup();
@@ -368,48 +414,6 @@ describe('popup.js Controller', () => {
     );
     expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
     expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);
-  });
-
-  it('當已有 API Key 但缺少 Data Source ID 時應正確處理', async () => {
-    const { mockElements } = setup();
-    checkSettings.mockResolvedValue({
-      valid: false,
-      apiKey: 'test-api-key',
-      dataSourceId: undefined,
-      missingReason: 'missing_data_source',
-    });
-
-    await initPopup();
-
-    expect(setStatus).toHaveBeenCalledWith(
-      mockElements,
-      expect.stringContaining(ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE)
-    );
-    expect(setButtonState).toHaveBeenCalledWith(mockElements.saveButton, true);
-    expect(setButtonState).toHaveBeenCalledWith(mockElements.highlightButton, true);
-  });
-
-  it('當 OAuth 已連接但缺少保存目標時應顯示保存目標提示而非 API Key 提示', async () => {
-    const { mockElements } = setup();
-    checkSettings.mockResolvedValue({
-      valid: false,
-      apiKey: undefined,
-      dataSourceId: undefined,
-      missingReason: 'missing_data_source',
-      authMode: 'oauth',
-      hasOAuthToken: true,
-    });
-
-    await initPopup();
-
-    expect(setStatus).toHaveBeenCalledWith(
-      mockElements,
-      expect.stringContaining(ERROR_MESSAGES.USER_MESSAGES.SETUP_MISSING_DATA_SOURCE)
-    );
-    expect(setStatus).not.toHaveBeenCalledWith(
-      mockElements,
-      expect.stringContaining(ERROR_MESSAGES.USER_MESSAGES.SETUP_KEY_NOT_CONFIGURED)
-    );
   });
 
   it('初始化失敗時應正確處理錯誤', async () => {
@@ -551,35 +555,27 @@ describe('popup.js Controller', () => {
       expect(setStatus).toHaveBeenCalledWith(mockElements, expect.stringContaining('發生未知錯誤'));
     });
 
-    it('當頁面已保存時，點擊 highlightButton 應啟動標註', async () => {
+    it.each([
+      {
+        name: '當頁面已保存時，點擊 highlightButton 應啟動標註',
+        pageStatus: { isSaved: true },
+        expectedStatus: UI_MESSAGES.POPUP.HIGHLIGHT_STARTING,
+      },
+      {
+        name: '即使頁面未保存，點擊 highlightButton 也應啟動標註',
+        pageStatus: { isSaved: false },
+        expectedStatus: UI_MESSAGES.POPUP.HIGHLIGHT_ACTIVATED,
+      },
+    ])('$name', async ({ pageStatus, expectedStatus }) => {
       const { mockElements } = setup();
       await initPopup();
-      checkPageStatus.mockResolvedValue({ isSaved: true });
+      checkPageStatus.mockResolvedValue(pageStatus);
       startHighlight.mockResolvedValue({ success: true });
 
       await triggerEvent(mockElements.highlightButton);
 
-      expect(setStatus).toHaveBeenCalledWith(
-        mockElements,
-        expect.stringContaining(UI_MESSAGES.POPUP.HIGHLIGHT_STARTING)
-      );
       expect(startHighlight).toHaveBeenCalled();
-    });
-
-    it('即使頁面未保存，點擊 highlightButton 也應啟動標註', async () => {
-      const { mockElements } = setup();
-      await initPopup();
-      checkPageStatus.mockResolvedValue({ isSaved: false });
-      startHighlight.mockResolvedValue({ success: true });
-
-      await triggerEvent(mockElements.highlightButton);
-
-      // Highlight-First：不再檢查 isSaved，直接啟動標註
-      expect(startHighlight).toHaveBeenCalled();
-      expect(setStatus).toHaveBeenCalledWith(
-        mockElements,
-        expect.stringContaining(UI_MESSAGES.POPUP.HIGHLIGHT_ACTIVATED)
-      );
+      expect(setStatus).toHaveBeenCalledWith(mockElements, expect.stringContaining(expectedStatus));
     });
 
     it('highlight 啟動失敗時應顯示錯誤並記錄 structured context', async () => {
@@ -666,30 +662,34 @@ describe('popup.js Controller', () => {
       expect(globalThis.window.close).toHaveBeenCalled();
     });
 
-    it('tabs.onActivated 觸發後應直接使用 activeInfo.tabId 開啟側邊欄', async () => {
+    it.each([
+      {
+        name: 'tabs.onActivated 觸發後應直接使用 activeInfo.tabId 開啟側邊欄',
+        activeInfo: { tabId: 888, windowId: 10 },
+        expectedTabId: 888,
+        expectNoTabQuery: true,
+      },
+      {
+        name: 'tabs.onActivated 觸發於其他 window 時不應覆蓋 popup 的 currentTab',
+        activeInfo: { tabId: 888, windowId: 20 },
+        expectedTabId: 777,
+      },
+    ])('$name', async ({ activeInfo, expectedTabId, expectNoTabQuery }) => {
       const { mockElements } = setup();
       getActiveTab.mockResolvedValue({ id: 777, windowId: 10, url: 'https://example.com/old' });
       await initPopup();
-      globalThis.chrome.tabs.query.mockClear();
+      if (expectNoTabQuery) {
+        globalThis.chrome.tabs.query.mockClear();
+      }
 
       const [onActivatedHandler] = globalThis.chrome.tabs.onActivated.addListener.mock.calls[0];
-      await onActivatedHandler({ tabId: 888, windowId: 10 });
+      await onActivatedHandler(activeInfo);
       await triggerEvent(mockElements.manageButton);
 
-      expect(globalThis.chrome.tabs.query).not.toHaveBeenCalled();
-      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: 888 });
-    });
-
-    it('tabs.onActivated 觸發於其他 window 時不應覆蓋 popup 的 currentTab', async () => {
-      const { mockElements } = setup();
-      getActiveTab.mockResolvedValue({ id: 777, windowId: 10, url: 'https://example.com/old' });
-      await initPopup();
-
-      const [onActivatedHandler] = globalThis.chrome.tabs.onActivated.addListener.mock.calls[0];
-      await onActivatedHandler({ tabId: 888, windowId: 20 });
-      await triggerEvent(mockElements.manageButton);
-
-      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: 777 });
+      if (expectNoTabQuery) {
+        expect(globalThis.chrome.tabs.query).not.toHaveBeenCalled();
+      }
+      expect(globalThis.chrome.sidePanel.open).toHaveBeenCalledWith({ tabId: expectedTabId });
     });
 
     it('當前分頁不可用時，點擊 manageButton 應顯示錯誤', async () => {


### PR DESCRIPTION
### 摘要
重構彈出控制器以降低其複雜性，提升可讀性和可維護性。

### 變更內容
- 將設定檢查的錯誤訊息處理邏輯提取到 `resolveMissingSettingsMessage` 函數中。
- 將主要按鈕的禁用邏輯提取到 `disablePrimaryPopupActions` 函數中。
- 將帳號管理和登入的處理邏輯分別提取到 `handleAccountManagementClick` 和 `handleAccountLoginClick` 函數中。
- 簡化 `initPopup` 函數的結構，提升可讀性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

