### PR TITLE
fix: enhance URL handling for logging security

### DIFF
--- a/scripts/background/handlers/logHandlers.js
+++ b/scripts/background/handlers/logHandlers.js
@@ -18,6 +18,27 @@ import Logger, { parseArgsToContext } from '../../utils/Logger.js';
 /** 接收端批量日誌的最大數量限制，防禦過量批次 */
 const MAX_BATCH_SIZE = 20;
 
+const UNKNOWN_EXTERNAL_SOURCE = 'unknown_external';
+const MALFORMED_EXTERNAL_SOURCE = 'malformed_external';
+
+/**
+ * 安全解析日誌來源路徑，避免 invalid URL 拋出異常或洩漏隱私。
+ *
+ * @param {string} senderUrl - 傳送者的 URL
+ * @returns {string} 來源路徑
+ */
+function resolveLogSourcePath(senderUrl) {
+  if (!senderUrl) {
+    return UNKNOWN_EXTERNAL_SOURCE;
+  }
+
+  try {
+    return new URL(senderUrl).pathname;
+  } catch {
+    return MALFORMED_EXTERNAL_SOURCE;
+  }
+}
+
 /**
  * 處理導出除錯日誌的請求
  *
@@ -89,7 +110,7 @@ export const handleDevLogSink = (message, sender, sendResponse) => {
       level,
       message: logMessage,
       context,
-      source: sender.url ? new URL(sender.url).pathname : 'unknown_external',
+      source: resolveLogSourcePath(sender.url),
       timestamp: new Date().toISOString(),
     });
 
@@ -128,7 +149,7 @@ export const handleDevLogSinkBatch = (message, sender, sendResponse) => {
     // 防禦性限制：截斷超過 MAX_BATCH_SIZE 的批次，避免處理過量日誌
     const safeLogs = logs.length > MAX_BATCH_SIZE ? logs.slice(0, MAX_BATCH_SIZE) : logs;
 
-    const sourcePath = sender.url ? new URL(sender.url).pathname : 'unknown_external';
+    const sourcePath = resolveLogSourcePath(sender.url);
 
     for (const entry of safeLogs) {
       const { level, message: logMessage, args = [] } = entry;

--- a/scripts/background/handlers/logHandlers.js
+++ b/scripts/background/handlers/logHandlers.js
@@ -20,6 +20,7 @@ const MAX_BATCH_SIZE = 20;
 
 const UNKNOWN_EXTERNAL_SOURCE = 'unknown_external';
 const MALFORMED_EXTERNAL_SOURCE = 'malformed_external';
+const LOCAL_FILE_SOURCE = 'local_file';
 
 /**
  * 安全解析日誌來源路徑，避免 invalid URL 拋出異常或洩漏隱私。
@@ -33,7 +34,11 @@ function resolveLogSourcePath(senderUrl) {
   }
 
   try {
-    return new URL(senderUrl).pathname;
+    const parsedUrl = new URL(senderUrl);
+    if (parsedUrl.protocol === 'file:') {
+      return LOCAL_FILE_SOURCE;
+    }
+    return parsedUrl.pathname;
   } catch {
     return MALFORMED_EXTERNAL_SOURCE;
   }

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -13,6 +13,7 @@
 /* global chrome */
 
 import Logger from '../../utils/Logger.js';
+import { sanitizeUrlForLogging } from '../../utils/LogSanitizer.js';
 import { RESTRICTED_PROTOCOLS } from '../../config/shared/core.js';
 import { RUNTIME_ACTIONS } from '../../config/shared/runtimeActions.js';
 
@@ -120,10 +121,11 @@ function isRestrictedInjectionUrl(url) {
       domain => urlObj.host === domain || urlObj.host.endsWith(`.${domain}`)
     );
   } catch (error) {
+    const sanitizedErrorMsg = String(error.message).replaceAll(url, '[invalid-url]');
     Logger.warn('[Injection:Utils] Failed to parse URL when checking restrictions', {
       action: 'isRestrictedInjectionUrl',
-      url,
-      error: error.message,
+      url: sanitizeUrlForLogging(url),
+      error: sanitizedErrorMsg,
     });
     return true;
   }

--- a/scripts/content/extractors/ImageCollector.js
+++ b/scripts/content/extractors/ImageCollector.js
@@ -103,7 +103,10 @@ const ImageCollector = {
       return null;
     }
 
-    const cleanedUrl = this._normalizeFeaturedImageUrl(src);
+    const cleanedUrl = this._normalizeFeaturedImageUrl(src, { selector, source: 'dom' });
+    if (!cleanedUrl) {
+      return null;
+    }
     if (
       this._shouldSkipTemporaryFeaturedImage(cleanedUrl, '跳過 temporary 圖片 URL (DOM 封面)', {
         selector,
@@ -182,7 +185,10 @@ const ImageCollector = {
       return null;
     }
 
-    const cleanedUrl = this._normalizeFeaturedImageUrl(content);
+    const cleanedUrl = this._normalizeFeaturedImageUrl(content, { source: selector });
+    if (!cleanedUrl) {
+      return null;
+    }
     if (
       this._shouldSkipTemporaryFeaturedImage(cleanedUrl, '跳過 temporary 圖片 URL (Meta 封面)', {
         source: selector,
@@ -206,9 +212,18 @@ const ImageCollector = {
     return Boolean(isValidImageUrl?.(src));
   },
 
-  _normalizeFeaturedImageUrl(src) {
-    const absoluteUrl = new URL(src, document.baseURI).href;
-    return cleanImageUrl?.(absoluteUrl) ?? absoluteUrl;
+  _normalizeFeaturedImageUrl(src, metadata = {}) {
+    try {
+      const absoluteUrl = new URL(src, document.baseURI).href;
+      return cleanImageUrl?.(absoluteUrl) ?? absoluteUrl;
+    } catch {
+      Logger.warn('無效的圖片 URL', {
+        action: 'collectFeaturedImage',
+        ...metadata,
+        url: sanitizeUrlForLogging(src),
+      });
+      return null;
+    }
   },
 
   _shouldSkipTemporaryFeaturedImage(cleanedUrl, message, metadata) {

--- a/tests/unit/background/handlers/logHandlers.test.js
+++ b/tests/unit/background/handlers/logHandlers.test.js
@@ -315,5 +315,63 @@ describe('logHandlers', () => {
       );
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
     });
+
+    test('devLogSink 應安全處理 malformed sender.url 且不保存 raw source', () => {
+      const sendResponse = jest.fn();
+      const sender = {
+        id: 'mock-extension-id',
+        tab: { id: 1 },
+        url: 'malformed_url_without_protocol?token=secret',
+      };
+
+      handlers.devLogSink({ level: 'info', message: 'bad url', args: [] }, sender, sendResponse);
+
+      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'malformed_external' })
+      );
+      expect(JSON.stringify(Logger.addLogToBuffer.mock.calls)).not.toContain(sender.url);
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
+
+    test('devLogSinkBatch 應安全處理 malformed sender.url 且不保存 raw source', () => {
+      const sendResponse = jest.fn();
+      const sender = {
+        id: 'mock-extension-id',
+        tab: { id: 1 },
+        url: 'malformed_url_without_protocol?token=secret',
+      };
+
+      handlers.devLogSinkBatch(
+        { logs: [{ level: 'info', message: 'bad batch', args: [] }] },
+        sender,
+        sendResponse
+      );
+
+      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'malformed_external' })
+      );
+      expect(JSON.stringify(Logger.addLogToBuffer.mock.calls)).not.toContain(sender.url);
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
+
+    test('devLogSinkBatch 應保留 valid sender.url 的 pathname source', () => {
+      const sendResponse = jest.fn();
+      const sender = {
+        id: 'mock-extension-id',
+        tab: { id: 1 },
+        url: 'https://example.com/page1?token=secret',
+      };
+
+      handlers.devLogSinkBatch(
+        { logs: [{ level: 'info', message: 'valid', args: [] }] },
+        sender,
+        sendResponse
+      );
+
+      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
+        expect.objectContaining({ source: '/page1' })
+      );
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
   });
 });

--- a/tests/unit/background/handlers/logHandlers.test.js
+++ b/tests/unit/background/handlers/logHandlers.test.js
@@ -342,67 +342,56 @@ describe('logHandlers', () => {
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
     });
 
-    test('devLogSink 應安全處理 malformed sender.url 且不保存 raw source', () => {
-      expect.hasAssertions();
-      const sender = createContentScriptSender('malformed_url_without_protocol?token=secret');
-
-      expectBufferedSource({
+    test.each([
+      {
+        name: 'devLogSink 應安全處理 malformed sender.url 且不保存 raw source',
         handlerName: 'devLogSink',
         message: { level: 'info', message: 'bad url', args: [] },
-        sender,
+        senderUrl: 'malformed_url_without_protocol?token=secret',
         expectedSource: 'malformed_external',
-        excludedRawSource: sender.url,
-      });
-    });
-
-    test('devLogSinkBatch 應安全處理 malformed sender.url 且不保存 raw source', () => {
-      expect.hasAssertions();
-      const sender = createContentScriptSender('malformed_url_without_protocol?token=secret');
-
-      expectBufferedSource({
+        excludedRawSource: 'malformed_url_without_protocol?token=secret',
+      },
+      {
+        name: 'devLogSinkBatch 應安全處理 malformed sender.url 且不保存 raw source',
         handlerName: 'devLogSinkBatch',
         message: { logs: [{ level: 'info', message: 'bad batch', args: [] }] },
-        sender,
+        senderUrl: 'malformed_url_without_protocol?token=secret',
         expectedSource: 'malformed_external',
-        excludedRawSource: sender.url,
-      });
-    });
-
-    test('devLogSink 應將 file sender.url 標記為 local_file 且不保存本機路徑', () => {
-      expect.hasAssertions();
-      const sender = createContentScriptSender('file:///Users/alice/Secrets/report.html');
-
-      expectBufferedSource({
+        excludedRawSource: 'malformed_url_without_protocol?token=secret',
+      },
+      {
+        name: 'devLogSink 應將 file sender.url 標記為 local_file 且不保存本機路徑',
         handlerName: 'devLogSink',
         message: { level: 'info', message: 'local file', args: [] },
-        sender,
+        senderUrl: 'file:///Users/alice/Secrets/report.html',
         expectedSource: 'local_file',
         excludedRawSource: '/Users/alice/Secrets/report.html',
-      });
-    });
-
-    test('devLogSinkBatch 應將 file sender.url 標記為 local_file 且不保存本機路徑', () => {
-      expect.hasAssertions();
-      const sender = createContentScriptSender('file:///C:/Users/Alice/Documents/report.html');
-
-      expectBufferedSource({
+      },
+      {
+        name: 'devLogSinkBatch 應將 file sender.url 標記為 local_file 且不保存本機路徑',
         handlerName: 'devLogSinkBatch',
         message: { logs: [{ level: 'info', message: 'local file batch', args: [] }] },
-        sender,
+        senderUrl: 'file:///C:/Users/Alice/Documents/report.html',
         expectedSource: 'local_file',
         excludedRawSource: '/C:/Users/Alice/Documents/report.html',
-      });
-    });
-
-    test('devLogSinkBatch 應保留 valid sender.url 的 pathname source', () => {
-      expect.hasAssertions();
-      const sender = createContentScriptSender('https://example.com/page1?token=secret');
-
-      expectBufferedSource({
+      },
+      {
+        name: 'devLogSinkBatch 應保留 valid sender.url 的 pathname source',
         handlerName: 'devLogSinkBatch',
         message: { logs: [{ level: 'info', message: 'valid', args: [] }] },
-        sender,
+        senderUrl: 'https://example.com/page1?token=secret',
         expectedSource: '/page1',
+      },
+    ])('$name', ({ handlerName, message, senderUrl, expectedSource, excludedRawSource }) => {
+      expect.hasAssertions();
+      const sender = createContentScriptSender(senderUrl);
+
+      expectBufferedSource({
+        handlerName,
+        message,
+        sender,
+        expectedSource,
+        excludedRawSource,
       });
     });
   });

--- a/tests/unit/background/handlers/logHandlers.test.js
+++ b/tests/unit/background/handlers/logHandlers.test.js
@@ -164,6 +164,32 @@ describe('logHandlers', () => {
   });
 
   describe('Action Logic', () => {
+    const createContentScriptSender = url => ({
+      id: 'mock-extension-id',
+      tab: { id: 1 },
+      url,
+    });
+
+    const expectBufferedSource = ({
+      handlerName,
+      message,
+      sender,
+      expectedSource,
+      excludedRawSource,
+    }) => {
+      const sendResponse = jest.fn();
+
+      handlers[handlerName](message, sender, sendResponse);
+
+      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
+        expect.objectContaining({ source: expectedSource })
+      );
+      if (excludedRawSource) {
+        expect(JSON.stringify(Logger.addLogToBuffer.mock.calls)).not.toContain(excludedRawSource);
+      }
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    };
+
     test('exportDebugLogs 應在合法請求時調用 Exporter', () => {
       const sendResponse = jest.fn();
       const sender = { id: 'mock-extension-id' };
@@ -317,61 +343,41 @@ describe('logHandlers', () => {
     });
 
     test('devLogSink 應安全處理 malformed sender.url 且不保存 raw source', () => {
-      const sendResponse = jest.fn();
-      const sender = {
-        id: 'mock-extension-id',
-        tab: { id: 1 },
-        url: 'malformed_url_without_protocol?token=secret',
-      };
+      expect.hasAssertions();
+      const sender = createContentScriptSender('malformed_url_without_protocol?token=secret');
 
-      handlers.devLogSink({ level: 'info', message: 'bad url', args: [] }, sender, sendResponse);
-
-      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
-        expect.objectContaining({ source: 'malformed_external' })
-      );
-      expect(JSON.stringify(Logger.addLogToBuffer.mock.calls)).not.toContain(sender.url);
-      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+      expectBufferedSource({
+        handlerName: 'devLogSink',
+        message: { level: 'info', message: 'bad url', args: [] },
+        sender,
+        expectedSource: 'malformed_external',
+        excludedRawSource: sender.url,
+      });
     });
 
     test('devLogSinkBatch 應安全處理 malformed sender.url 且不保存 raw source', () => {
-      const sendResponse = jest.fn();
-      const sender = {
-        id: 'mock-extension-id',
-        tab: { id: 1 },
-        url: 'malformed_url_without_protocol?token=secret',
-      };
+      expect.hasAssertions();
+      const sender = createContentScriptSender('malformed_url_without_protocol?token=secret');
 
-      handlers.devLogSinkBatch(
-        { logs: [{ level: 'info', message: 'bad batch', args: [] }] },
+      expectBufferedSource({
+        handlerName: 'devLogSinkBatch',
+        message: { logs: [{ level: 'info', message: 'bad batch', args: [] }] },
         sender,
-        sendResponse
-      );
-
-      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
-        expect.objectContaining({ source: 'malformed_external' })
-      );
-      expect(JSON.stringify(Logger.addLogToBuffer.mock.calls)).not.toContain(sender.url);
-      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+        expectedSource: 'malformed_external',
+        excludedRawSource: sender.url,
+      });
     });
 
     test('devLogSinkBatch 應保留 valid sender.url 的 pathname source', () => {
-      const sendResponse = jest.fn();
-      const sender = {
-        id: 'mock-extension-id',
-        tab: { id: 1 },
-        url: 'https://example.com/page1?token=secret',
-      };
+      expect.hasAssertions();
+      const sender = createContentScriptSender('https://example.com/page1?token=secret');
 
-      handlers.devLogSinkBatch(
-        { logs: [{ level: 'info', message: 'valid', args: [] }] },
+      expectBufferedSource({
+        handlerName: 'devLogSinkBatch',
+        message: { logs: [{ level: 'info', message: 'valid', args: [] }] },
         sender,
-        sendResponse
-      );
-
-      expect(Logger.addLogToBuffer).toHaveBeenCalledWith(
-        expect.objectContaining({ source: '/page1' })
-      );
-      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+        expectedSource: '/page1',
+      });
     });
   });
 });

--- a/tests/unit/background/handlers/logHandlers.test.js
+++ b/tests/unit/background/handlers/logHandlers.test.js
@@ -368,6 +368,32 @@ describe('logHandlers', () => {
       });
     });
 
+    test('devLogSink 應將 file sender.url 標記為 local_file 且不保存本機路徑', () => {
+      expect.hasAssertions();
+      const sender = createContentScriptSender('file:///Users/alice/Secrets/report.html');
+
+      expectBufferedSource({
+        handlerName: 'devLogSink',
+        message: { level: 'info', message: 'local file', args: [] },
+        sender,
+        expectedSource: 'local_file',
+        excludedRawSource: '/Users/alice/Secrets/report.html',
+      });
+    });
+
+    test('devLogSinkBatch 應將 file sender.url 標記為 local_file 且不保存本機路徑', () => {
+      expect.hasAssertions();
+      const sender = createContentScriptSender('file:///C:/Users/Alice/Documents/report.html');
+
+      expectBufferedSource({
+        handlerName: 'devLogSinkBatch',
+        message: { logs: [{ level: 'info', message: 'local file batch', args: [] }] },
+        sender,
+        expectedSource: 'local_file',
+        excludedRawSource: '/C:/Users/Alice/Documents/report.html',
+      });
+    });
+
     test('devLogSinkBatch 應保留 valid sender.url 的 pathname source', () => {
       expect.hasAssertions();
       const sender = createContentScriptSender('https://example.com/page1?token=secret');

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -435,11 +435,20 @@ describe('InjectionService', () => {
   });
 
   describe('Edge Case Utilities', () => {
-    it('isRestrictedInjectionUrl 應處理無法解析的 URL 字符串', () => {
+    it('isRestrictedInjectionUrl 應處理無法解析的 URL 字符串且不記錄 raw URL', () => {
       // 傳入無法被 new URL() 解析的字串，應觸發 catch 區塊並返回 true
-      const result = isRestrictedInjectionUrl('not-a-url');
+      const rawUrl = 'not-a-url?token=secret';
+      const result = isRestrictedInjectionUrl(rawUrl);
       expect(result).toBe(true);
-      expect(Logger.warn).toHaveBeenCalled();
+      expect(Logger.warn).toHaveBeenCalledWith(
+        '[Injection:Utils] Failed to parse URL when checking restrictions',
+        expect.objectContaining({
+          action: 'isRestrictedInjectionUrl',
+          url: '[invalid-url]',
+          error: expect.any(String),
+        })
+      );
+      expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(rawUrl);
     });
 
     describe('getRuntimeErrorMessage', () => {

--- a/tests/unit/content/extractors/ImageCollector.test.js
+++ b/tests/unit/content/extractors/ImageCollector.test.js
@@ -106,6 +106,85 @@ describe('ImageCollector', () => {
       const result = ImageCollector.collectFeaturedImage();
       expect(result).toBeNull();
     });
+
+    test('DOM featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL', () => {
+      const originalBaseURI = document.baseURI;
+      Object.defineProperty(document, 'baseURI', {
+        value: 'invalid-base-uri',
+        configurable: true,
+      });
+
+      try {
+        const mockImg = document.createElement('img');
+        cachedQuery.mockImplementation((_selector, _context, options) => {
+          if (options?.single) {
+            return mockImg;
+          }
+          return null;
+        });
+        extractImageSrc.mockReturnValue('malformed_url_without_protocol?token=secret');
+
+        const result = ImageCollector._collectFeaturedFromDOM();
+
+        expect(result).toBeNull();
+        expect(Logger.warn).toHaveBeenCalledWith(
+          '無效的圖片 URL',
+          expect.objectContaining({
+            action: 'collectFeaturedImage',
+            source: 'dom',
+            selector: '.featured-image img',
+            url: '[invalid-url]',
+          })
+        );
+        expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(
+          'malformed_url_without_protocol?token=secret'
+        );
+      } finally {
+        Object.defineProperty(document, 'baseURI', {
+          value: originalBaseURI,
+          configurable: true,
+        });
+      }
+    });
+
+    test('meta featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL', () => {
+      const originalBaseURI = document.baseURI;
+      Object.defineProperty(document, 'baseURI', {
+        value: 'invalid-base-uri',
+        configurable: true,
+      });
+
+      try {
+        const mockMeta = document.createElement('meta');
+        mockMeta.content = 'malformed_url_without_protocol?token=secret';
+        trackSpy(document, 'querySelector').mockImplementation(selector => {
+          if (selector === 'meta[property="og:image"]') {
+            return mockMeta;
+          }
+          return null;
+        });
+
+        const result = ImageCollector._collectFeaturedFromMeta();
+
+        expect(result).toBeNull();
+        expect(Logger.warn).toHaveBeenCalledWith(
+          '無效的圖片 URL',
+          expect.objectContaining({
+            action: 'collectFeaturedImage',
+            source: 'meta[property="og:image"]',
+            url: '[invalid-url]',
+          })
+        );
+        expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(
+          'malformed_url_without_protocol?token=secret'
+        );
+      } finally {
+        Object.defineProperty(document, 'baseURI', {
+          value: originalBaseURI,
+          configurable: true,
+        });
+      }
+    });
   });
 
   describe('processImageForCollection', () => {

--- a/tests/unit/content/extractors/ImageCollector.test.js
+++ b/tests/unit/content/extractors/ImageCollector.test.js
@@ -21,6 +21,39 @@ describe('ImageCollector', () => {
   setupImageCollectorTestLifecycle();
 
   describe('collectFeaturedImage', () => {
+    const MALFORMED_FEATURED_IMAGE_URL = 'malformed_url_without_protocol?token=secret';
+    const INVALID_DOCUMENT_BASE_URI = 'invalid-base-uri';
+    const SANITIZED_INVALID_IMAGE_URL = '[invalid-url]';
+
+    const withInvalidDocumentBaseURI = runTest => {
+      const originalBaseURI = document.baseURI;
+      Object.defineProperty(document, 'baseURI', {
+        value: INVALID_DOCUMENT_BASE_URI,
+        configurable: true,
+      });
+
+      try {
+        return runTest();
+      } finally {
+        Object.defineProperty(document, 'baseURI', {
+          value: originalBaseURI,
+          configurable: true,
+        });
+      }
+    };
+
+    const expectMalformedFeaturedImageWarning = expectedContext => {
+      expect(Logger.warn).toHaveBeenCalledWith(
+        '無效的圖片 URL',
+        expect.objectContaining({
+          action: 'collectFeaturedImage',
+          ...expectedContext,
+          url: SANITIZED_INVALID_IMAGE_URL,
+        })
+      );
+      expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(MALFORMED_FEATURED_IMAGE_URL);
+    };
+
     test('should return valid featured image src (DOM fallback)', () => {
       const mockImg = document.createElement('img');
       mockImg.src = 'https://example.com/featured.jpg';
@@ -107,83 +140,51 @@ describe('ImageCollector', () => {
       expect(result).toBeNull();
     });
 
-    test('DOM featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL', () => {
-      const originalBaseURI = document.baseURI;
-      Object.defineProperty(document, 'baseURI', {
-        value: 'invalid-base-uri',
-        configurable: true,
-      });
+    test.each([
+      {
+        label: 'DOM featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL',
+        setupImageSource: () => {
+          const mockImg = document.createElement('img');
+          cachedQuery.mockImplementation((_selector, _context, options) => {
+            if (options?.single) {
+              return mockImg;
+            }
+            return null;
+          });
+          extractImageSrc.mockReturnValue(MALFORMED_FEATURED_IMAGE_URL);
+        },
+        collectFeaturedImage: () => ImageCollector._collectFeaturedFromDOM(),
+        expectedLogContext: {
+          source: 'dom',
+          selector: '.featured-image img',
+        },
+      },
+      {
+        label: 'meta featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL',
+        setupImageSource: () => {
+          const mockMeta = document.createElement('meta');
+          mockMeta.content = MALFORMED_FEATURED_IMAGE_URL;
+          trackSpy(document, 'querySelector').mockImplementation(selector => {
+            if (selector === 'meta[property="og:image"]') {
+              return mockMeta;
+            }
+            return null;
+          });
+        },
+        collectFeaturedImage: () => ImageCollector._collectFeaturedFromMeta(),
+        expectedLogContext: {
+          source: 'meta[property="og:image"]',
+        },
+      },
+    ])('$label', ({ setupImageSource, collectFeaturedImage, expectedLogContext }) => {
+      withInvalidDocumentBaseURI(() => {
+        setupImageSource();
 
-      try {
-        const mockImg = document.createElement('img');
-        cachedQuery.mockImplementation((_selector, _context, options) => {
-          if (options?.single) {
-            return mockImg;
-          }
-          return null;
-        });
-        extractImageSrc.mockReturnValue('malformed_url_without_protocol?token=secret');
-
-        const result = ImageCollector._collectFeaturedFromDOM();
-
-        expect(result).toBeNull();
-        expect(Logger.warn).toHaveBeenCalledWith(
-          '無效的圖片 URL',
-          expect.objectContaining({
-            action: 'collectFeaturedImage',
-            source: 'dom',
-            selector: '.featured-image img',
-            url: '[invalid-url]',
-          })
-        );
-        expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(
-          'malformed_url_without_protocol?token=secret'
-        );
-      } finally {
-        Object.defineProperty(document, 'baseURI', {
-          value: originalBaseURI,
-          configurable: true,
-        });
-      }
-    });
-
-    test('meta featured image 遇到 malformed URL 時應回傳 null 且記錄 sanitized URL', () => {
-      const originalBaseURI = document.baseURI;
-      Object.defineProperty(document, 'baseURI', {
-        value: 'invalid-base-uri',
-        configurable: true,
-      });
-
-      try {
-        const mockMeta = document.createElement('meta');
-        mockMeta.content = 'malformed_url_without_protocol?token=secret';
-        trackSpy(document, 'querySelector').mockImplementation(selector => {
-          if (selector === 'meta[property="og:image"]') {
-            return mockMeta;
-          }
-          return null;
-        });
-
-        const result = ImageCollector._collectFeaturedFromMeta();
+        const result = collectFeaturedImage();
 
         expect(result).toBeNull();
-        expect(Logger.warn).toHaveBeenCalledWith(
-          '無效的圖片 URL',
-          expect.objectContaining({
-            action: 'collectFeaturedImage',
-            source: 'meta[property="og:image"]',
-            url: '[invalid-url]',
-          })
-        );
-        expect(JSON.stringify(Logger.warn.mock.calls)).not.toContain(
-          'malformed_url_without_protocol?token=secret'
-        );
-      } finally {
-        Object.defineProperty(document, 'baseURI', {
-          value: originalBaseURI,
-          configurable: true,
-        });
-      }
+        expectMalformedFeaturedImageWarning(expectedLogContext);
+      });
     });
   });
 


### PR DESCRIPTION
### 摘要
強化日誌來源路徑解析的安全性，避免無效 URL 拋出異常或洩漏隱私。

### 變更內容
- 新增 `resolveLogSourcePath` 函數，安全解析傳送者的 URL。
- 在 `devLogSink` 和 `devLogSinkBatch` 中使用 `resolveLogSourcePath` 來獲取來源路徑，確保不保存原始的無效 URL。
- 減少 `isRestrictedInjectionUrl` 函數中對無效 URL 的日誌記錄，並隱藏原始 URL。
- 增加單元測試以驗證對於無效 URL 的處理，確保系統能夠正確記錄和回應。

### 測試方式
已增加單元測試以驗證對於無效 URL 的處理。

### 潛在風險
無顯著風險。

