### PR TITLE
refactor: simplify InjectionService logging and error handling

### DIFF
--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -201,6 +201,33 @@ function isRecoverableInjectionError(message) {
   return patterns.some(pattern => message.includes(pattern));
 }
 
+const LOGGER_METHODS = ['debug', 'warn', 'error', 'success', 'start'];
+
+/**
+ * 將傳入的 logger 標準化，確保其包含所有必要的日誌方法，缺少的則靜默處理 (no-op)
+ *
+ * @param {object} logger - 原始 logger 對象
+ * @returns {object} 標準化後的 logger 對象
+ */
+function normalizeLogger(logger) {
+  const base = logger || console;
+  const normalized = {};
+  for (const method of LOGGER_METHODS) {
+    normalized[method] = typeof base[method] === 'function' ? base[method].bind(base) : () => {};
+  }
+  return normalized;
+}
+
+/**
+ * 格式化錯誤，獲取錯誤訊息文字
+ *
+ * @param {any} error - 錯誤對象
+ * @returns {string} 錯誤詳細訊息
+ */
+function getErrorDetail(error) {
+  return error?.message || String(error);
+}
+
 /**
  * InjectionService 類
  */
@@ -210,7 +237,7 @@ class InjectionService {
    * @param {object} options.logger - 日誌對象
    */
   constructor(options = {}) {
-    this.logger = options.logger || console;
+    this.logger = normalizeLogger(options.logger);
   }
 
   /**
@@ -254,15 +281,12 @@ class InjectionService {
       }
     } catch (error) {
       if (options.logErrors !== false) {
-        const errorDetail = error?.message || String(error);
-        this.logger.error?.(
-          `[Injection] ${options.errorMessage || 'Script injection failed'}: ${errorDetail}`,
-          {
-            action: 'injectAndExecute',
-            files,
-            error,
-          }
-        );
+        const errorDetail = getErrorDetail(error);
+        this.logger.error(`[Injection] ${options.errorMessage}: ${errorDetail}`, {
+          action: 'injectAndExecute',
+          files,
+          error,
+        });
       }
       throw error;
     }
@@ -282,7 +306,7 @@ class InjectionService {
   async _injectFiles(tabId, files, options) {
     return new Promise((resolve, reject) => {
       chrome.scripting.executeScript({ target: { tabId }, files }, () =>
-        this._handleScriptResult(resolve, reject, options, false)
+        this._handleScriptResult({ resolve, reject }, options, false)
       );
     });
   }
@@ -294,12 +318,13 @@ class InjectionService {
         injection.args = options.args;
       }
       chrome.scripting.executeScript(injection, results =>
-        this._handleScriptResult(resolve, reject, options, true, results)
+        this._handleScriptResult({ resolve, reject }, options, true, results)
       );
     });
   }
 
-  _handleScriptResult(resolve, reject, options, isFunction, results = null) {
+  _handleScriptResult(promiseHandlers, options, isFunction, results = null) {
+    const { resolve, reject } = promiseHandlers;
     if (chrome.runtime.lastError) {
       return this._handleInjectionError(resolve, reject, options, isFunction);
     }
@@ -340,8 +365,9 @@ class InjectionService {
    * @private
    */
   _handleInjectionSuccess(resolve, options, isFunction, results) {
-    if (isFunction && options.successMessage && options.logErrors) {
-      this.logger.success?.(`[Injection] ${options.successMessage}`);
+    const shouldLogSuccess = isFunction && options.successMessage && options.logErrors;
+    if (shouldLogSuccess) {
+      this.logger.success(`[Injection] ${options.successMessage}`);
     }
     const result = (options.returnResult && results?.[0]?.result) ?? null;
     resolve(result);
@@ -363,7 +389,7 @@ class InjectionService {
     }
 
     const msgPrefix = isFunction ? 'Function execution' : 'File injection';
-    this.logger.debug?.(`[Injection] ${msgPrefix} skipped (recoverable)`, {
+    this.logger.debug(`[Injection] ${msgPrefix} skipped (recoverable)`, {
       action: 'logInjectionStatus',
       operation: isFunction ? 'executeFunction' : 'injectFiles',
       error: errMsg,
@@ -371,13 +397,13 @@ class InjectionService {
   }
 
   /**
-   * 確保 Content Bundle 已注入到指定標籤頁
-   * 使用 PING 機制檢測 Bundle 是否存在，若無則注入
+   * 探測目標標籤頁的 Content Bundle 狀態
    *
    * @param {number} tabId - 目標標籤頁 ID
-   * @returns {Promise<boolean>} 若已注入或成功注入返回 true
+   * @returns {Promise<'ready' | 'unreachable' | 'missing'>} 狀態值
+   * @private
    */
-  async ensureBundleInjected(tabId) {
+  async _probeBundleStatus(tabId) {
     try {
       // 發送 PING 檢查 Bundle 是否存在（帶超時保護）
       const response = await Promise.race([
@@ -403,36 +429,45 @@ class InjectionService {
       ]);
 
       if (response?.status === 'bundle_ready') {
-        this.logger.success?.(`[Injection] Bundle already exists in tab ${tabId}`, {
+        this.logger.success(`[Injection] Bundle already exists in tab ${tabId}`, {
           action: 'ensureBundleInjected',
           tabId,
         });
-        return true; // Bundle 已存在
+        return 'ready';
       }
+      return 'missing';
     } catch (error) {
       if (isRecoverableInjectionError(error.message)) {
         // 特別處理 PING 超時：視為頁面反應慢，但不代表不能注入，所以不 return false 而是記錄警告後繼續
         if (error.message.includes(INJECTION_CONFIG.PING_TIMEOUT_ERROR)) {
-          this.logger.warn?.(`[Injection] PING timed out, proceeding with injection anyway`, {
+          this.logger.warn(`[Injection] PING timed out, proceeding with injection anyway`, {
             action: 'ensureBundleInjected',
             tabId,
           });
-        } else {
-          this.logger.warn?.(`[Injection] PING failed with recoverable error, returning false`, {
-            action: 'ensureBundleInjected',
-            tabId,
-            error,
-          });
-          return false;
+          return 'missing';
         }
-      } else {
-        throw error;
-      }
-    }
 
+        this.logger.warn(`[Injection] PING failed with recoverable error, returning false`, {
+          action: 'ensureBundleInjected',
+          tabId,
+          error,
+        });
+        return 'unreachable';
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * 注入 Content Bundle 到目標標籤頁
+   *
+   * @param {number} tabId - 目標標籤頁 ID
+   * @returns {Promise<boolean>} 是否成功注入
+   * @private
+   */
+  async _injectContentBundle(tabId) {
     try {
-      // Bundle 不存在，注入主程式
-      this.logger.start?.(`[Injection] Injecting Content Bundle into tab ${tabId}`, {
+      this.logger.start(`[Injection] Injecting Content Bundle into tab ${tabId}`, {
         action: 'ensureBundleInjected',
         tabId,
       });
@@ -453,27 +488,48 @@ class InjectionService {
         );
       });
 
-      this.logger.success?.(`[Injection] Content Bundle injected into tab ${tabId}`, {
+      this.logger.success(`[Injection] Content Bundle injected into tab ${tabId}`, {
         action: 'ensureBundleInjected',
         tabId,
       });
       return true;
     } catch (error) {
       // 處理錯誤（如無法連接、權限受限）
-      const errorMessage = error?.message || String(error);
+      const errorMessage = getErrorDetail(error);
       if (isRecoverableInjectionError(errorMessage)) {
-        this.logger.warn?.(`[Injection] Bundle injection skipped (recoverable)`, {
+        this.logger.warn(`[Injection] Bundle injection skipped (recoverable)`, {
           action: 'ensureBundleInjected',
           error,
         });
         return false;
       }
-      this.logger.error?.(`[Injection] Bundle injection failed`, {
+      this.logger.error(`[Injection] Bundle injection failed`, {
         action: 'ensureBundleInjected',
         error,
       });
       throw error;
     }
+  }
+
+  /**
+   * 確保 Content Bundle 已注入到指定標籤頁
+   * 使用 PING 機制檢測 Bundle 是否存在，若無則注入
+   *
+   * @param {number} tabId - 目標標籤頁 ID
+   * @returns {Promise<boolean>} 若已注入或成功注入返回 true
+   */
+  async ensureBundleInjected(tabId) {
+    const status = await this._probeBundleStatus(tabId);
+
+    if (status === 'ready') {
+      return true;
+    }
+
+    if (status === 'unreachable') {
+      return false;
+    }
+
+    return this._injectContentBundle(tabId);
   }
 
   /**
@@ -564,8 +620,9 @@ class InjectionService {
    */
   async injectWithResponse(tabId, func, files = [], args = []) {
     try {
+      const hasFilesToInject = files?.length > 0;
       // 如果有文件需要注入，先注入文件（由外層 catch 統一記錄，避免重複日誌）
-      if (files && files.length > 0) {
+      if (hasFilesToInject) {
         await this.injectAndExecute(tabId, files, null, { logErrors: false });
       }
 
@@ -576,20 +633,17 @@ class InjectionService {
           logErrors: false,
           args,
         });
-      } else if (files && files.length > 0) {
+      } else if (hasFilesToInject) {
         // 如果只注入文件而不執行函數，等待注入完成後返回成功標記
         return [{ result: { success: true } }];
       }
 
       return null;
     } catch (error) {
-      this.logger.error?.(
-        `[Injection] injectWithResponse failed: ${error?.message || String(error)}`,
-        {
-          action: 'injectWithResponse',
-          error,
-        }
-      );
+      this.logger.error(`[Injection] injectWithResponse failed: ${getErrorDetail(error)}`, {
+        action: 'injectWithResponse',
+        error,
+      });
       // 返回 null，由調用方判斷並回覆錯誤，避免未捕獲拒絕
       return null;
     }
@@ -610,7 +664,7 @@ class InjectionService {
         logErrors: true,
       });
     } catch (error) {
-      this.logger.error?.('[Injection] inject failed', {
+      this.logger.error('[Injection] inject failed', {
         action: 'inject',
         error,
       });

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -26,6 +26,15 @@ const INJECTION_CONFIG = {
   CONTENT_BUNDLE_PATH: 'dist/content.bundle.js',
 };
 
+const ERROR_DETAIL_MAX_LENGTH = 160;
+const ERROR_URL_PATTERN = /(?:https?|chrome-extension|file|ftp):\/\/[^\s"',)]+/gi;
+const ERROR_AUTH_HEADER_PATTERN = /(?:Bearer|Basic)\s+[\w+./~-]+=*/gi;
+const ERROR_JWT_PATTERN = /\beyJ[\w.-]+\b/g;
+const ERROR_API_KEY_PATTERN = /\b(?:sk|ghp|gho|xoxb|xoxp|key)-[\dA-Za-z]{20,}\b/g;
+const ERROR_NOTION_TOKEN_PATTERN = /secret_[\dA-Za-z]+/g;
+const ERROR_SENSITIVE_ASSIGNMENT_PATTERN =
+  /\b([\w.-]*(?:token|secret|password|credential|authorization|session|api[_-]?key)[\w.-]*)=(?:[^\s&"',)]+)/gi;
+
 async function activateFloatingRailInPage() {
   const timeout = 2000;
   const interval = 100;
@@ -124,6 +133,7 @@ function isRestrictedInjectionUrl(url) {
     const sanitizedErrorMsg = String(error.message).replaceAll(url, '[invalid-url]');
     Logger.warn('[Injection:Utils] Failed to parse URL when checking restrictions', {
       action: 'isRestrictedInjectionUrl',
+      result: 'failure',
       url: sanitizeUrlForLogging(url),
       error: sanitizedErrorMsg,
     });
@@ -155,6 +165,7 @@ function getRuntimeErrorMessage(runtimeError) {
   } catch (error) {
     Logger.warn('[Injection:Utils] Unable to stringify runtime error', {
       action: 'getRuntimeErrorMessage',
+      result: 'failure',
       error: error.message,
     });
     return `[Runtime Error: ${Object.prototype.toString.call(runtimeError)}]`;
@@ -219,13 +230,58 @@ function normalizeLogger(logger) {
 }
 
 /**
- * 格式化錯誤，獲取錯誤訊息文字
+ * 格式化錯誤，獲取適合日誌使用的安全短訊息
  *
  * @param {any} error - 錯誤對象
  * @returns {string} 錯誤詳細訊息
  */
 function getErrorDetail(error) {
-  return error?.message || String(error);
+  const rawMessage = getRawErrorMessage(error);
+  const sanitizedMessage = sanitizeErrorMessage(rawMessage);
+  const identifier = getErrorIdentifier(error);
+  return `${identifier}: ${sanitizedMessage || 'Unknown error'}`;
+}
+
+function getRawErrorMessage(error) {
+  if (!error) {
+    return '';
+  }
+
+  if (typeof error?.message === 'string') {
+    return error.message;
+  }
+
+  try {
+    return String(error);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+function getErrorIdentifier(error) {
+  const identifier = error?.code || error?.name;
+  if (typeof identifier === 'string' && identifier.trim()) {
+    return identifier.trim();
+  }
+  return 'Error';
+}
+
+function sanitizeErrorMessage(message) {
+  const firstLine = String(message || '')
+    .split(/\r?\n/u)[0]
+    .trim();
+  const sanitized = firstLine
+    .replaceAll(ERROR_URL_PATTERN, '[URL]')
+    .replaceAll(ERROR_AUTH_HEADER_PATTERN, '[REDACTED_AUTH_HEADER]')
+    .replaceAll(ERROR_JWT_PATTERN, '[REDACTED_TOKEN]')
+    .replaceAll(ERROR_API_KEY_PATTERN, '[REDACTED_API_KEY]')
+    .replaceAll(ERROR_NOTION_TOKEN_PATTERN, '[REDACTED_TOKEN]')
+    .replaceAll(ERROR_SENSITIVE_ASSIGNMENT_PATTERN, '$1=[REDACTED]');
+
+  if (sanitized.length <= ERROR_DETAIL_MAX_LENGTH) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, ERROR_DETAIL_MAX_LENGTH - 3)}...`;
 }
 
 /**
@@ -284,8 +340,9 @@ class InjectionService {
         const errorDetail = getErrorDetail(error);
         this.logger.error(`[Injection] ${options.errorMessage}: ${errorDetail}`, {
           action: 'injectAndExecute',
+          result: 'failure',
           files,
-          error,
+          error: errorDetail,
         });
       }
       throw error;
@@ -367,7 +424,10 @@ class InjectionService {
   _handleInjectionSuccess(resolve, options, isFunction, results) {
     const shouldLogSuccess = isFunction && options.successMessage && options.logErrors;
     if (shouldLogSuccess) {
-      this.logger.success(`[Injection] ${options.successMessage}`);
+      this.logger.success(`[Injection] ${options.successMessage}`, {
+        action: 'injectAndExecute',
+        result: 'success',
+      });
     }
     const result = (options.returnResult && results?.[0]?.result) ?? null;
     resolve(result);
@@ -390,9 +450,11 @@ class InjectionService {
 
     const msgPrefix = isFunction ? 'Function execution' : 'File injection';
     this.logger.debug(`[Injection] ${msgPrefix} skipped (recoverable)`, {
-      action: 'logInjectionStatus',
+      action: 'injectAndExecute',
       operation: isFunction ? 'executeFunction' : 'injectFiles',
-      error: errMsg,
+      result: 'skipped',
+      reason: 'recoverable_error',
+      error: getErrorDetail(new Error(errMsg)),
     });
   }
 
@@ -408,13 +470,13 @@ class InjectionService {
       // 發送 PING 檢查 Bundle 是否存在（帶超時保護）
       const response = await Promise.race([
         new Promise(resolve => {
-          // 使用 resolve(null) 而非 reject：
+          // 使用 sentinel resolve 而非 reject：
           // 若 timeout 先贏得 race，這個 Promise 可能在之後才 settle。
           // 用 reject 會在「已無人監聽」時產生 Unhandled Rejection；
-          // 改為 resolve(null) 讓它靜默關閉，PING 錯誤由外層 try/catch 統一處理。
+          // sentinel 讓外層保留 lastError 分類，同時避免 race 後續 reject。
           chrome.tabs.sendMessage(tabId, { action: RUNTIME_ACTIONS.PING }, result => {
             if (chrome.runtime.lastError) {
-              resolve(null); // 靜默：錯誤已由 timeout race 或後續注入流程處理
+              resolve({ lastError: getRuntimeErrorMessage(chrome.runtime.lastError) });
             } else {
               resolve(result);
             }
@@ -428,9 +490,14 @@ class InjectionService {
         ),
       ]);
 
+      if (response?.lastError) {
+        throw new Error(response.lastError);
+      }
+
       if (response?.status === 'bundle_ready') {
         this.logger.success(`[Injection] Bundle already exists in tab ${tabId}`, {
           action: 'ensureBundleInjected',
+          result: 'success',
           tabId,
         });
         return 'ready';
@@ -442,6 +509,8 @@ class InjectionService {
         if (error.message.includes(INJECTION_CONFIG.PING_TIMEOUT_ERROR)) {
           this.logger.warn(`[Injection] PING timed out, proceeding with injection anyway`, {
             action: 'ensureBundleInjected',
+            result: 'failure',
+            reason: 'ping_timeout',
             tabId,
           });
           return 'missing';
@@ -449,8 +518,10 @@ class InjectionService {
 
         this.logger.warn(`[Injection] PING failed with recoverable error, returning false`, {
           action: 'ensureBundleInjected',
+          result: 'failure',
+          reason: 'ping_unreachable',
           tabId,
-          error,
+          error: getErrorDetail(error),
         });
         return 'unreachable';
       }
@@ -469,6 +540,7 @@ class InjectionService {
     try {
       this.logger.start(`[Injection] Injecting Content Bundle into tab ${tabId}`, {
         action: 'ensureBundleInjected',
+        result: 'started',
         tabId,
       });
 
@@ -490,6 +562,7 @@ class InjectionService {
 
       this.logger.success(`[Injection] Content Bundle injected into tab ${tabId}`, {
         action: 'ensureBundleInjected',
+        result: 'success',
         tabId,
       });
       return true;
@@ -499,13 +572,15 @@ class InjectionService {
       if (isRecoverableInjectionError(errorMessage)) {
         this.logger.warn(`[Injection] Bundle injection skipped (recoverable)`, {
           action: 'ensureBundleInjected',
-          error,
+          result: 'skipped',
+          error: errorMessage,
         });
         return false;
       }
       this.logger.error(`[Injection] Bundle injection failed`, {
         action: 'ensureBundleInjected',
-        error,
+        result: 'failure',
+        error: errorMessage,
       });
       throw error;
     }
@@ -640,9 +715,11 @@ class InjectionService {
 
       return null;
     } catch (error) {
-      this.logger.error(`[Injection] injectWithResponse failed: ${getErrorDetail(error)}`, {
+      const errorDetail = getErrorDetail(error);
+      this.logger.error(`[Injection] injectWithResponse failed: ${errorDetail}`, {
         action: 'injectWithResponse',
-        error,
+        result: 'failure',
+        error: errorDetail,
       });
       // 返回 null，由調用方判斷並回覆錯誤，避免未捕獲拒絕
       return null;
@@ -666,7 +743,8 @@ class InjectionService {
     } catch (error) {
       this.logger.error('[Injection] inject failed', {
         action: 'inject',
-        error,
+        result: 'failure',
+        error: getErrorDetail(error),
       });
       throw error;
     }

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -284,6 +284,26 @@ function sanitizeErrorMessage(message) {
   return `${sanitized.slice(0, ERROR_DETAIL_MAX_LENGTH - 3)}...`;
 }
 
+function readBundlePingResult(result) {
+  if (chrome.runtime.lastError) {
+    return { lastError: getRuntimeErrorMessage(chrome.runtime.lastError) };
+  }
+  return result;
+}
+
+function createBundlePingTimeout() {
+  return new Promise((resolve, reject) =>
+    setTimeout(
+      () => reject(new Error(INJECTION_CONFIG.PING_TIMEOUT_ERROR)),
+      INJECTION_CONFIG.PING_TIMEOUT_MS
+    )
+  );
+}
+
+function isBundlePingTimeoutError(error) {
+  return error.message.includes(INJECTION_CONFIG.PING_TIMEOUT_ERROR);
+}
+
 /**
  * InjectionService 類
  */
@@ -467,66 +487,78 @@ class InjectionService {
    */
   async _probeBundleStatus(tabId) {
     try {
-      // 發送 PING 檢查 Bundle 是否存在（帶超時保護）
-      const response = await Promise.race([
-        new Promise(resolve => {
-          // 使用 sentinel resolve 而非 reject：
-          // 若 timeout 先贏得 race，這個 Promise 可能在之後才 settle。
-          // 用 reject 會在「已無人監聽」時產生 Unhandled Rejection；
-          // sentinel 讓外層保留 lastError 分類，同時避免 race 後續 reject。
-          chrome.tabs.sendMessage(tabId, { action: RUNTIME_ACTIONS.PING }, result => {
-            if (chrome.runtime.lastError) {
-              resolve({ lastError: getRuntimeErrorMessage(chrome.runtime.lastError) });
-            } else {
-              resolve(result);
-            }
-          });
-        }),
-        new Promise((resolve, reject) =>
-          setTimeout(
-            () => reject(new Error(INJECTION_CONFIG.PING_TIMEOUT_ERROR)),
-            INJECTION_CONFIG.PING_TIMEOUT_MS
-          )
-        ),
-      ]);
-
-      if (response?.lastError) {
-        throw new Error(response.lastError);
-      }
-
-      if (response?.status === 'bundle_ready') {
-        this.logger.success(`[Injection] Bundle already exists in tab ${tabId}`, {
-          action: 'ensureBundleInjected',
-          result: 'success',
-          tabId,
-        });
-        return 'ready';
-      }
-      return 'missing';
+      const response = await this._sendBundlePing(tabId);
+      return this._resolveBundlePingStatus(response, tabId);
     } catch (error) {
-      if (isRecoverableInjectionError(error.message)) {
-        // 特別處理 PING 超時：視為頁面反應慢，但不代表不能注入，所以不 return false 而是記錄警告後繼續
-        if (error.message.includes(INJECTION_CONFIG.PING_TIMEOUT_ERROR)) {
-          this.logger.warn(`[Injection] PING timed out, proceeding with injection anyway`, {
-            action: 'ensureBundleInjected',
-            result: 'failure',
-            reason: 'ping_timeout',
-            tabId,
-          });
-          return 'missing';
-        }
+      return this._handleBundlePingError(error, tabId);
+    }
+  }
 
-        this.logger.warn(`[Injection] PING failed with recoverable error, returning false`, {
-          action: 'ensureBundleInjected',
-          result: 'failure',
-          reason: 'ping_unreachable',
-          tabId,
-          error: getErrorDetail(error),
-        });
-        return 'unreachable';
-      }
+  _sendBundlePing(tabId) {
+    return Promise.race([this._sendBundlePingMessage(tabId), createBundlePingTimeout()]);
+  }
+
+  _sendBundlePingMessage(tabId) {
+    return new Promise(resolve => {
+      // 使用 sentinel resolve 而非 reject：
+      // 若 timeout 先贏得 race，這個 Promise 可能在之後才 settle。
+      // 用 reject 會在「已無人監聽」時產生 Unhandled Rejection；
+      // sentinel 讓外層保留 lastError 分類，同時避免 race 後續 reject。
+      chrome.tabs.sendMessage(tabId, { action: RUNTIME_ACTIONS.PING }, result => {
+        resolve(readBundlePingResult(result));
+      });
+    });
+  }
+
+  _resolveBundlePingStatus(response, tabId) {
+    if (response?.lastError) {
+      throw new Error(response.lastError);
+    }
+
+    if (response?.status !== 'bundle_ready') {
+      return 'missing';
+    }
+
+    this.logger.success(`[Injection] Bundle already exists in tab ${tabId}`, {
+      action: 'ensureBundleInjected',
+      result: 'success',
+      tabId,
+    });
+    return 'ready';
+  }
+
+  _handleBundlePingError(error, tabId) {
+    if (!isRecoverableInjectionError(error.message)) {
       throw error;
     }
+
+    if (isBundlePingTimeoutError(error)) {
+      return this._handleBundlePingTimeout(tabId);
+    }
+
+    return this._handleBundlePingUnreachable(error, tabId);
+  }
+
+  _handleBundlePingTimeout(tabId) {
+    // PING 超時：頁面反應慢不代表不能注入，所以記錄警告後繼續。
+    this.logger.warn(`[Injection] PING timed out, proceeding with injection anyway`, {
+      action: 'ensureBundleInjected',
+      result: 'failure',
+      reason: 'ping_timeout',
+      tabId,
+    });
+    return 'missing';
+  }
+
+  _handleBundlePingUnreachable(error, tabId) {
+    this.logger.warn(`[Injection] PING failed with recoverable error, returning false`, {
+      action: 'ensureBundleInjected',
+      result: 'failure',
+      reason: 'ping_unreachable',
+      tabId,
+      error: getErrorDetail(error),
+    });
+    return 'unreachable';
   }
 
   /**

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -210,7 +210,7 @@ const LOGGER_METHODS = ['debug', 'warn', 'error', 'success', 'start'];
  * @returns {object} 標準化後的 logger 對象
  */
 function normalizeLogger(logger) {
-  const base = logger || console;
+  const base = logger || Logger;
   const normalized = {};
   for (const method of LOGGER_METHODS) {
     normalized[method] = typeof base[method] === 'function' ? base[method].bind(base) : () => {};

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -324,6 +324,35 @@ describe('InjectionService', () => {
       );
     });
 
+    it('未傳入 logger 時應使用專案 Logger fallback', async () => {
+      const serviceWithDefaultLogger = new InjectionService();
+      chrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        chrome.runtime.lastError = undefined;
+        callback({ status: 'preloader_only' });
+      });
+      chrome.scripting.executeScript.mockImplementation((opts, callback) => {
+        chrome.runtime.lastError = undefined;
+        callback();
+      });
+
+      await serviceWithDefaultLogger.ensureBundleInjected(1);
+
+      expect(Logger.start).toHaveBeenCalledWith(
+        expect.stringContaining('Injecting Content Bundle'),
+        expect.objectContaining({
+          action: 'ensureBundleInjected',
+          tabId: 1,
+        })
+      );
+      expect(Logger.success).toHaveBeenCalledWith(
+        expect.stringContaining('Content Bundle injected'),
+        expect.objectContaining({
+          action: 'ensureBundleInjected',
+          tabId: 1,
+        })
+      );
+    });
+
     it('應在權限受限頁面時返回 false', async () => {
       // PING 請求根本就無法送達（sendMessage 靜默失敗）
       // → 流程繼續嘗試注入，注入也遇到可恢復錯誤 → 返回 false

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -70,6 +70,7 @@ const mockLogger = {
   warn: jest.fn(),
   error: jest.fn(),
   success: jest.fn(),
+  start: jest.fn(),
 };
 
 describe('InjectionService', () => {
@@ -165,10 +166,12 @@ describe('InjectionService', () => {
       await expect(service.injectAndExecute(1, ['file.js'])).rejects.toThrow('Injection failed');
     });
 
-    it('應在注入失敗時於日誌 context 中包含 stack trace', async () => {
+    it('應在注入失敗時只記錄脫敏後的短錯誤訊息', async () => {
       const injectionError = new Error('Injection failed');
       injectionError.stack =
-        'Error: Injection failed\n    at inject (InjectionService.test.js:1:1)';
+        'Error: Injection failed for https://private.example.com/path?token=secret_abc&keep=value\n    at https://private.example.com/script.js?access_token=abc:1:1';
+      injectionError.message =
+        'Injection failed for https://private.example.com/path?token=secret_abc&keep=value with Bearer secret_abc';
       chrome.runtime.lastError = injectionError;
       chrome.scripting.executeScript.mockImplementation((opts, cb) => cb());
 
@@ -179,14 +182,19 @@ describe('InjectionService', () => {
       );
 
       expect(injectErrorCall).toBeDefined();
-      expect(injectErrorCall[0]).toContain('Script injection failed: Injection failed');
+      expect(injectErrorCall[0]).toContain('Script injection failed: Error: Injection failed');
       expect(injectErrorCall[1]).toEqual(
         expect.objectContaining({
           action: 'injectAndExecute',
+          result: 'failure',
           files: ['file.js'],
-          error: expect.any(Error),
+          error: expect.stringContaining('[URL]'),
         })
       );
+      expect(JSON.stringify(injectErrorCall)).not.toContain('private.example.com');
+      expect(JSON.stringify(injectErrorCall)).not.toContain('secret_abc');
+      expect(JSON.stringify(injectErrorCall)).not.toContain('access_token=abc');
+      expect(JSON.stringify(injectErrorCall)).not.toContain('\n    at ');
     });
 
     it('should resolve recoverable errors without throwing', async () => {
@@ -195,7 +203,13 @@ describe('InjectionService', () => {
 
       await expect(service.injectAndExecute(1, ['file.js'])).resolves.toBeUndefined();
       // Default logErrors is true, recoverable error should log debug instead of warn
-      expect(mockLogger.debug).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('File injection skipped'),
+        expect.objectContaining({
+          action: 'injectAndExecute',
+          result: 'skipped',
+        })
+      );
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
@@ -295,7 +309,10 @@ describe('InjectionService', () => {
       expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
       expect(mockLogger.success).toHaveBeenCalledWith(
         expect.stringContaining('Bundle already exists'),
-        expect.anything()
+        expect.objectContaining({
+          action: 'ensureBundleInjected',
+          result: 'success',
+        })
       );
     });
 
@@ -341,6 +358,7 @@ describe('InjectionService', () => {
         expect.stringContaining('Injecting Content Bundle'),
         expect.objectContaining({
           action: 'ensureBundleInjected',
+          result: 'started',
           tabId: 1,
         })
       );
@@ -348,23 +366,17 @@ describe('InjectionService', () => {
         expect.stringContaining('Content Bundle injected'),
         expect.objectContaining({
           action: 'ensureBundleInjected',
+          result: 'success',
           tabId: 1,
         })
       );
     });
 
     it('應在權限受限頁面時返回 false', async () => {
-      // PING 請求根本就無法送達（sendMessage 靜默失敗）
-      // → 流程繼續嘗試注入，注入也遇到可恢復錯誤 → 返回 false
+      // PING 請求根本就無法送達，應直接分類為 unreachable，不再繼續注入。
       chrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
-        // PING 失敗：用 resolve(null)（新行為）
         chrome.runtime.lastError = { message: 'Cannot access contents of page' };
         callback();
-      });
-      // 注入也遇到可恢復錯誤（模擬頁面權限受限）
-      chrome.scripting.executeScript.mockImplementation((opts, cb) => {
-        chrome.runtime.lastError = { message: 'Cannot access contents of page' };
-        cb();
       });
 
       // Act
@@ -372,13 +384,13 @@ describe('InjectionService', () => {
 
       // Assert
       expect(result).toBe(false);
+      expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Bundle injection skipped'),
+        expect.stringContaining('PING failed with recoverable error'),
         expect.objectContaining({
           action: 'ensureBundleInjected',
-          error: expect.objectContaining({
-            message: 'Cannot access contents of page',
-          }),
+          result: 'failure',
+          error: expect.stringContaining('Cannot access contents of page'),
         })
       );
     });
@@ -411,22 +423,16 @@ describe('InjectionService', () => {
         callback();
       });
 
-      // Promise.race 遇到 chrome.runtime.lastError 會 resolve(null)，因此需讓注入階段回報相同錯誤以覆蓋 recoverable path。
-      chrome.scripting.executeScript.mockImplementation((opts, cb) => {
-        chrome.runtime.lastError = { message: 'Receiving end does not exist' };
-        cb();
-      });
-
       const result = await service.ensureBundleInjected(1);
 
       expect(result).toBe(false);
+      expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Bundle injection skipped'),
+        expect.stringContaining('PING failed with recoverable error'),
         expect.objectContaining({
           action: 'ensureBundleInjected',
-          error: expect.objectContaining({
-            message: expect.stringContaining('Receiving end does not exist'),
-          }),
+          result: 'failure',
+          error: expect.stringContaining('Receiving end does not exist'),
         })
       );
     });
@@ -440,26 +446,14 @@ describe('InjectionService', () => {
       await expect(service.ensureBundleInjected(1)).rejects.toThrow('Fatal Native Error');
     });
 
-    it('應在 injectAndExecute 內部拋出不可恢復異常時向外拋出', async () => {
+    it('應在 PING 回傳不可恢復 lastError 時向外拋出', async () => {
       chrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
-        chrome.runtime.lastError = { message: 'Cannot access contents of page' };
+        chrome.runtime.lastError = { message: 'Fatal Ping Error' };
         callback();
       });
-      chrome.scripting.executeScript.mockImplementation((opts, cb) => {
-        chrome.runtime.lastError = { message: 'Fatal Extension Error' };
-        cb();
-      });
 
-      await expect(service.ensureBundleInjected(1)).rejects.toThrow('Fatal Extension Error');
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Bundle injection failed'),
-        expect.objectContaining({
-          action: 'ensureBundleInjected',
-          error: expect.objectContaining({
-            message: 'Fatal Extension Error',
-          }),
-        })
-      );
+      await expect(service.ensureBundleInjected(1)).rejects.toThrow('Fatal Ping Error');
+      expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
     });
   });
 
@@ -517,9 +511,11 @@ describe('InjectionService', () => {
       expect(result).toEqual([{ result: { success: true } }]);
     });
 
-    it('應該在拋出異常時記錄錯誤並返回 null', async () => {
+    it('應該在拋出異常時記錄脫敏後的錯誤並返回 null', async () => {
       chrome.scripting.executeScript.mockImplementationOnce((opts, cb) => {
-        chrome.runtime.lastError = { message: 'Fatal' };
+        chrome.runtime.lastError = {
+          message: 'Fatal https://example.com/private?token=secret_abc',
+        };
         cb();
       });
 
@@ -528,17 +524,22 @@ describe('InjectionService', () => {
       expect(result).toBeNull();
       // 錯誤訊息應嵌入到日誌字串中，不再是 [object Object]
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('injectWithResponse failed: Fatal'),
+        expect.stringContaining('injectWithResponse failed: Error: Fatal [URL]'),
         expect.objectContaining({
           action: 'injectWithResponse',
-          error: expect.any(Error),
+          result: 'failure',
+          error: expect.stringContaining('[URL]'),
         })
       );
+      expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('secret_abc');
+      expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('example.com');
     });
 
-    it('應在 injectWithResponse 失敗時於日誌 context 中包含 stack trace', async () => {
+    it('應在 injectWithResponse 失敗時避免記錄 raw stack trace', async () => {
       const runtimeError = new Error('Fatal');
-      runtimeError.stack = 'Error: Fatal\n    at injectWithResponse (InjectionService.test.js:1:1)';
+      runtimeError.stack =
+        'Error: Fatal https://example.com/private?token=secret_abc\n    at https://example.com/script.js?access_token=abc:1:1';
+      runtimeError.message = 'Fatal https://example.com/private?token=secret_abc';
 
       chrome.scripting.executeScript.mockImplementationOnce((opts, cb) => {
         chrome.runtime.lastError = runtimeError;
@@ -553,13 +554,19 @@ describe('InjectionService', () => {
       );
 
       expect(injectWithResponseErrorCall).toBeDefined();
-      expect(injectWithResponseErrorCall[0]).toContain('injectWithResponse failed: Fatal');
+      expect(injectWithResponseErrorCall[0]).toContain(
+        'injectWithResponse failed: Error: Fatal [URL]'
+      );
       expect(injectWithResponseErrorCall[1]).toEqual(
         expect.objectContaining({
           action: 'injectWithResponse',
-          error: expect.any(Error),
+          result: 'failure',
+          error: expect.stringContaining('[URL]'),
         })
       );
+      expect(JSON.stringify(injectWithResponseErrorCall)).not.toContain('example.com');
+      expect(JSON.stringify(injectWithResponseErrorCall)).not.toContain('secret_abc');
+      expect(JSON.stringify(injectWithResponseErrorCall)).not.toContain('\n    at ');
     });
 
     it('應該只觸發一條 ERROR 日誌而非三條', async () => {
@@ -645,9 +652,8 @@ describe('InjectionService', () => {
         expect.stringContaining('[Injection] inject failed'),
         expect.objectContaining({
           action: 'inject',
-          error: expect.objectContaining({
-            message: 'Fatal crash',
-          }),
+          result: 'failure',
+          error: 'Error: Fatal crash',
         })
       );
     });


### PR DESCRIPTION
### 摘要
簡化 InjectionService 的日誌處理與錯誤管理，提升可讀性與維護性。

### 變更內容
- 標準化 logger，確保所有必要的日誌方法可用，並處理缺失情況。
- 新增 getErrorDetail 函數以統一錯誤訊息格式。
- 更新 InjectionService 的建構子以使用標準化的 logger。
- 改進錯誤處理邏輯，確保可恢復錯誤的日誌記錄一致性。
- 重構 Content Bundle 注入邏輯，提升可讀性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

