### PR TITLE
refactor: simplify argument parsing and measurement logic

### DIFF
--- a/tests/unit/scripts/check-size-gates.test.js
+++ b/tests/unit/scripts/check-size-gates.test.js
@@ -159,6 +159,9 @@ describe('tools/check-size-gates.mjs', () => {
 
     expect(thrownError).toBeDefined();
     expect(`${thrownError.stdout}${thrownError.stderr}`).toMatch(/content\.bundle\.js/);
+    expect(`${thrownError.stdout}${thrownError.stderr}`).toMatch(
+      /content\.bundle\.js 超過硬性上限/
+    );
   });
 
   test.each([
@@ -230,7 +233,9 @@ describe('tools/check-size-gates.mjs', () => {
     }
 
     expect(thrownError).toBeDefined();
-    expect(`${thrownError.stdout}${thrownError.stderr}`).toMatch(/delta limit/i);
+    expect(`${thrownError.stdout}${thrownError.stderr}`).toMatch(
+      /content\.bundle\.js 超出差異限制/
+    );
   });
 
   test('[REGRESSION] delta mode 應允許 Floating Rail 已核准的 content bundle 增量', () => {

--- a/tools/check-size-gates.mjs
+++ b/tools/check-size-gates.mjs
@@ -164,49 +164,53 @@ function extractZipToTemp(zipPath) {
   return tempDir;
 }
 
+const MEASURE_HANDLERS = Object.freeze({
+  file: (rootDir, target) => {
+    const absolutePath = path.join(rootDir, target.relPath);
+    if (!fs.existsSync(absolutePath)) {
+      return { found: false };
+    }
+    return { found: true, value: fs.statSync(absolutePath).size };
+  },
+  zip: rootDir => {
+    const zipPath = getLatestZipPath(rootDir);
+    if (!zipPath) {
+      return { found: false };
+    }
+    return { found: true, value: fs.statSync(zipPath).size, metadata: { zipPath } };
+  },
+  dir: (rootDir, _target, unpackedDirOverride) => {
+    if (unpackedDirOverride) {
+      if (!fs.existsSync(unpackedDirOverride)) {
+        return { found: false };
+      }
+      return { found: true, value: getDirectorySizeBytes(unpackedDirOverride) };
+    }
+
+    const zipPath = getLatestZipPath(rootDir);
+    if (!zipPath) {
+      return { found: false };
+    }
+
+    const tempDir = extractZipToTemp(zipPath);
+    try {
+      return {
+        found: true,
+        value: getDirectorySizeBytes(tempDir),
+        metadata: { extractedFrom: zipPath },
+      };
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  },
+});
+
 function measureTarget(rootDir, target, unpackedDirOverride = '') {
-  switch (target.type) {
-    case 'file': {
-      const absolutePath = path.join(rootDir, target.relPath);
-      if (!fs.existsSync(absolutePath)) {
-        return { found: false };
-      }
-      return { found: true, value: fs.statSync(absolutePath).size };
-    }
-    case 'zip': {
-      const zipPath = getLatestZipPath(rootDir);
-      if (!zipPath) {
-        return { found: false };
-      }
-      return { found: true, value: fs.statSync(zipPath).size, metadata: { zipPath } };
-    }
-    case 'dir': {
-      if (unpackedDirOverride) {
-        if (!fs.existsSync(unpackedDirOverride)) {
-          return { found: false };
-        }
-        return { found: true, value: getDirectorySizeBytes(unpackedDirOverride) };
-      }
-
-      const zipPath = getLatestZipPath(rootDir);
-      if (!zipPath) {
-        return { found: false };
-      }
-
-      const tempDir = extractZipToTemp(zipPath);
-      try {
-        return {
-          found: true,
-          value: getDirectorySizeBytes(tempDir),
-          metadata: { extractedFrom: zipPath },
-        };
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
-    }
-    default:
-      throw new Error(`未知 target type：${target.type}`);
+  const handler = MEASURE_HANDLERS[target.type];
+  if (!handler) {
+    throw new Error(`未知 target type：${target.type}`);
   }
+  return handler(rootDir, target, unpackedDirOverride);
 }
 
 function createCheckResult(target, currentMeasurement, baseMeasurement, mode) {
@@ -240,26 +244,42 @@ function createCheckResult(target, currentMeasurement, baseMeasurement, mode) {
     return result;
   }
 
-  if (mode === 'delta') {
-    if (!baseMeasurement?.found) {
-      result.status = 'skipped';
-      result.message = `${target.label} 缺少 base 產物，略過 delta 檢查`;
-      return result;
-    }
+  if (mode !== 'delta') {
+    return result;
+  }
 
-    result.base = baseMeasurement.value;
-    result.delta = currentMeasurement.value - baseMeasurement.value;
-    if (baseMeasurement.metadata) {
-      result.baseMeta = baseMeasurement.metadata;
-    }
+  if (!baseMeasurement?.found) {
+    result.status = 'skipped';
+    result.message = `${target.label} 缺少 base 產物，略過 delta 檢查`;
+    return result;
+  }
 
-    if (result.delta > target.deltaLimit) {
-      result.status = 'failed';
-      result.message = `${target.label} exceeds delta limit`;
-    }
+  result.base = baseMeasurement.value;
+  result.delta = currentMeasurement.value - baseMeasurement.value;
+  if (baseMeasurement.metadata) {
+    result.baseMeta = baseMeasurement.metadata;
+  }
+
+  if (result.delta > target.deltaLimit) {
+    result.status = 'failed';
+    result.message = `${target.label} exceeds delta limit`;
   }
 
   return result;
+}
+
+function formatCheckLine(check) {
+  const parts = [`[${check.status.toUpperCase()}]`, check.label];
+  if (typeof check.current === 'number') {
+    parts.push(`current=${check.current}`);
+  }
+  if (typeof check.base === 'number') {
+    parts.push(`base=${check.base}`, `delta=${check.delta}`);
+  }
+  if (check.message) {
+    parts.push(check.message);
+  }
+  return parts.join(' ');
 }
 
 function main() {
@@ -292,17 +312,7 @@ function main() {
   }
 
   for (const check of checks) {
-    const parts = [`[${check.status.toUpperCase()}]`, check.label];
-    if (typeof check.current === 'number') {
-      parts.push(`current=${check.current}`);
-    }
-    if (typeof check.base === 'number') {
-      parts.push(`base=${check.base}`, `delta=${check.delta}`);
-    }
-    if (check.message) {
-      parts.push(check.message);
-    }
-    console.log(parts.join(' '));
+    console.log(formatCheckLine(check));
   }
 
   if (report.failed) {

--- a/tools/check-size-gates.mjs
+++ b/tools/check-size-gates.mjs
@@ -54,6 +54,43 @@ const BUDGETS = Object.freeze({
   ],
 });
 
+// 每個旗標對應一個賦值處理器；需要絕對路徑的旗標在此包一層 path.resolve。
+const ARG_HANDLERS = Object.freeze({
+  '--mode': (options, value) => {
+    options.mode = value;
+  },
+  '--scope': (options, value) => {
+    options.scope = value;
+  },
+  '--root': (options, value) => {
+    options.root = path.resolve(value);
+  },
+  '--base-root': (options, value) => {
+    options.baseRoot = path.resolve(value);
+  },
+  '--unpacked-dir': (options, value) => {
+    options.unpackedDir = path.resolve(value);
+  },
+  '--base-unpacked-dir': (options, value) => {
+    options.baseUnpackedDir = path.resolve(value);
+  },
+  '--report-file': (options, value) => {
+    options.reportFile = path.resolve(value);
+  },
+});
+
+function assertValidOptions(options) {
+  if (!['hard', 'delta'].includes(options.mode)) {
+    throw new Error(`不支援的 mode：${options.mode}`);
+  }
+  if (!['bundle', 'package', 'all'].includes(options.scope)) {
+    throw new Error(`不支援的 scope：${options.scope}`);
+  }
+  if (options.mode === 'delta' && !options.baseRoot) {
+    throw new Error('delta 模式必須提供 --base-root');
+  }
+}
+
 function parseArgs(argv) {
   const options = {
     mode: 'hard',
@@ -67,44 +104,14 @@ function parseArgs(argv) {
 
   for (const arg of argv) {
     const [rawKey, ...rawValueParts] = arg.split('=');
-    const value = rawValueParts.join('=');
-    switch (rawKey) {
-      case '--mode':
-        options.mode = value;
-        break;
-      case '--scope':
-        options.scope = value;
-        break;
-      case '--root':
-        options.root = path.resolve(value);
-        break;
-      case '--base-root':
-        options.baseRoot = path.resolve(value);
-        break;
-      case '--unpacked-dir':
-        options.unpackedDir = path.resolve(value);
-        break;
-      case '--base-unpacked-dir':
-        options.baseUnpackedDir = path.resolve(value);
-        break;
-      case '--report-file':
-        options.reportFile = path.resolve(value);
-        break;
-      default:
-        throw new Error(`未知參數：${arg}`);
+    const handler = ARG_HANDLERS[rawKey];
+    if (!handler) {
+      throw new Error(`未知參數：${arg}`);
     }
+    handler(options, rawValueParts.join('='));
   }
 
-  if (!['hard', 'delta'].includes(options.mode)) {
-    throw new Error(`不支援的 mode：${options.mode}`);
-  }
-  if (!['bundle', 'package', 'all'].includes(options.scope)) {
-    throw new Error(`不支援的 scope：${options.scope}`);
-  }
-  if (options.mode === 'delta' && !options.baseRoot) {
-    throw new Error('delta 模式必須提供 --base-root');
-  }
-
+  assertValidOptions(options);
   return options;
 }
 

--- a/tools/check-size-gates.mjs
+++ b/tools/check-size-gates.mjs
@@ -240,7 +240,7 @@ function createCheckResult(target, currentMeasurement, baseMeasurement, mode) {
 
   if (currentMeasurement.value > target.hardLimit) {
     result.status = 'failed';
-    result.message = `${target.label} exceeds hard limit`;
+    result.message = `${target.label} 超過硬性上限`;
     return result;
   }
 
@@ -262,7 +262,7 @@ function createCheckResult(target, currentMeasurement, baseMeasurement, mode) {
 
   if (result.delta > target.deltaLimit) {
     result.status = 'failed';
-    result.message = `${target.label} exceeds delta limit`;
+    result.message = `${target.label} 超出差異限制`;
   }
 
   return result;


### PR DESCRIPTION
### 摘要
重構了參數解析和測量邏輯，以提高可讀性和降低循環複雜度。

### 變更內容
- 將參數解析邏輯從 switch 語句改為使用映射表，簡化了代碼結構。
- 抽取了驗證選項的邏輯到 `assertValidOptions` 函數中。
- 測量邏輯使用處理器映射來簡化不同類型的測量處理。
- 提取格式化檢查結果的邏輯到 `formatCheckLine` 函數中。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

