### PR TITLE
refactor: reduce complexity in StorageService and introduce StorageMigrationScanner

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -13,6 +13,7 @@ import { getActiveNotionToken } from './utils/notionAuth.js';
 
 // Import Services
 import { StorageService } from './background/services/StorageService.js';
+import { StorageMigrationScanner } from './background/services/StorageMigrationScanner.js';
 import { NotionService } from './background/services/NotionService.js';
 import {
   InjectionService,
@@ -63,6 +64,7 @@ const pageContentService = new PageContentService({
   logger: Logger,
 });
 const storageService = new StorageService({ logger: Logger });
+const migrationScanner = new StorageMigrationScanner({ logger: Logger });
 const notionService = new NotionService({ logger: Logger });
 const destinationProfileResolver = new ProfileResolver({
   repository: new LocalDestinationProfileRepository(),
@@ -151,6 +153,7 @@ const actionHandlers = {
     storageService,
     notionService,
     migrationService,
+    migrationScanner,
   }),
   ...createLogHandlers(),
   ...createNotionHandlers({ notionService }),

--- a/scripts/background/handlers/migrationHandlers.js
+++ b/scripts/background/handlers/migrationHandlers.js
@@ -37,7 +37,7 @@ function sanitizeBatchDeleteFailureReason(error) {
  * @returns {object} 遷移處理函數映射
  */
 export function createMigrationHandlers(services) {
-  const { migrationService, storageService } = services;
+  const { migrationService, storageService, migrationScanner } = services;
 
   return {
     /**
@@ -408,8 +408,8 @@ export function createMigrationHandlers(services) {
           return;
         }
 
-        // 使用 StorageService.getAllHighlights() 取代直接操作 chrome.storage.local
-        const allHighlights = await storageService.getAllHighlights();
+        // 使用 StorageMigrationScanner.getAllHighlights() 取代直接操作 chrome.storage.local
+        const allHighlights = await migrationScanner.getAllHighlights();
         const pendingItems = [];
         const failedItems = [];
 

--- a/scripts/background/services/StorageMigrationScanner.js
+++ b/scripts/background/services/StorageMigrationScanner.js
@@ -30,7 +30,7 @@ export class StorageMigrationScanner {
    * @private
    */
   _isNormalizedHighlightObject(value) {
-    return value && typeof value === 'object' && 'highlights' in value;
+    return this._isStorageObjectValue(value) && 'highlights' in value;
   }
 
   /**
@@ -72,6 +72,17 @@ export class StorageMigrationScanner {
   }
 
   /**
+   * 取得外部提供或 storage 內的完整掃描資料
+   *
+   * @param {object|null} allData - 外部提供的全量儲存空間數據
+   * @returns {Promise<object>} 可供掃描的完整 storage snapshot
+   * @private
+   */
+  async _resolveStorageSnapshot(allData) {
+    return allData || (await this._getAllStorageData());
+  }
+
+  /**
    * 從全量儲存空間數據中收集新格式 page_* 的 highlights 資料
    *
    * @param {object} allData - 全量數據
@@ -108,7 +119,7 @@ export class StorageMigrationScanner {
    * @private
    */
   _collectLegacyHighlights(allData, existingResult) {
-    if (!allData || typeof allData !== 'object') {
+    if (!this._isStorageObjectValue(allData)) {
       return existingResult;
     }
     const result = { ...existingResult };
@@ -150,7 +161,7 @@ export class StorageMigrationScanner {
     }
 
     try {
-      const data = allData || (await this._getAllStorageData());
+      const data = await this._resolveStorageSnapshot(allData);
       const pageResult = this._collectPageHighlights(data);
       return this._collectLegacyHighlights(data, pageResult);
     } catch (error) {
@@ -173,7 +184,7 @@ export class StorageMigrationScanner {
     }
 
     try {
-      const result = allData || (await this._getAllStorageData());
+      const result = await this._resolveStorageSnapshot(allData);
       return this._extractUrlsFromStorageData(result);
     } catch (error) {
       this.logger.error?.('[StorageMigrationScanner] getAllSavedPageUrls failed', { error });
@@ -189,7 +200,7 @@ export class StorageMigrationScanner {
    * @private
    */
   _extractUrlsFromStorageData(result) {
-    if (!result || typeof result !== 'object') {
+    if (!this._isStorageObjectValue(result)) {
       return [];
     }
     const urlSet = new Set();

--- a/scripts/background/services/StorageMigrationScanner.js
+++ b/scripts/background/services/StorageMigrationScanner.js
@@ -83,6 +83,23 @@ export class StorageMigrationScanner {
   }
 
   /**
+   * 逐筆列出指定 prefix 的 storage entries
+   *
+   * @param {object} allData - 全量 storage snapshot
+   * @param {string} prefix - 目標 storage key prefix
+   * @returns {Generator<[string, any]>} 符合 prefix 的 storage entries
+   * @yields {[string, any]} 符合 prefix 的 storage entry
+   * @private
+   */
+  *_storageEntriesWithPrefix(allData, prefix) {
+    for (const [key, value] of Object.entries(allData)) {
+      if (key.startsWith(prefix)) {
+        yield [key, value];
+      }
+    }
+  }
+
+  /**
    * 從全量儲存空間數據中收集新格式 page_* 的 highlights 資料
    *
    * @param {object} allData - 全量數據
@@ -94,10 +111,7 @@ export class StorageMigrationScanner {
       return {};
     }
     const result = {};
-    for (const [key, value] of Object.entries(allData)) {
-      if (!key.startsWith(PAGE_PREFIX)) {
-        continue;
-      }
+    for (const [key, value] of this._storageEntriesWithPrefix(allData, PAGE_PREFIX)) {
       if (!this._isStorageObjectValue(value)) {
         this.logger.warn?.('[StorageMigrationScanner] page_* entry has invalid shape, skipped', {
           key,
@@ -123,13 +137,11 @@ export class StorageMigrationScanner {
       return existingResult;
     }
     const result = { ...existingResult };
-    for (const [key, value] of Object.entries(allData)) {
-      if (key.startsWith(HIGHLIGHTS_PREFIX)) {
-        const url = key.slice(HIGHLIGHTS_PREFIX.length);
-        if (!result[url]) {
-          const normalized = this._normalizeLegacyHighlight(value);
-          result[url] = { ...normalized, url };
-        }
+    for (const [key, value] of this._storageEntriesWithPrefix(allData, HIGHLIGHTS_PREFIX)) {
+      const url = key.slice(HIGHLIGHTS_PREFIX.length);
+      if (!result[url]) {
+        const normalized = this._normalizeLegacyHighlight(value);
+        result[url] = { ...normalized, url };
       }
     }
     return result;

--- a/scripts/background/services/StorageMigrationScanner.js
+++ b/scripts/background/services/StorageMigrationScanner.js
@@ -61,6 +61,17 @@ export class StorageMigrationScanner {
   }
 
   /**
+   * 檢查 storage entry value 是否可當作物件讀取
+   *
+   * @param {any} value - 待檢查的 storage value
+   * @returns {boolean} 是否可作為 page state 物件處理
+   * @private
+   */
+  _isStorageObjectValue(value) {
+    return Boolean(value) && typeof value === 'object';
+  }
+
+  /**
    * 從全量儲存空間數據中收集新格式 page_* 的 highlights 資料
    *
    * @param {object} allData - 全量數據
@@ -68,7 +79,7 @@ export class StorageMigrationScanner {
    * @private
    */
   _collectPageHighlights(allData) {
-    if (!allData || typeof allData !== 'object') {
+    if (!this._isStorageObjectValue(allData)) {
       return {};
     }
     const result = {};
@@ -76,7 +87,7 @@ export class StorageMigrationScanner {
       if (!key.startsWith(PAGE_PREFIX)) {
         continue;
       }
-      if (!value || typeof value !== 'object') {
+      if (!this._isStorageObjectValue(value)) {
         this.logger.warn?.('[StorageMigrationScanner] page_* entry has invalid shape, skipped', {
           key,
         });
@@ -105,7 +116,8 @@ export class StorageMigrationScanner {
       if (key.startsWith(HIGHLIGHTS_PREFIX)) {
         const url = key.slice(HIGHLIGHTS_PREFIX.length);
         if (!result[url]) {
-          result[url] = this._normalizeLegacyHighlight(value);
+          const normalized = this._normalizeLegacyHighlight(value);
+          result[url] = { ...normalized, url };
         }
       }
     }

--- a/scripts/background/services/StorageMigrationScanner.js
+++ b/scripts/background/services/StorageMigrationScanner.js
@@ -68,6 +68,9 @@ export class StorageMigrationScanner {
    * @private
    */
   _collectPageHighlights(allData) {
+    if (!allData || typeof allData !== 'object') {
+      return {};
+    }
     const result = {};
     for (const [key, value] of Object.entries(allData)) {
       if (!key.startsWith(PAGE_PREFIX)) {
@@ -94,6 +97,9 @@ export class StorageMigrationScanner {
    * @private
    */
   _collectLegacyHighlights(allData, existingResult) {
+    if (!allData || typeof allData !== 'object') {
+      return existingResult;
+    }
     const result = { ...existingResult };
     for (const [key, value] of Object.entries(allData)) {
       if (key.startsWith(HIGHLIGHTS_PREFIX)) {
@@ -171,6 +177,9 @@ export class StorageMigrationScanner {
    * @private
    */
   _extractUrlsFromStorageData(result) {
+    if (!result || typeof result !== 'object') {
+      return [];
+    }
     const urlSet = new Set();
 
     for (const [key, value] of Object.entries(result)) {

--- a/scripts/background/services/StorageMigrationScanner.js
+++ b/scripts/background/services/StorageMigrationScanner.js
@@ -1,0 +1,205 @@
+/**
+ * StorageMigrationScanner - 遷移掃描器
+ *
+ * 職責：處理一次性全量儲存空間掃描
+ * - 獲取所有 highlights_* 和 page_* 格式的 highlights（用於遷移掃描）
+ * - 獲取所有已保存頁面的 URL
+ * - 從 StorageService 中拆分出來，降低主存儲服務的複雜度，便於未來整體移除。
+ *
+ * @module services/StorageMigrationScanner
+ */
+
+/* global chrome */
+
+import { PAGE_PREFIX, SAVED_PREFIX, HIGHLIGHTS_PREFIX } from '../../config/shared/storage.js';
+import { ERROR_MESSAGES } from '../../config/messages/errorMessages.js';
+
+const STORAGE_ERROR = ERROR_MESSAGES.TECHNICAL.CHROME_STORAGE_UNAVAILABLE;
+
+export class StorageMigrationScanner {
+  constructor(options = {}) {
+    this.storage = options.chromeStorage || (typeof chrome === 'undefined' ? null : chrome.storage);
+    this.logger = options.logger || console;
+  }
+
+  /**
+   * 檢查資料是否已是規範化的 highlights 物件形狀
+   *
+   * @param {any} value - 待檢查的值
+   * @returns {boolean} 是否為規範化物件
+   * @private
+   */
+  _isNormalizedHighlightObject(value) {
+    return value && typeof value === 'object' && 'highlights' in value;
+  }
+
+  /**
+   * 規範化舊格式標註資料，確保回傳形狀一律為 { highlights: [...] }
+   *
+   * @param {any} value - 原始儲存值（可能是陣列或含 highlights 欄位的物件）
+   * @returns {object} 統一為 { highlights: [...] } 格式
+   * @private
+   */
+  _normalizeLegacyHighlight(value) {
+    if (this._isNormalizedHighlightObject(value)) {
+      return value;
+    }
+    return { highlights: Array.isArray(value) ? value : [] };
+  }
+
+  /**
+   * 共用全量儲存空間讀取
+   *
+   * @returns {Promise<object>}
+   * @private
+   */
+  async _getAllStorageData() {
+    if (!this.storage) {
+      throw new Error(STORAGE_ERROR);
+    }
+    return await this.storage.local.get(null);
+  }
+
+  /**
+   * 從全量儲存空間數據中收集新格式 page_* 的 highlights 資料
+   *
+   * @param {object} allData - 全量數據
+   * @returns {Record<string, object>} 收集結果
+   * @private
+   */
+  _collectPageHighlights(allData) {
+    const result = {};
+    for (const [key, value] of Object.entries(allData)) {
+      if (!key.startsWith(PAGE_PREFIX)) {
+        continue;
+      }
+      if (!value || typeof value !== 'object') {
+        this.logger.warn?.('[StorageMigrationScanner] page_* entry has invalid shape, skipped', {
+          key,
+        });
+        continue;
+      }
+      const url = key.slice(PAGE_PREFIX.length);
+      result[url] = { url, highlights: Array.isArray(value.highlights) ? value.highlights : [] };
+    }
+    return result;
+  }
+
+  /**
+   * 從全量儲存空間數據中收集舊格式 highlights_* 的 highlights 資料，且不覆寫已存在的 result
+   *
+   * @param {object} allData - 全量數據
+   * @param {Record<string, object>} existingResult - 已收集到的 highlights 結果
+   * @returns {Record<string, object>} 補充過渡期格式後的完整收集結果
+   * @private
+   */
+  _collectLegacyHighlights(allData, existingResult) {
+    const result = { ...existingResult };
+    for (const [key, value] of Object.entries(allData)) {
+      if (key.startsWith(HIGHLIGHTS_PREFIX)) {
+        const url = key.slice(HIGHLIGHTS_PREFIX.length);
+        if (!result[url]) {
+          result[url] = this._normalizeLegacyHighlight(value);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * 獲取所有 highlights_* 和 page_* 的資料（用於遷移掃描）
+   *
+   * ⚠️ **效能警告**：此方法透過 `storage.local.get(null)` 讀取整個 chrome.storage.local，
+   * 屬於昂貴的一次性 migration-only helper，不應在 hot paths 或頻繁觸發的流程中使用。
+   * 若需讀取單一 URL 的標註，請改用 `getHighlights(pageUrl)`。
+   *
+   * Phase 3：同時掃描 page_* + highlights_*，去重（同 URL 優先用 page_* 資料）。
+   *
+   * 回傳格式：
+   * ```
+   * {
+   *   "https://example.com": { url, highlights: [...] },
+   *   ...
+   * }
+   * ```
+   *
+   * @param {object} [allData] - 外部提供的全量儲存空間數據，若未提供則從 storage 讀取
+   * @returns {Promise<Record<string, object>>} key 為 URL，value 為完整標註資料
+   */
+  async getAllHighlights(allData = null) {
+    if (!this.storage) {
+      throw new Error(STORAGE_ERROR);
+    }
+
+    try {
+      const data = allData || (await this._getAllStorageData());
+      const pageResult = this._collectPageHighlights(data);
+      return this._collectLegacyHighlights(data, pageResult);
+    } catch (error) {
+      this.logger.error?.('[StorageMigrationScanner] getAllHighlights failed', { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 獲取所有已保存頁面的 URL
+   *
+   * Phase 3：合併 page_*（notion 非 null）+ saved_* 的 URLs（去重）。
+   *
+   * @param {object} [allData] - 外部提供的全量儲存空間數據，若未提供則從 storage 讀取
+   * @returns {Promise<string[]>}
+   */
+  async getAllSavedPageUrls(allData = null) {
+    if (!this.storage) {
+      throw new Error(STORAGE_ERROR);
+    }
+
+    try {
+      const result = allData || (await this._getAllStorageData());
+      return this._extractUrlsFromStorageData(result);
+    } catch (error) {
+      this.logger.error?.('[StorageMigrationScanner] getAllSavedPageUrls failed', { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 從儲存數據中提取所有已保存的 URL
+   *
+   * @param {object} result - 儲存數據
+   * @returns {string[]}
+   * @private
+   */
+  _extractUrlsFromStorageData(result) {
+    const urlSet = new Set();
+
+    for (const [key, value] of Object.entries(result)) {
+      const url = this._extractSavedUrlFromEntry(key, value);
+      if (url) {
+        urlSet.add(url);
+      }
+    }
+
+    return Array.from(urlSet);
+  }
+
+  /**
+   * 從儲存體項目的鍵名與值中解析並提取已保存的頁面 URL
+   *
+   * @param {string} key - 儲存體鍵名
+   * @param {any} value - 儲存體值
+   * @returns {string|null} 提取出的頁面 URL，若未保存則為 null
+   * @private
+   */
+  _extractSavedUrlFromEntry(key, value) {
+    if (key.startsWith(PAGE_PREFIX) && value?.notion) {
+      // 新格式：有 notion 欄位代表已保存
+      return key.slice(PAGE_PREFIX.length);
+    }
+    if (key.startsWith(SAVED_PREFIX)) {
+      // 舊格式（過渡期）
+      return key.slice(SAVED_PREFIX.length);
+    }
+    return null;
+  }
+}

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -13,6 +13,10 @@
  * - 讀取時先查 page_*，沒有才查舊格式，找到舊格式則觸發讀時升級
  * - _withLock 確保同一 URL 的 read-modify-write 序列化
  *
+ * ⚠️ Deprecation Note:
+ * Migration 掃描（getAllHighlights / getAllSavedPageUrls）已遷移至 StorageMigrationScanner
+ * 詳見：scripts/background/services/StorageMigrationScanner.js
+ *
  * @module services/StorageService
  */
 
@@ -595,50 +599,6 @@ class StorageService {
   }
 
   /**
-   * 從全量儲存空間數據中收集新格式 page_* 的 highlights 資料
-   *
-   * @param {object} allData - 全量數據
-   * @returns {Record<string, object>} 收集結果
-   * @private
-   */
-  _collectPageHighlights(allData) {
-    const result = {};
-    for (const [key, value] of Object.entries(allData)) {
-      if (!key.startsWith(PAGE_PREFIX)) {
-        continue;
-      }
-      if (!value || typeof value !== 'object') {
-        this.logger.warn?.('[StorageService] page_* entry has invalid shape, skipped', { key });
-        continue;
-      }
-      const url = key.slice(PAGE_PREFIX.length);
-      result[url] = { url, highlights: Array.isArray(value.highlights) ? value.highlights : [] };
-    }
-    return result;
-  }
-
-  /**
-   * 從全量儲存空間數據中收集舊格式 highlights_* 的 highlights 資料，且不覆寫已存在的 result
-   *
-   * @param {object} allData - 全量數據
-   * @param {Record<string, object>} existingResult - 已收集到的 highlights 結果
-   * @returns {Record<string, object>} 補充過渡期格式後的完整收集結果
-   * @private
-   */
-  _collectLegacyHighlights(allData, existingResult) {
-    const result = { ...existingResult };
-    for (const [key, value] of Object.entries(allData)) {
-      if (key.startsWith(HIGHLIGHTS_PREFIX)) {
-        const url = key.slice(HIGHLIGHTS_PREFIX.length);
-        if (!result[url]) {
-          result[url] = this._normalizeLegacyHighlight(value);
-        }
-      }
-    }
-    return result;
-  }
-
-  /**
    * 將內部儲存的 notion 欄位映射為公開的預期欄位名
    *
    * @param {object|null} notion - 內部儲存的 notion 資料
@@ -657,26 +617,6 @@ class StorageService {
       lastVerifiedAt: notion.lastVerifiedAt ?? null,
       destinationProfileId: notion.destinationProfileId ?? null,
     };
-  }
-
-  /**
-   * 從儲存體項目的鍵名與值中解析並提取已保存的頁面 URL
-   *
-   * @param {string} key - 儲存體鍵名
-   * @param {any} value - 儲存體值
-   * @returns {string|null} 提取出的頁面 URL，若未保存則為 null
-   * @private
-   */
-  _extractSavedUrlFromEntry(key, value) {
-    if (key.startsWith(PAGE_PREFIX) && value?.notion) {
-      // 新格式：有 notion 欄位代表已保存
-      return key.slice(PAGE_PREFIX.length);
-    }
-    if (key.startsWith(SAVED_PREFIX)) {
-      // 舊格式（過渡期）
-      return key.slice(SAVED_PREFIX.length);
-    }
-    return null;
   }
 
   /**
@@ -1648,79 +1588,6 @@ class StorageService {
   }
 
   /**
-   * 檢查資料是否已是規範化的 highlights 物件形狀
-   *
-   * @param {any} value - 待檢查的值
-   * @returns {boolean} 是否為規範化物件
-   * @private
-   */
-  _isNormalizedHighlightObject(value) {
-    return value && typeof value === 'object' && 'highlights' in value;
-  }
-
-  /**
-   * 規範化舊格式標註資料，確保回傳形狀一律為 { highlights: [...] }
-   *
-   * @param {any} value - 原始儲存值（可能是陣列或含 highlights 欄位的物件）
-   * @returns {object} 統一為 { highlights: [...] } 格式
-   * @private
-   */
-  _normalizeLegacyHighlight(value) {
-    if (this._isNormalizedHighlightObject(value)) {
-      return value;
-    }
-    return { highlights: Array.isArray(value) ? value : [] };
-  }
-
-  /**
-   * 共用全量儲存空間讀取
-   *
-   * @returns {Promise<object>}
-   * @private
-   */
-  async _getAllStorageData() {
-    if (!this.storage) {
-      throw new Error(STORAGE_ERROR);
-    }
-    return await this.storage.local.get(null);
-  }
-
-  /**
-   * 獲取所有 highlights_* 和 page_* 的資料（用於遷移掃描）
-   *
-   * ⚠️ **效能警告**：此方法透過 `storage.local.get(null)` 讀取整個 chrome.storage.local，
-   * 屬於昂貴的一次性 migration-only helper，不應在 hot paths 或頻繁觸發的流程中使用。
-   * 若需讀取單一 URL 的標註，請改用 `getHighlights(pageUrl)`。
-   *
-   * Phase 3：同時掃描 page_* + highlights_*，去重（同 URL 優先用 page_* 資料）。
-   *
-   * 回傳格式：
-   * ```
-   * {
-   *   "https://example.com": { url, highlights: [...] },
-   *   ...
-   * }
-   * ```
-   *
-   * @param {object} [allData] - 外部提供的全量儲存空間數據，若未提供則從 storage 讀取
-   * @returns {Promise<Record<string, object>>} key 為 URL，value 為完整標註資料
-   */
-  async getAllHighlights(allData = null) {
-    if (!this.storage) {
-      throw new Error(STORAGE_ERROR);
-    }
-
-    try {
-      const data = allData || (await this._getAllStorageData());
-      const pageResult = this._collectPageHighlights(data);
-      return this._collectLegacyHighlights(data, pageResult);
-    } catch (error) {
-      this.logger.error?.('[StorageService] getAllHighlights failed', { error });
-      throw error;
-    }
-  }
-
-  /**
    * 更新指定 URL 的標註陣列（Phase 4：contract-driven mutation + canonical-lock）
    *
    * 流程：
@@ -1780,48 +1647,6 @@ class StorageService {
       this.logger.error?.('[StorageService] updateHighlights failed', { error });
       throw error;
     }
-  }
-
-  /**
-   * 獲取所有已保存頁面的 URL
-   *
-   * Phase 3：合併 page_*（notion 非 null）+ saved_* 的 URLs（去重）。
-   *
-   * @param {object} [allData] - 外部提供的全量儲存空間數據，若未提供則從 storage 讀取
-   * @returns {Promise<string[]>}
-   */
-  async getAllSavedPageUrls(allData = null) {
-    if (!this.storage) {
-      throw new Error(STORAGE_ERROR);
-    }
-
-    try {
-      const result = allData || (await this._getAllStorageData());
-      return this._extractUrlsFromStorageData(result);
-    } catch (error) {
-      this.logger.error?.('[StorageService] getAllSavedPageUrls failed', { error });
-      throw error;
-    }
-  }
-
-  /**
-   * 從儲存數據中提取所有已保存的 URL
-   *
-   * @param {object} result - 儲存數據
-   * @returns {string[]}
-   * @private
-   */
-  _extractUrlsFromStorageData(result) {
-    const urlSet = new Set();
-
-    for (const [key, value] of Object.entries(result)) {
-      const url = this._extractSavedUrlFromEntry(key, value);
-      if (url) {
-        urlSet.add(url);
-      }
-    }
-
-    return Array.from(urlSet);
   }
 }
 

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -166,7 +166,7 @@ class StorageService {
    */
   async _resolveCanonicalLockKey(normalizedUrl, rawUrl = null) {
     const aliasKeys = getAliasLookupKeys(normalizedUrl, rawUrl);
-    const aliasResult = aliasKeys.length > 0 ? await this.storage.local.get(aliasKeys) : {};
+    const aliasResult = aliasKeys.length > 0 ? (await this.storage.local.get(aliasKeys)) || {} : {};
     const aliasCandidate = pickAliasCandidate(aliasResult, normalizedUrl, rawUrl);
     const contract = resolveHighlightLookupKeys(normalizedUrl, aliasCandidate);
     return { lockKey: contract.mutationTargetKey, aliasCandidate, contract };
@@ -187,7 +187,7 @@ class StorageService {
     const savedKey = `${SAVED_PREFIX}${normalizedUrl}`;
     const aliasKey = `${URL_ALIAS_PREFIX}${normalizedUrl}`;
 
-    const result = await this.storage.local.get([pageKey, savedKey, aliasKey]);
+    const result = (await this.storage.local.get([pageKey, savedKey, aliasKey])) || {};
 
     // 已是新格式（page_*）
     if (result[pageKey]) {
@@ -199,7 +199,7 @@ class StorageService {
     if (stableUrl) {
       const stablePageKey = `${PAGE_PREFIX}${stableUrl}`;
       const stableSavedKey = `${SAVED_PREFIX}${stableUrl}`;
-      const r2 = await this.storage.local.get([stablePageKey, stableSavedKey]);
+      const r2 = (await this.storage.local.get([stablePageKey, stableSavedKey])) || {};
       if (r2[stablePageKey]) {
         return { format: 'new', key: stablePageKey, data: r2[stablePageKey] };
       }
@@ -591,7 +591,7 @@ class StorageService {
     }
 
     if (extraKeys.length > 0) {
-      const extra = await this.storage.local.get(extraKeys);
+      const extra = (await this.storage.local.get(extraKeys)) || {};
       return { ...preloadResult, ...extra };
     }
 
@@ -927,7 +927,7 @@ class StorageService {
       // 步驟 1：批量讀取所有需要的 keys（包含 alias + 所有可能的 page_* 和 highlights_*）
       const aliasKeys = getAliasLookupKeys(normalizedUrl, rawUrl);
       const preloadKeys = this._buildHighlightsPreloadKeys(normalizedUrl, rawUrl, aliasKeys);
-      const preloadResult = await this.storage.local.get(preloadKeys);
+      const preloadResult = (await this.storage.local.get(preloadKeys)) || {};
 
       // 步驟 2：從讀取結果選出 alias candidate
       const aliasCandidate = pickAliasCandidate(preloadResult, normalizedUrl, rawUrl);
@@ -1047,7 +1047,7 @@ class StorageService {
         const { fallbackPageKey, fallbackHlKey, normalizedHlKey, readKeys } =
           this._resolveSavedPageDependencies(normalizedUrl, state, targetKey, contract);
 
-        const existing = await this.storage.local.get(readKeys);
+        const existing = (await this.storage.local.get(readKeys)) || {};
 
         // current 優先取 canonical;若 canonical 尚不存在,fallback 至 _getPageState 命中的 page_*。
         const current = this._resolveCurrentPageState(existing, state, targetKey, fallbackPageKey);
@@ -1192,7 +1192,7 @@ class StorageService {
     return this._withLock(lockKey, async () => {
       try {
         const pageKey = `${PAGE_PREFIX}${normalizedUrl}`;
-        const existing = await this.storage.local.get([pageKey]);
+        const existing = (await this.storage.local.get([pageKey])) || {};
         const current = existing[pageKey];
 
         await this._removeSavedPageLocal(pageKey, current);
@@ -1526,7 +1526,7 @@ class StorageService {
     try {
       const [syncConfig, localConfig] = await Promise.all([
         this.storage.sync.get(keys),
-        this.storage.local.get(keys),
+        this.storage.local.get(keys).then(result => result || {}),
       ]);
       return { ...syncConfig, ...localConfig };
     } catch (error) {
@@ -1625,7 +1625,7 @@ class StorageService {
         const readKeys = Array.from(
           new Set([targetKey, ...contract.lookupOrder, ...contract.legacyCleanupKeys])
         );
-        const existing = await this.storage.local.get(readKeys);
+        const existing = (await this.storage.local.get(readKeys)) || {};
         const canonicalCurrent = existing[targetKey];
 
         // 嘗試從 lookupOrder 找出第一個有資料的 key 作為遷移來源

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -935,18 +935,30 @@ class StorageService {
         return null;
       }
 
-      if (state.format === 'new') {
-        return this._mapNotionToPublic(state.data.notion);
-      }
-
-      // 舊格式：觸發讀時升級（非阻塞），返回舊資料維持向後兼容
-      const targetUrl = state.resolvedUrl || normalizedUrl;
-      this._triggerReadTimeUpgrade(targetUrl, state.savedData, state.savedKey);
-      return state.savedData;
+      return this._resolveSavedPageDataFromState(state, normalizedUrl);
     } catch (error) {
       this.logger.error?.('[StorageService] getSavedPageData failed', { error });
       throw error;
     }
+  }
+
+  /**
+   * 從頁面狀態解析保存數據
+   *
+   * @param {object} state - 頁面狀態
+   * @param {string} normalizedUrl - 正規化 URL
+   * @returns {object|null}
+   * @private
+   */
+  _resolveSavedPageDataFromState(state, normalizedUrl) {
+    if (state.format === 'new') {
+      return this._mapNotionToPublic(state.data.notion);
+    }
+
+    // 舊格式：觸發讀時升級（非阻塞），返回舊資料維持向後兼容
+    const targetUrl = state.resolvedUrl || normalizedUrl;
+    this._triggerReadTimeUpgrade(targetUrl, state.savedData, state.savedKey);
+    return state.savedData;
   }
 
   /**
@@ -1038,23 +1050,37 @@ class StorageService {
     const targetKey = contract.mutationTargetKey;
 
     return this._withLock(lockKey, async () => {
-      try {
-        // 鎖內讀取 lookupOrder 與 legacyCleanupKeys 一次,作為 cleanup 計算依據。
-        const readKeys = Array.from(
-          new Set([targetKey, ...contract.lookupOrder, ...contract.legacyCleanupKeys])
-        );
-        const existing = await this.storage.local.get(readKeys);
-
-        const pageObj = this._buildPageObject(pageData, highlights || [], contract.canonicalUrl);
-        await this.storage.local.set({ [targetKey]: pageObj });
-
-        // Cleanup legacy keys（與 updateHighlights 同 pattern）：實際存在 + 字典序
-        await this._runLegacyKeyCleanup(targetKey, contract.legacyCleanupKeys, existing);
-      } catch (error) {
-        this.logger.error?.('[StorageService] savePageDataAndHighlights failed', { error });
-        throw error;
-      }
+      await this._savePageDataAndHighlightsUnderLock(targetKey, contract, pageData, highlights);
     });
+  }
+
+  /**
+   * 在鎖保護下執行 savePageDataAndHighlights 寫入
+   *
+   * @param {string} targetKey - 目標寫入 key
+   * @param {object} contract - canonical lock contract
+   * @param {object|null} pageData - 頁面數據
+   * @param {Array|null} highlights - 標註數據
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _savePageDataAndHighlightsUnderLock(targetKey, contract, pageData, highlights) {
+    try {
+      // 鎖內讀取 lookupOrder 與 legacyCleanupKeys 一次,作為 cleanup 計算依據。
+      const readKeys = Array.from(
+        new Set([targetKey, ...contract.lookupOrder, ...contract.legacyCleanupKeys])
+      );
+      const existing = await this.storage.local.get(readKeys);
+
+      const pageObj = this._buildPageObject(pageData, highlights || [], contract.canonicalUrl);
+      await this.storage.local.set({ [targetKey]: pageObj });
+
+      // Cleanup legacy keys（與 updateHighlights 同 pattern）：實際存在 + 字典序
+      await this._runLegacyKeyCleanup(targetKey, contract.legacyCleanupKeys, existing);
+    } catch (error) {
+      this.logger.error?.('[StorageService] savePageDataAndHighlights failed', { error });
+      throw error;
+    }
   }
 
   /**
@@ -1771,20 +1797,31 @@ class StorageService {
 
     try {
       const result = allData || (await this._getAllStorageData());
-      const urlSet = new Set();
-
-      for (const [key, value] of Object.entries(result)) {
-        const url = this._extractSavedUrlFromEntry(key, value);
-        if (url) {
-          urlSet.add(url);
-        }
-      }
-
-      return Array.from(urlSet);
+      return this._extractUrlsFromStorageData(result);
     } catch (error) {
       this.logger.error?.('[StorageService] getAllSavedPageUrls failed', { error });
       throw error;
     }
+  }
+
+  /**
+   * 從儲存數據中提取所有已保存的 URL
+   *
+   * @param {object} result - 儲存數據
+   * @returns {string[]}
+   * @private
+   */
+  _extractUrlsFromStorageData(result) {
+    const urlSet = new Set();
+
+    for (const [key, value] of Object.entries(result)) {
+      const url = this._extractSavedUrlFromEntry(key, value);
+      if (url) {
+        urlSet.add(url);
+      }
+    }
+
+    return Array.from(urlSet);
   }
 }
 

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -839,9 +839,6 @@ class StorageService {
       return;
     }
 
-    const pageKey = `${PAGE_PREFIX}${targetUrl}`;
-    const highlightKey = `${HIGHLIGHTS_PREFIX}${targetUrl}`;
-
     // Phase 4 follow-up（Lite plan 2026-05-04）：lock key 改採 canonical helper,
     // 與其他 page-state writers 共用同一條 lock namespace。
     // 注意:此 function 對 caller 仍為 fire-and-forget;_withLock 內的工作 MAY 在 caller 已返回後才完成。
@@ -856,33 +853,49 @@ class StorageService {
 
     // 在鎖的保護下進行升級，避免併發覆蓋
     this._withLock(lockKey, async () => {
-      const lockNow = Date.now();
-      if (!this._canRetryUpgrade(targetUrl, lockNow)) {
-        return;
-      }
-
-      // 同時讀取現有 page_* 和 highlights_*，防止覆寫鎖等待期間寫入的較新資料
-      try {
-        const readResult = await this.storage.local.get([pageKey, highlightKey]);
-        const existingPage = readResult[pageKey];
-        const highlightData = readResult[highlightKey];
-        const builtObj = this._buildPageObject(savedData, highlightData, targetUrl, savedKey);
-
-        // 若已有較新的 page_* 資料（以 metadata.lastUpdated 判斷），合併而非覆寫
-        const finalObj = this._isExistingPageNewer(existingPage, builtObj)
-          ? this._mergeUpgradePage(existingPage, builtObj)
-          : builtObj;
-
-        await this.storage.local.set({ [pageKey]: finalObj });
-        await this.storage.local.remove([savedKey, highlightKey]);
-        this._clearUpgradeFailure(targetUrl);
-      } catch (error) {
-        this._recordUpgradeFailure(targetUrl, Date.now());
-        throw error;
-      }
+      await this._executeUpgradeUnderLock(targetUrl, savedData, savedKey);
     }).catch(error => {
       this.logger.warn?.('[StorageService] 讀時升級失敗', { error });
     });
+  }
+
+  /**
+   * 在鎖保護下執行讀時升級邏輯
+   *
+   * @param {string} targetUrl - 目標 URL
+   * @param {object} savedData - 舊資料
+   * @param {string} savedKey - 舊 key
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _executeUpgradeUnderLock(targetUrl, savedData, savedKey) {
+    const lockNow = Date.now();
+    if (!this._canRetryUpgrade(targetUrl, lockNow)) {
+      return;
+    }
+
+    const pageKey = `${PAGE_PREFIX}${targetUrl}`;
+    const highlightKey = `${HIGHLIGHTS_PREFIX}${targetUrl}`;
+
+    try {
+      // 同時讀取現有 page_* 和 highlights_*，防止覆寫鎖等待期間寫入的較新資料
+      const readResult = await this.storage.local.get([pageKey, highlightKey]);
+      const existingPage = readResult[pageKey];
+      const highlightData = readResult[highlightKey];
+      const builtObj = this._buildPageObject(savedData, highlightData, targetUrl, savedKey);
+
+      // 若已有較新的 page_* 資料（以 metadata.lastUpdated 判斷），合併而非覆寫
+      const finalObj = this._isExistingPageNewer(existingPage, builtObj)
+        ? this._mergeUpgradePage(existingPage, builtObj)
+        : builtObj;
+
+      await this.storage.local.set({ [pageKey]: finalObj });
+      await this.storage.local.remove([savedKey, highlightKey]);
+      this._clearUpgradeFailure(targetUrl);
+    } catch (error) {
+      this._recordUpgradeFailure(targetUrl, Date.now());
+      throw error;
+    }
   }
 
   /**
@@ -1053,21 +1066,9 @@ class StorageService {
     return this._withLock(lockKey, async () => {
       try {
         const state = await this._getPageState(normalizedUrl);
-        const fallbackTargetUrl = this._resolvePageStateTargetUrl(state, normalizedUrl);
-        const fallbackPageKey = `${PAGE_PREFIX}${fallbackTargetUrl}`;
-        const fallbackHlKey = `${HIGHLIGHTS_PREFIX}${fallbackTargetUrl}`;
-        const normalizedHlKey = `${HIGHLIGHTS_PREFIX}${normalizedUrl}`;
+        const { fallbackPageKey, fallbackHlKey, normalizedHlKey, readKeys } =
+          this._resolveSavedPageDependencies(normalizedUrl, state, targetKey, contract);
 
-        // 一次讀取所有可能來源:canonical target、fallback page、相關 highlights_*。
-        const readKeys = Array.from(
-          new Set([
-            targetKey,
-            fallbackPageKey,
-            fallbackHlKey,
-            normalizedHlKey,
-            ...contract.legacyCleanupKeys,
-          ])
-        );
         const existing = await this.storage.local.get(readKeys);
 
         // current 優先取 canonical;若 canonical 尚不存在,fallback 至 _getPageState 命中的 page_*。
@@ -1096,14 +1097,12 @@ class StorageService {
 
         // Cleanup:saved_<targetUrl>、saved_<normalizedUrl>(過渡期殘留)、
         // contract.legacyCleanupKeys(含 page_<other> 與 highlights_*)、_getPageState 返回的 legacy savedKey。
-        const targetUrl = targetKey.slice(PAGE_PREFIX.length);
-        const candidateKeys = [`${SAVED_PREFIX}${targetUrl}`, `${SAVED_PREFIX}${normalizedUrl}`];
-        if (state?.format === 'legacy' && state.savedKey) {
-          candidateKeys.push(state.savedKey);
-        }
-        for (const key of contract.legacyCleanupKeys) {
-          candidateKeys.push(key);
-        }
+        const candidateKeys = this._collectSetSavedCleanupKeys(
+          state,
+          contract,
+          targetKey,
+          normalizedUrl
+        );
 
         await this._runLegacyKeyCleanup(targetKey, candidateKeys, existing, [SAVED_PREFIX]);
       } catch (error) {
@@ -1111,6 +1110,61 @@ class StorageService {
         throw error;
       }
     });
+  }
+
+  /**
+   * 解析 setSavedPageData 所需的依賴 keys
+   *
+   * @param {string} normalizedUrl - 正規化 URL
+   * @param {object} state - 頁面狀態
+   * @param {string} targetKey - 目標寫入 key
+   * @param {object} contract - canonical lock contract
+   * @returns {{fallbackPageKey: string, fallbackHlKey: string, normalizedHlKey: string, readKeys: string[]}}
+   * @private
+   */
+  _resolveSavedPageDependencies(normalizedUrl, state, targetKey, contract) {
+    const fallbackTargetUrl = this._resolvePageStateTargetUrl(state, normalizedUrl);
+    const fallbackPageKey = `${PAGE_PREFIX}${fallbackTargetUrl}`;
+    const fallbackHlKey = `${HIGHLIGHTS_PREFIX}${fallbackTargetUrl}`;
+    const normalizedHlKey = `${HIGHLIGHTS_PREFIX}${normalizedUrl}`;
+
+    // 一次讀取所有可能來源:canonical target、fallback page、相關 highlights_*。
+    const readKeys = Array.from(
+      new Set([
+        targetKey,
+        fallbackPageKey,
+        fallbackHlKey,
+        normalizedHlKey,
+        ...contract.legacyCleanupKeys,
+      ])
+    );
+
+    return { fallbackPageKey, fallbackHlKey, normalizedHlKey, readKeys };
+  }
+
+  /**
+   * 收集 setSavedPageData 的 cleanup keys
+   *
+   * @param {object} state - 頁面狀態
+   * @param {object} contract - canonical lock contract
+   * @param {string} targetKey - 目標寫入 key
+   * @param {string} normalizedUrl - 正規化 URL
+   * @returns {string[]}
+   * @private
+   */
+  _collectSetSavedCleanupKeys(state, contract, targetKey, normalizedUrl) {
+    const targetUrl = targetKey.slice(PAGE_PREFIX.length);
+    const candidateKeys = [`${SAVED_PREFIX}${targetUrl}`, `${SAVED_PREFIX}${normalizedUrl}`];
+
+    if (state?.format === 'legacy' && state.savedKey) {
+      candidateKeys.push(state.savedKey);
+    }
+
+    for (const key of contract.legacyCleanupKeys) {
+      candidateKeys.push(key);
+    }
+
+    return candidateKeys;
   }
 
   /**
@@ -1234,13 +1288,9 @@ class StorageService {
       const state = await this._getPageState(normalizedUrl);
 
       if (state?.format === 'new') {
-        if (this._isMismatchedPageId(state, expectedPageId)) {
-          this.logger.warn?.('[StorageService] clearNotionState skipped: pageId mismatch', {
-            expectedPageId: expectedPageId.slice(0, 4),
-            foundPageId: state.data.notion.pageId.slice(0, 4),
-            url: sanitizeUrlForLogging(normalizedUrl),
-          });
-          return { skipped: true, reason: 'pageId_mismatch' };
+        const skipResult = this._shouldSkipClearNotionState(state, expectedPageId, normalizedUrl);
+        if (skipResult) {
+          return skipResult;
         }
 
         const clearPayload = this._clearNotionFromPage(state, Date.now());
@@ -1257,6 +1307,32 @@ class StorageService {
 
       return { cleared: true };
     });
+  }
+
+  /**
+   * 檢查是否應跳過 clearNotionState（pageId 不匹配時）
+   *
+   * @param {object} state - 頁面狀態
+   * @param {string} expectedPageId - 預期的 pageId
+   * @param {string} normalizedUrl - 正規化的 URL
+   * @returns {{skipped: true, reason: string} | null}
+   * @private
+   */
+  _shouldSkipClearNotionState(state, expectedPageId, normalizedUrl) {
+    if (!this._isMismatchedPageId(state, expectedPageId)) {
+      return null;
+    }
+
+    const shortExpected = expectedPageId ? expectedPageId.slice(0, 4) : 'none';
+    const shortFound = state.data?.notion?.pageId?.slice(0, 4) || 'unknown';
+
+    this.logger.warn?.('[StorageService] clearNotionState skipped: pageId mismatch', {
+      expectedPageId: shortExpected,
+      foundPageId: shortFound,
+      url: sanitizeUrlForLogging(normalizedUrl),
+    });
+
+    return { skipped: true, reason: 'pageId_mismatch' };
   }
 
   /**

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -831,7 +831,7 @@ class StorageService {
 
     try {
       // 同時讀取現有 page_* 和 highlights_*，防止覆寫鎖等待期間寫入的較新資料
-      const readResult = await this.storage.local.get([pageKey, highlightKey]);
+      const readResult = (await this.storage.local.get([pageKey, highlightKey])) || {};
       const existingPage = readResult[pageKey];
       const highlightData = readResult[highlightKey];
       const builtObj = this._buildPageObject(savedData, highlightData, targetUrl, savedKey);
@@ -1010,7 +1010,7 @@ class StorageService {
       const readKeys = Array.from(
         new Set([targetKey, ...contract.lookupOrder, ...contract.legacyCleanupKeys])
       );
-      const existing = await this.storage.local.get(readKeys);
+      const existing = (await this.storage.local.get(readKeys)) || {};
 
       const pageObj = this._buildPageObject(pageData, highlights || [], contract.canonicalUrl);
       await this.storage.local.set({ [targetKey]: pageObj });

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -337,15 +337,7 @@ class StorageService {
    */
   async _runLegacyKeyCleanup(targetKey, candidateKeys, existing, forceIncludePrefixes = []) {
     const cleanupKeys = candidateKeys
-      .filter(k => {
-        if (k === targetKey) {
-          return false;
-        }
-        if (Object.hasOwn(existing, k)) {
-          return true;
-        }
-        return forceIncludePrefixes.some(prefix => k.startsWith(prefix));
-      })
+      .filter(k => this._shouldCleanupKey(k, targetKey, existing, forceIncludePrefixes))
       .toSorted(compareKeysAlphabetically);
 
     if (cleanupKeys.length > 0) {
@@ -356,6 +348,26 @@ class StorageService {
         });
       });
     }
+  }
+
+  /**
+   * 判斷 key 是否應該被清理
+   *
+   * @param {string} key - 候選 key
+   * @param {string} targetKey - 當前寫入的主鍵名
+   * @param {object} existing - 既有數據字典
+   * @param {Array<string>} forceIncludePrefixes - 強制包含的鍵名首碼
+   * @returns {boolean}
+   * @private
+   */
+  _shouldCleanupKey(key, targetKey, existing, forceIncludePrefixes) {
+    if (key === targetKey) {
+      return false;
+    }
+    if (Object.hasOwn(existing, key)) {
+      return true;
+    }
+    return forceIncludePrefixes.some(prefix => key.startsWith(prefix));
   }
 
   /**

--- a/tests/unit/background/handlers/migrationHandlers.test.js
+++ b/tests/unit/background/handlers/migrationHandlers.test.js
@@ -32,6 +32,7 @@ describe('migrationHandlers', () => {
   let handlers = null;
   let mockServices = null;
   let mockStorageService = null;
+  let mockMigrationScanner = null;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -49,12 +50,17 @@ describe('migrationHandlers', () => {
       setUrlAlias: jest.fn().mockResolvedValue(),
     };
 
+    mockMigrationScanner = {
+      getAllHighlights: jest.fn().mockResolvedValue({}),
+    };
+
     mockServices = {
       migrationService: {
         executeContentMigration: jest.fn(),
         migrateStorageKey: jest.fn().mockResolvedValue(true),
       },
       storageService: mockStorageService,
+      migrationScanner: mockMigrationScanner,
     };
     handlers = createMigrationHandlers(mockServices);
   });
@@ -459,8 +465,8 @@ describe('migrationHandlers', () => {
     test('應該正確回收待處理和失敗的項目', async () => {
       const sendResponse = jest.fn();
 
-      // 改用 storageService.getAllHighlights（Phase 1）
-      mockStorageService.getAllHighlights.mockResolvedValue({
+      // 改用 migrationScanner.getAllHighlights()
+      mockMigrationScanner.getAllHighlights.mockResolvedValue({
         'https://pending.com': { highlights: [{ id: 'p1', needsRangeInfo: true }] },
         'https://failed.com': { highlights: [{ id: 'f1', migrationFailed: true }] },
       });
@@ -479,7 +485,7 @@ describe('migrationHandlers', () => {
 
     test('如果 getAllHighlights 拋出錯誤，應該捕捉並回傳錯誤訊息', async () => {
       const sendResponse = jest.fn();
-      mockStorageService.getAllHighlights.mockRejectedValue(new Error('Storage Error'));
+      mockMigrationScanner.getAllHighlights.mockRejectedValue(new Error('Storage Error'));
 
       await handlers.migration_get_pending({}, defaultSender, sendResponse);
 

--- a/tests/unit/background/services/StorageMigrationScanner.test.js
+++ b/tests/unit/background/services/StorageMigrationScanner.test.js
@@ -28,6 +28,11 @@ describe('StorageMigrationScanner', () => {
 
     mockLogger = {
       log: jest.fn(),
+      success: jest.fn(),
+      start: jest.fn(),
+      ready: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
     };
@@ -205,12 +210,14 @@ describe('StorageMigrationScanner', () => {
       const originalChrome = globalThis.chrome;
       delete globalThis.chrome;
 
-      const scannerNoStorage = new StorageMigrationScanner({ chromeStorage: null });
+      try {
+        const scannerNoStorage = new StorageMigrationScanner({ chromeStorage: null });
 
-      await expect(scannerNoStorage.getAllSavedPageUrls()).rejects.toThrow(STORAGE_ERROR);
-      await expect(scannerNoStorage.getAllHighlights()).rejects.toThrow(STORAGE_ERROR);
-
-      globalThis.chrome = originalChrome;
+        await expect(scannerNoStorage.getAllSavedPageUrls()).rejects.toThrow(STORAGE_ERROR);
+        await expect(scannerNoStorage.getAllHighlights()).rejects.toThrow(STORAGE_ERROR);
+      } finally {
+        globalThis.chrome = originalChrome;
+      }
     });
 
     it('應該在 getAllSavedPageUrls 失敗時記錄錯誤並拋出', async () => {

--- a/tests/unit/background/services/StorageMigrationScanner.test.js
+++ b/tests/unit/background/services/StorageMigrationScanner.test.js
@@ -1,0 +1,238 @@
+import { StorageMigrationScanner } from '../../../../scripts/background/services/StorageMigrationScanner.js';
+import {
+  PAGE_PREFIX,
+  SAVED_PREFIX,
+  HIGHLIGHTS_PREFIX,
+} from '../../../../scripts/background/services/StorageService.js';
+import { ERROR_MESSAGES } from '../../../../scripts/config/messages/errorMessages.js';
+
+const STORAGE_ERROR = ERROR_MESSAGES.TECHNICAL.CHROME_STORAGE_UNAVAILABLE;
+
+describe('StorageMigrationScanner', () => {
+  let scanner;
+  let mockStorage;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockStorage = {
+      local: {
+        get: jest.fn(),
+        set: jest.fn(),
+        remove: jest.fn(),
+      },
+      sync: {
+        get: jest.fn(),
+        set: jest.fn(),
+      },
+    };
+
+    mockLogger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    scanner = new StorageMigrationScanner({
+      chromeStorage: mockStorage,
+      logger: mockLogger,
+    });
+  });
+
+  describe('getAllSavedPageUrls', () => {
+    it('應該返回所有已保存頁面的 URL（Phase 3: page_*.notion 非 null）', async () => {
+      mockStorage.local.get.mockResolvedValue({
+        [`${PAGE_PREFIX}https://example.com/page1`]: {
+          notion: { pageId: 'p1' },
+          highlights: [],
+          metadata: {},
+        },
+        [`${PAGE_PREFIX}https://example.com/page2`]: {
+          notion: { pageId: 'p2' },
+          highlights: [],
+          metadata: {},
+        },
+        // 無 notion 的 page_* 不應被計算
+        [`${PAGE_PREFIX}https://example.com/page3`]: {
+          notion: null,
+          highlights: [],
+          metadata: {},
+        },
+        // 過渡期：舊格式也要計算
+        [`${SAVED_PREFIX}https://example.com/page4`]: {},
+        other_key: 'value',
+      });
+
+      const result = await scanner.getAllSavedPageUrls();
+      expect(result.toSorted((a, b) => a.localeCompare(b))).toEqual(
+        [
+          'https://example.com/page1',
+          'https://example.com/page2',
+          'https://example.com/page4',
+        ].toSorted((a, b) => a.localeCompare(b))
+      );
+    });
+
+    it('應在提供 allData 時直接使用該資料且不呼召 storage.local.get', async () => {
+      const allData = {
+        [`${PAGE_PREFIX}https://example.com/all-data-page1`]: {
+          notion: { pageId: 'p1' },
+          highlights: [],
+          metadata: {},
+        },
+        [`${PAGE_PREFIX}https://example.com/all-data-page2`]: {
+          notion: null,
+          highlights: [],
+          metadata: {},
+        },
+        [`${SAVED_PREFIX}https://example.com/all-data-page3`]: {},
+        other_key: 'value',
+      };
+      mockStorage.local.get.mockClear();
+
+      const result = await scanner.getAllSavedPageUrls(allData);
+
+      expect(mockStorage.local.get).not.toHaveBeenCalled();
+      expect(result.toSorted((a, b) => a.localeCompare(b))).toEqual(
+        ['https://example.com/all-data-page1', 'https://example.com/all-data-page3'].toSorted(
+          (a, b) => a.localeCompare(b)
+        )
+      );
+    });
+  });
+
+  describe('getAllHighlights', () => {
+    it('應該返回所有 page_* 和 highlights_* 的標註資料（Phase 3）', async () => {
+      mockStorage.local.get.mockResolvedValue({
+        // 新格式（Phase 3）
+        [`${PAGE_PREFIX}https://example.com/page1`]: {
+          notion: { pageId: 'p1' },
+          highlights: ['h1'],
+          metadata: {},
+        },
+        // 舊格式（過渡期）
+        [`${HIGHLIGHTS_PREFIX}https://example.com/page2`]: {
+          url: 'https://example.com/page2',
+          highlights: ['h2'],
+        },
+        // 同 URL 有 page_* 時，highlights_* 不應覆蓋
+        [`${HIGHLIGHTS_PREFIX}https://example.com/page1`]: {
+          url: 'https://example.com/page1',
+          highlights: ['legacy-h1'],
+        },
+        other_key: 'value',
+      });
+
+      const result = await scanner.getAllHighlights();
+      // page1 使用 page_* 資料（不被舊 highlights_* 覆蓋）
+      expect(result['https://example.com/page1']).toEqual({
+        url: 'https://example.com/page1',
+        highlights: ['h1'],
+      });
+      // page2 使用 highlights_* 資料（尚未升級）
+      expect(result['https://example.com/page2']).toEqual({
+        url: 'https://example.com/page2',
+        highlights: ['h2'],
+      });
+    });
+
+    it('應在提供 allData 時直接使用該資料且不呼召 storage.local.get', async () => {
+      const allData = {
+        [`${PAGE_PREFIX}https://example.com/all-data-page1`]: {
+          notion: { pageId: 'p1' },
+          highlights: ['new-h1'],
+          metadata: {},
+        },
+        [`${HIGHLIGHTS_PREFIX}https://example.com/all-data-page1`]: {
+          url: 'https://example.com/all-data-page1',
+          highlights: ['legacy-h1'],
+        },
+        [`${HIGHLIGHTS_PREFIX}https://example.com/all-data-page2`]: {
+          url: 'https://example.com/all-data-page2',
+          highlights: ['legacy-h2'],
+        },
+        other_key: 'value',
+      };
+      mockStorage.local.get.mockClear();
+
+      const result = await scanner.getAllHighlights(allData);
+
+      expect(mockStorage.local.get).not.toHaveBeenCalled();
+      expect(result['https://example.com/all-data-page1']).toEqual({
+        url: 'https://example.com/all-data-page1',
+        highlights: ['new-h1'],
+      });
+      expect(result['https://example.com/all-data-page2']).toEqual({
+        url: 'https://example.com/all-data-page2',
+        highlights: ['legacy-h2'],
+      });
+    });
+
+    it('遇到毀損的 page_* entry(value 非物件)應跳過並警告,不應拋錯也不應偽造空 highlights', async () => {
+      const allData = {
+        [`${PAGE_PREFIX}https://example.com/good`]: {
+          notion: { pageId: 'p1' },
+          highlights: ['h1'],
+          metadata: {},
+        },
+        [`${PAGE_PREFIX}https://example.com/corrupt-null`]: null,
+        [`${PAGE_PREFIX}https://example.com/corrupt-string`]: 'unexpected-string',
+      };
+
+      const result = await scanner.getAllHighlights(allData);
+
+      // 健康 entry 正常返回
+      expect(result['https://example.com/good']).toEqual({
+        url: 'https://example.com/good',
+        highlights: ['h1'],
+      });
+      // 毀損 entry MUST NOT 出現在結果中(避免偽造「URL 存在但 highlights 為空」的假狀態)
+      expect(result).not.toHaveProperty('https://example.com/corrupt-null');
+      expect(result).not.toHaveProperty('https://example.com/corrupt-string');
+      // 毀損 entry MUST 留下 warn 足跡以利後續排查
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('page_* entry has invalid shape'),
+        expect.objectContaining({ key: `${PAGE_PREFIX}https://example.com/corrupt-null` })
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('page_* entry has invalid shape'),
+        expect.objectContaining({ key: `${PAGE_PREFIX}https://example.com/corrupt-string` })
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('應該在沒有 storage 時拋出錯誤', async () => {
+      const originalChrome = globalThis.chrome;
+      delete globalThis.chrome;
+
+      const scannerNoStorage = new StorageMigrationScanner({ chromeStorage: null });
+
+      await expect(scannerNoStorage.getAllSavedPageUrls()).rejects.toThrow(STORAGE_ERROR);
+      await expect(scannerNoStorage.getAllHighlights()).rejects.toThrow(STORAGE_ERROR);
+
+      globalThis.chrome = originalChrome;
+    });
+
+    it('應該在 getAllSavedPageUrls 失敗時記錄錯誤並拋出', async () => {
+      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
+      await expect(scanner.getAllSavedPageUrls()).rejects.toThrow('Storage fail');
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('StorageMigrationScanner'),
+        {
+          error: expect.any(Error),
+        }
+      );
+    });
+
+    it('應該在 getAllHighlights 失敗時記錄錯誤並拋出', async () => {
+      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
+      await expect(scanner.getAllHighlights()).rejects.toThrow('Storage fail');
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('StorageMigrationScanner'),
+        {
+          error: expect.any(Error),
+        }
+      );
+    });
+  });
+});

--- a/tests/unit/background/services/StorageMigrationScanner.test.js
+++ b/tests/unit/background/services/StorageMigrationScanner.test.js
@@ -220,26 +220,18 @@ describe('StorageMigrationScanner', () => {
       }
     });
 
-    it('應該在 getAllSavedPageUrls 失敗時記錄錯誤並拋出', async () => {
-      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
-      await expect(scanner.getAllSavedPageUrls()).rejects.toThrow('Storage fail');
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('StorageMigrationScanner'),
-        {
-          error: expect.any(Error),
-        }
-      );
-    });
-
-    it('應該在 getAllHighlights 失敗時記錄錯誤並拋出', async () => {
-      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
-      await expect(scanner.getAllHighlights()).rejects.toThrow('Storage fail');
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('StorageMigrationScanner'),
-        {
-          error: expect.any(Error),
-        }
-      );
-    });
+    it.each(['getAllSavedPageUrls', 'getAllHighlights'])(
+      '應該在 %s 失敗時記錄錯誤並拋出',
+      async methodName => {
+        mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
+        await expect(scanner[methodName]()).rejects.toThrow('Storage fail');
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('StorageMigrationScanner'),
+          {
+            error: expect.any(Error),
+          }
+        );
+      }
+    );
   });
 });

--- a/tests/unit/background/services/StorageService.test.js
+++ b/tests/unit/background/services/StorageService.test.js
@@ -207,6 +207,14 @@ describe('StorageService', () => {
       expect(result).toBeNull();
     });
 
+    it('storage.local.get 回傳 null 時應視為空結果', async () => {
+      mockStorage.local.get.mockResolvedValue(null);
+
+      const result = await service.getSavedPageData('https://example.com/page');
+
+      expect(result).toBeNull();
+    });
+
     it('應該在 page_* 的 notion 為 null 時返回 null', async () => {
       mockStorage.local.get.mockResolvedValue({
         [`${PAGE_PREFIX}https://example.com/page`]: {

--- a/tests/unit/background/services/StorageService.test.js
+++ b/tests/unit/background/services/StorageService.test.js
@@ -1535,168 +1535,6 @@ describe('StorageService', () => {
     });
   });
 
-  describe('getAllSavedPageUrls', () => {
-    it('應該返回所有已保存頁面的 URL（Phase 3: page_*.notion 非 null）', async () => {
-      mockStorage.local.get.mockResolvedValue({
-        [`${PAGE_PREFIX}https://example.com/page1`]: {
-          notion: { pageId: 'p1' },
-          highlights: [],
-          metadata: {},
-        },
-        [`${PAGE_PREFIX}https://example.com/page2`]: {
-          notion: { pageId: 'p2' },
-          highlights: [],
-          metadata: {},
-        },
-        // 無 notion 的 page_* 不應被計算
-        [`${PAGE_PREFIX}https://example.com/page3`]: {
-          notion: null,
-          highlights: [],
-          metadata: {},
-        },
-        // 過渡期：舊格式也要計算
-        [`${SAVED_PREFIX}https://example.com/page4`]: {},
-        other_key: 'value',
-      });
-
-      const result = await service.getAllSavedPageUrls();
-      expect(result.toSorted((a, b) => a.localeCompare(b))).toEqual(
-        [
-          'https://example.com/page1',
-          'https://example.com/page2',
-          'https://example.com/page4',
-        ].toSorted((a, b) => a.localeCompare(b))
-      );
-    });
-
-    it('應在提供 allData 時直接使用該資料且不呼叫 storage.local.get', async () => {
-      const allData = {
-        [`${PAGE_PREFIX}https://example.com/all-data-page1`]: {
-          notion: { pageId: 'p1' },
-          highlights: [],
-          metadata: {},
-        },
-        [`${PAGE_PREFIX}https://example.com/all-data-page2`]: {
-          notion: null,
-          highlights: [],
-          metadata: {},
-        },
-        [`${SAVED_PREFIX}https://example.com/all-data-page3`]: {},
-        other_key: 'value',
-      };
-      mockStorage.local.get.mockClear();
-
-      const result = await service.getAllSavedPageUrls(allData);
-
-      expect(mockStorage.local.get).not.toHaveBeenCalled();
-      expect(result.toSorted((a, b) => a.localeCompare(b))).toEqual(
-        ['https://example.com/all-data-page1', 'https://example.com/all-data-page3'].toSorted(
-          (a, b) => a.localeCompare(b)
-        )
-      );
-    });
-  });
-
-  describe('getAllHighlights', () => {
-    it('應該返回所有 page_* 和 highlights_* 的標註資料（Phase 3）', async () => {
-      mockStorage.local.get.mockResolvedValue({
-        // 新格式（Phase 3）
-        [`${PAGE_PREFIX}https://example.com/page1`]: {
-          notion: { pageId: 'p1' },
-          highlights: ['h1'],
-          metadata: {},
-        },
-        // 舊格式（過渡期）
-        [`${HIGHLIGHTS_PREFIX}https://example.com/page2`]: {
-          url: 'https://example.com/page2',
-          highlights: ['h2'],
-        },
-        // 同 URL 有 page_* 時，highlights_* 不應覆蓋
-        [`${HIGHLIGHTS_PREFIX}https://example.com/page1`]: {
-          url: 'https://example.com/page1',
-          highlights: ['legacy-h1'],
-        },
-        other_key: 'value',
-      });
-
-      const result = await service.getAllHighlights();
-      // page1 使用 page_* 資料（不被舊 highlights_* 覆蓋）
-      expect(result['https://example.com/page1']).toEqual({
-        url: 'https://example.com/page1',
-        highlights: ['h1'],
-      });
-      // page2 使用 highlights_* 資料（尚未升級）
-      expect(result['https://example.com/page2']).toEqual({
-        url: 'https://example.com/page2',
-        highlights: ['h2'],
-      });
-    });
-
-    it('應在提供 allData 時直接使用該資料且不呼叫 storage.local.get', async () => {
-      const allData = {
-        [`${PAGE_PREFIX}https://example.com/all-data-page1`]: {
-          notion: { pageId: 'p1' },
-          highlights: ['new-h1'],
-          metadata: {},
-        },
-        [`${HIGHLIGHTS_PREFIX}https://example.com/all-data-page1`]: {
-          url: 'https://example.com/all-data-page1',
-          highlights: ['legacy-h1'],
-        },
-        [`${HIGHLIGHTS_PREFIX}https://example.com/all-data-page2`]: {
-          url: 'https://example.com/all-data-page2',
-          highlights: ['legacy-h2'],
-        },
-        other_key: 'value',
-      };
-      mockStorage.local.get.mockClear();
-
-      const result = await service.getAllHighlights(allData);
-
-      expect(mockStorage.local.get).not.toHaveBeenCalled();
-      expect(result['https://example.com/all-data-page1']).toEqual({
-        url: 'https://example.com/all-data-page1',
-        highlights: ['new-h1'],
-      });
-      expect(result['https://example.com/all-data-page2']).toEqual({
-        url: 'https://example.com/all-data-page2',
-        highlights: ['legacy-h2'],
-      });
-    });
-
-    it('遇到毀損的 page_* entry(value 非物件)應跳過並警告,不應拋錯也不應偽造空 highlights', async () => {
-      const allData = {
-        [`${PAGE_PREFIX}https://example.com/good`]: {
-          notion: { pageId: 'p1' },
-          highlights: ['h1'],
-          metadata: {},
-        },
-        [`${PAGE_PREFIX}https://example.com/corrupt-null`]: null,
-        [`${PAGE_PREFIX}https://example.com/corrupt-string`]: 'unexpected-string',
-      };
-
-      const result = await service.getAllHighlights(allData);
-
-      // 健康 entry 正常返回
-      expect(result['https://example.com/good']).toEqual({
-        url: 'https://example.com/good',
-        highlights: ['h1'],
-      });
-      // 毀損 entry MUST NOT 出現在結果中(避免偽造「URL 存在但 highlights 為空」的假狀態)
-      expect(result).not.toHaveProperty('https://example.com/corrupt-null');
-      expect(result).not.toHaveProperty('https://example.com/corrupt-string');
-      // 毀損 entry MUST 留下 warn 足跡以利後續排查
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('page_* entry has invalid shape'),
-        expect.objectContaining({ key: `${PAGE_PREFIX}https://example.com/corrupt-null` })
-      );
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('page_* entry has invalid shape'),
-        expect.objectContaining({ key: `${PAGE_PREFIX}https://example.com/corrupt-string` })
-      );
-    });
-  });
-
   describe('updateHighlights', () => {
     it('應該更新 page_* 的 highlights 欄位（Phase 3）', async () => {
       const existingPageData = {
@@ -2108,8 +1946,6 @@ describe('StorageService', () => {
       await expect(serviceNoStorage.clearPageState('url')).rejects.toThrow(STORAGE_ERROR);
       await expect(serviceNoStorage.getConfig(['key'])).rejects.toThrow(STORAGE_ERROR);
       await expect(serviceNoStorage.setConfig({ key: 'val' })).rejects.toThrow(STORAGE_ERROR);
-      await expect(serviceNoStorage.getAllSavedPageUrls()).rejects.toThrow(STORAGE_ERROR);
-      await expect(serviceNoStorage.getAllHighlights()).rejects.toThrow(STORAGE_ERROR);
       await expect(serviceNoStorage.updateHighlights('url', [])).rejects.toThrow(STORAGE_ERROR);
 
       globalThis.chrome = originalChrome;
@@ -2150,22 +1986,6 @@ describe('StorageService', () => {
     it('應該在 storage.sync.set 失敗時記錄錯誤並拋出', async () => {
       mockStorage.sync.set.mockRejectedValue(new Error('Storage fail'));
       await expect(service.setConfig({ key: 'val' })).rejects.toThrow('Storage fail');
-      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('StorageService'), {
-        error: expect.any(Error),
-      });
-    });
-
-    it('應該在 getAllSavedPageUrls 失敗時記錄錯誤並拋出', async () => {
-      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
-      await expect(service.getAllSavedPageUrls()).rejects.toThrow('Storage fail');
-      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('StorageService'), {
-        error: expect.any(Error),
-      });
-    });
-
-    it('應該在 getAllHighlights 失敗時記錄錯誤並拋出', async () => {
-      mockStorage.local.get.mockRejectedValue(new Error('Storage fail'));
-      await expect(service.getAllHighlights()).rejects.toThrow('Storage fail');
       expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('StorageService'), {
         error: expect.any(Error),
       });


### PR DESCRIPTION
### 摘要
重構 StorageService，降低其複雜度並引入 StorageMigrationScanner 以處理資料遷移邏輯。

### 變更內容
- 降低 StorageService 中多個函數的圈複雜度，並抽出輔助函數以簡化邏輯。
- 新增 StorageMigrationScanner 類別，專責處理全量儲存空間掃描及資料遷移。
- 更新 migrationHandlers 使用新的 migrationScanner 進行資料獲取，簡化 StorageService 的介面。
- 移除 StorageService 中與遷移相關的過時方法，提升維護性。

### 測試方式
測試已在 StorageService.test.js 中進行，所有測試通過。

### 潛在風險
無顯著風險。

