### PR TITLE
refactor: simplify MigrationService complexity

### DIFF
--- a/scripts/background/services/MigrationService.js
+++ b/scripts/background/services/MigrationService.js
@@ -9,6 +9,11 @@ const MIGRATION_CONFIG = Object.freeze({
   SCRIPT_READY_RETRY_DELAY: 200,
 });
 
+const MIGRATION_WRITE_RESULTS = Object.freeze({
+  SUCCESS: 'success',
+  CLEANUP_NEEDED: 'cleanup_needed',
+});
+
 /**
  * Migration 服務
  * 負責處理跨版本升級的數據遷移與初始化
@@ -34,65 +39,27 @@ export class MigrationService {
       return false;
     }
 
-    // 防禦層 1：拒絕遷移到根路徑 URL（首頁），防止不同頁面資料被覆寫到同一 key
-    if (isRootUrl(stableUrl)) {
-      Logger.warn('Blocked migration to root URL', {
-        stable: sanitizeUrlForLogging(stableUrl),
-        legacy: sanitizeUrlForLogging(legacyUrl),
-      });
+    if (this._shouldBlockRootMigration(stableUrl, legacyUrl)) {
       return false;
     }
 
     try {
-      // 並行取得 saved 和 highlights 數據
-      const [pageData, legacyHighlightsRaw] = await Promise.all([
-        this.storageService.getSavedPageData(legacyUrl),
-        this.storageService.getHighlights(legacyUrl),
-      ]);
-      const legacyHighlights = this._normalizeHighlights(legacyHighlightsRaw);
-
-      // 兩者皆無 → 不需遷移
+      const { pageData, legacyHighlights } = await this._loadLegacyMigrationData(legacyUrl);
       if (this._isNoDataToMigrate(pageData, legacyHighlights)) {
         return false;
       }
 
-      // 防禦層 2：目標 key 已有資料時拒絕覆寫（防止不同文章頁的資料互相破壞）
-      const [existingHighlightsRaw, existingPageData] = await Promise.all([
-        this.storageService.getHighlights(stableUrl),
-        this.storageService.getSavedPageData(stableUrl),
-      ]);
-      const existingHighlights = this._normalizeHighlights(existingHighlightsRaw);
-      if (this._hasExistingData(existingHighlights, existingPageData)) {
-        return this._handleMigrationTargetConflict({
-          stableUrl,
-          legacyUrl,
-          existingPageData,
-          pageData,
-          existingHighlightsCount: existingHighlights.length,
-        });
-      }
-
-      const { migratedHighlights, formatConverted } = await this._resolveMigratedHighlights({
-        highlights: legacyHighlights,
-        convertFormat: options.convertFormat,
-        formatConverter: options.formatConverter,
+      return await this._migrateLoadedStorageData({
         stableUrl,
         legacyUrl,
+        pageData,
+        legacyHighlights,
+        options,
       });
-
-      Logger.info('Migrating legacy data to stable URL', {
-        legacy: sanitizeUrlForLogging(legacyUrl),
-        stable: sanitizeUrlForLogging(stableUrl),
-        hasPageData: Boolean(pageData),
-        hasHighlights: legacyHighlights.length > 0,
-        formatConverted,
-      });
-
-      await this._applyMigrationWriteAndCleanup(stableUrl, legacyUrl, pageData, migratedHighlights);
-
-      return true;
     } catch (error) {
       Logger.error('Migration failed', {
+        action: 'migrate:storage-key',
+        result: 'failure',
         error: error.message,
         legacy: sanitizeUrlForLogging(legacyUrl),
         stable: sanitizeUrlForLogging(stableUrl),
@@ -100,6 +67,172 @@ export class MigrationService {
       // 如果遷移失敗，保持舊數據不動，確保數據安全
       return false;
     }
+  }
+
+  /**
+   * @param {string} stableUrl
+   * @param {string} legacyUrl
+   * @returns {boolean}
+   * @private
+   */
+  _shouldBlockRootMigration(stableUrl, legacyUrl) {
+    // 防禦層：拒絕遷移到根路徑 URL（首頁），防止不同頁面資料被覆寫到同一 key
+    if (!isRootUrl(stableUrl)) {
+      return false;
+    }
+    Logger.warn('Blocked migration to root URL', {
+      action: 'migrate:validate-target',
+      result: 'blocked',
+      stable: sanitizeUrlForLogging(stableUrl),
+      legacy: sanitizeUrlForLogging(legacyUrl),
+    });
+    return true;
+  }
+
+  /**
+   * @param {string} legacyUrl
+   * @returns {Promise<{ pageData: object|null, legacyHighlights: Array }>}
+   * @private
+   */
+  async _loadLegacyMigrationData(legacyUrl) {
+    const [pageData, legacyHighlightsRaw] = await Promise.all([
+      this.storageService.getSavedPageData(legacyUrl),
+      this.storageService.getHighlights(legacyUrl),
+    ]);
+    return {
+      pageData,
+      legacyHighlights: this._normalizeHighlights(legacyHighlightsRaw),
+    };
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.stableUrl
+   * @param {string} params.legacyUrl
+   * @param {object|null} params.pageData
+   * @param {Array} params.legacyHighlights
+   * @param {object} params.options
+   * @returns {Promise<boolean>}
+   * @private
+   */
+  async _migrateLoadedStorageData({ stableUrl, legacyUrl, pageData, legacyHighlights, options }) {
+    const { existingHighlights, existingPageData } =
+      await this._loadStableMigrationTarget(stableUrl);
+    const { migratedHighlights, formatConverted } = await this._resolveMigratedHighlights({
+      highlights: legacyHighlights,
+      convertFormat: options.convertFormat,
+      formatConverter: options.formatConverter,
+      stableUrl,
+      legacyUrl,
+    });
+
+    if (this._hasExistingHighlights(existingHighlights)) {
+      return this._handleMigrationTargetConflict({
+        stableUrl,
+        legacyUrl,
+        existingPageData,
+        pageData,
+        existingHighlights,
+        migratedHighlights,
+        existingHighlightsCount: existingHighlights.length,
+      });
+    }
+
+    await this._writeMigrationData({
+      stableUrl,
+      legacyUrl,
+      existingPageData,
+      pageData,
+      legacyHighlights,
+      migratedHighlights,
+      formatConverted,
+    });
+    return true;
+  }
+
+  /**
+   * @param {string} stableUrl
+   * @returns {Promise<{ existingHighlights: Array, existingPageData: object|null }>}
+   * @private
+   */
+  async _loadStableMigrationTarget(stableUrl) {
+    const [existingHighlightsRaw, existingPageData] = await Promise.all([
+      this.storageService.getHighlights(stableUrl),
+      this.storageService.getSavedPageData(stableUrl),
+    ]);
+    return {
+      existingHighlights: this._normalizeHighlights(existingHighlightsRaw),
+      existingPageData,
+    };
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.stableUrl
+   * @param {string} params.legacyUrl
+   * @param {object|null} params.existingPageData
+   * @param {object|null} params.pageData
+   * @param {Array} params.legacyHighlights
+   * @param {Array} params.migratedHighlights
+   * @param {boolean} params.formatConverted
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _writeMigrationData({
+    stableUrl,
+    legacyUrl,
+    existingPageData,
+    pageData,
+    legacyHighlights,
+    migratedHighlights,
+    formatConverted,
+  }) {
+    const pageDataToWrite = this._resolveMigrationPageData(existingPageData, pageData);
+    this._logMigrationWriteStart({
+      stableUrl,
+      legacyUrl,
+      pageDataToWrite,
+      existingPageData,
+      legacyHighlights,
+      formatConverted,
+    });
+    await this._applyMigrationWriteAndCleanup(
+      stableUrl,
+      legacyUrl,
+      pageDataToWrite,
+      migratedHighlights
+    );
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.stableUrl
+   * @param {string} params.legacyUrl
+   * @param {object|null} params.pageDataToWrite
+   * @param {object|null} params.existingPageData
+   * @param {Array} params.legacyHighlights
+   * @param {boolean} params.formatConverted
+   * @returns {void}
+   * @private
+   */
+  _logMigrationWriteStart({
+    stableUrl,
+    legacyUrl,
+    pageDataToWrite,
+    existingPageData,
+    legacyHighlights,
+    formatConverted,
+  }) {
+    Logger.start('Migrating legacy data to stable URL', {
+      action: 'migrate:write-stable',
+      result: 'started',
+      legacy: sanitizeUrlForLogging(legacyUrl),
+      stable: sanitizeUrlForLogging(stableUrl),
+      hasPageData: Boolean(pageDataToWrite),
+      hasExistingPageData: Boolean(existingPageData),
+      hasHighlights: legacyHighlights.length > 0,
+      formatConverted,
+    });
   }
 
   /**
@@ -136,18 +269,26 @@ export class MigrationService {
   }
 
   /**
-   * 判斷目標 key 是否已有數據
+   * 判斷目標 key 是否已有 highlights
    *
    * @param {Array} existingHighlights - 目標已有標註
-   * @param {object|null} existingPageData - 目標已有頁面數據
-   * @returns {boolean} 是否已有數據
+   * @returns {boolean} 是否已有標註
    * @private
    */
-  _hasExistingData(existingHighlights, existingPageData) {
-    if (existingHighlights.length > 0) {
-      return true;
-    }
-    return Boolean(existingPageData);
+  _hasExistingHighlights(existingHighlights) {
+    return existingHighlights.length > 0;
+  }
+
+  /**
+   * stable side 只有 metadata 時，保留 stable metadata 並搬移 legacy highlights。
+   *
+   * @param {object|null} existingPageData - 目標已有頁面數據
+   * @param {object|null} pageData - 來源頁面數據
+   * @returns {object|null}
+   * @private
+   */
+  _resolveMigrationPageData(existingPageData, pageData) {
+    return existingPageData ?? pageData;
   }
 
   /**
@@ -158,6 +299,8 @@ export class MigrationService {
    * @param {string} params.legacyUrl - 來源舊版 URL
    * @param {object|null} params.existingPageData - 目標已有頁面數據
    * @param {object|null} params.pageData - 來源頁面數據
+   * @param {Array} params.existingHighlights - 目標已有標註
+   * @param {Array} params.migratedHighlights - 來源遷移後標註
    * @param {number} params.existingHighlightsCount - 目標已有標註數量
    * @returns {Promise<boolean>} 是否有補遷移 saved metadata
    * @private
@@ -167,8 +310,23 @@ export class MigrationService {
     legacyUrl,
     existingPageData,
     pageData,
+    existingHighlights,
+    migratedHighlights,
     existingHighlightsCount,
   }) {
+    if (this._areHighlightsEquivalent(existingHighlights, migratedHighlights)) {
+      await this._setUrlAliasSafe(legacyUrl, stableUrl);
+      const cleanupResult = await this._clearLegacyKeysForMigration(stableUrl, legacyUrl);
+      Logger.info('Migration stable data already present; completed legacy cleanup', {
+        action: 'migrate:cleanup-existing',
+        result: cleanupResult === MIGRATION_WRITE_RESULTS.SUCCESS ? 'success' : 'cleanup_needed',
+        stable: sanitizeUrlForLogging(stableUrl),
+        legacy: sanitizeUrlForLogging(legacyUrl),
+        existingHighlightsCount,
+      });
+      return true;
+    }
+
     const supplementedNotion = await this._supplementStableNotionIfNeeded({
       stableUrl,
       legacyUrl,
@@ -179,6 +337,8 @@ export class MigrationService {
     await this._setUrlAliasSafe(legacyUrl, stableUrl);
 
     Logger.warn('Migration target already has data, skipping highlight overwrite', {
+      action: 'migrate:skip-overwrite',
+      result: 'skipped',
       stable: sanitizeUrlForLogging(stableUrl),
       legacy: sanitizeUrlForLogging(legacyUrl),
       existingHighlightsCount,
@@ -195,7 +355,7 @@ export class MigrationService {
    * @param {string} legacyUrl - 來源舊版 URL
    * @param {object|null} pageData - 頁面數據
    * @param {Array} migratedHighlights - 遷移後標註
-   * @returns {Promise<void>}
+   * @returns {Promise<string>}
    * @private
    */
   async _applyMigrationWriteAndCleanup(stableUrl, legacyUrl, pageData, migratedHighlights) {
@@ -207,11 +367,106 @@ export class MigrationService {
     // 2. 刪除舊 Key（使用 clearLegacyKeys 避免誤刪新寫入的 stable URL key）
     // clearLegacyKeys 僅刪除 saved_<normalizedUrl> 和 highlights_<normalizedUrl>，
     // 不會呼叫 computeStableUrl，確保不會與新寫入的 stableUrl key 衝突
-    await this.storageService.clearLegacyKeys(legacyUrl);
+    const cleanupResult = await this._clearLegacyKeysForMigration(stableUrl, legacyUrl);
+    this._logMigrationWriteResult(stableUrl, cleanupResult);
+    return cleanupResult;
+  }
 
-    Logger.info('Migration successful', {
+  /**
+   * @param {string} stableUrl
+   * @param {string} cleanupResult
+   * @returns {void}
+   * @private
+   */
+  _logMigrationWriteResult(stableUrl, cleanupResult) {
+    if (cleanupResult !== MIGRATION_WRITE_RESULTS.SUCCESS) {
+      return;
+    }
+    Logger.success('Migration successful', {
+      action: 'migrate:write-cleanup',
+      result: 'success',
       url: sanitizeUrlForLogging(stableUrl),
     });
+  }
+
+  /**
+   * 清理 legacy key；stable write 已成功時，cleanup 失敗只留下可重試的 partial state。
+   *
+   * @param {string} stableUrl
+   * @param {string} legacyUrl
+   * @returns {Promise<string>}
+   * @private
+   */
+  async _clearLegacyKeysForMigration(stableUrl, legacyUrl) {
+    try {
+      await this.storageService.clearLegacyKeys(legacyUrl);
+      return MIGRATION_WRITE_RESULTS.SUCCESS;
+    } catch (error) {
+      Logger.warn('Migration stable write completed but legacy cleanup failed', {
+        action: 'migrate:clear-legacy',
+        result: 'failure',
+        stable: sanitizeUrlForLogging(stableUrl),
+        legacy: sanitizeUrlForLogging(legacyUrl),
+        error: error?.message ?? String(error),
+      });
+      return MIGRATION_WRITE_RESULTS.CLEANUP_NEEDED;
+    }
+  }
+
+  /**
+   * 判斷 stable highlights 是否已是本次遷移結果，用於 retry cleanup。
+   *
+   * @param {Array} existingHighlights
+   * @param {Array} migratedHighlights
+   * @returns {boolean}
+   * @private
+   */
+  _areHighlightsEquivalent(existingHighlights, migratedHighlights) {
+    if (
+      existingHighlights.length === 0 ||
+      existingHighlights.length !== migratedHighlights.length
+    ) {
+      return false;
+    }
+
+    const existingIds = this._extractHighlightIds(existingHighlights);
+    const migratedIds = this._extractHighlightIds(migratedHighlights);
+    if (existingIds && migratedIds) {
+      return this._haveSameHighlightIds(existingIds, migratedIds);
+    }
+
+    try {
+      return JSON.stringify(existingHighlights) === JSON.stringify(migratedHighlights);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * @param {Array} highlights
+   * @returns {string[]|null}
+   * @private
+   */
+  _extractHighlightIds(highlights) {
+    const ids = highlights.map(highlight => highlight?.id);
+    if (ids.every(id => typeof id === 'string' && id.length > 0)) {
+      return ids;
+    }
+    return null;
+  }
+
+  /**
+   * @param {string[]} firstIds
+   * @param {string[]} secondIds
+   * @returns {boolean}
+   * @private
+   */
+  _haveSameHighlightIds(firstIds, secondIds) {
+    const secondSet = new Set(secondIds);
+    if (secondSet.size !== firstIds.length) {
+      return false;
+    }
+    return firstIds.every(id => secondSet.has(id));
   }
 
   /**
@@ -240,6 +495,8 @@ export class MigrationService {
     if (this._shouldSupplement(hasStableNotion, hasLegacyNotion)) {
       await this.storageService.setSavedPageData(stableUrl, legacySavedData);
       Logger.info(logMessages.supplemented ?? 'Supplemented notion metadata on stable URL', {
+        action: logContext.action ?? 'migrate:supplement-notion',
+        result: 'success',
         stable: sanitizeUrlForLogging(stableUrl),
         legacy: sanitizeUrlForLogging(legacyUrl),
         ...logContext,
@@ -252,6 +509,9 @@ export class MigrationService {
       Logger.warn(
         logMessages.conflict ?? 'Stable/legacy notion metadata conflict, keeping stable data',
         {
+          action: logContext.action ?? 'migrate:supplement-notion',
+          result: 'skipped',
+          reason: 'notion_conflict',
           stable: sanitizeUrlForLogging(stableUrl),
           legacy: sanitizeUrlForLogging(legacyUrl),
           ...logContext,
@@ -308,13 +568,24 @@ export class MigrationService {
     if (typeof this.storageService.setUrlAlias !== 'function') {
       return;
     }
-    await Promise.resolve(this.storageService.setUrlAlias(legacyUrl, stableUrl)).catch(error => {
-      Logger.warn('Failed to set URL alias during migration', {
-        legacy: sanitizeUrlForLogging(legacyUrl),
-        stable: sanitizeUrlForLogging(stableUrl),
-        error: error?.message ?? String(error),
+    await Promise.resolve(this.storageService.setUrlAlias(legacyUrl, stableUrl))
+      .then(() => {
+        Logger.info('Set URL alias during migration', {
+          action: 'migrate:set-alias',
+          result: 'success',
+          legacy: sanitizeUrlForLogging(legacyUrl),
+          stable: sanitizeUrlForLogging(stableUrl),
+        });
+      })
+      .catch(error => {
+        Logger.warn('Failed to set URL alias during migration', {
+          action: 'migrate:set-alias',
+          result: 'failure',
+          legacy: sanitizeUrlForLogging(legacyUrl),
+          stable: sanitizeUrlForLogging(stableUrl),
+          error: error?.message ?? String(error),
+        });
       });
-    });
   }
 
   /**
@@ -367,6 +638,8 @@ export class MigrationService {
 
     if (typeof formatConverter !== 'function') {
       Logger.warn('convertFormat enabled without a valid formatConverter, skipping conversion', {
+        action: 'migrate:convert-format',
+        result: 'skipped',
         stable: sanitizeUrlForLogging(stableUrl),
         legacy: sanitizeUrlForLogging(legacyUrl),
       });
@@ -416,8 +689,9 @@ export class MigrationService {
         return { success: false, error: ERROR_MESSAGES.USER_MESSAGES.MISSING_URL };
       }
 
-      Logger.log('Starting migration', {
+      Logger.start('Starting migration', {
         action: 'executeContentMigration',
+        result: 'started',
         url: sanitizeUrlForLogging(url),
       });
 
@@ -442,7 +716,11 @@ export class MigrationService {
       return this._formatMigrationSuccessResponse(url, stats);
     } catch (error) {
       const errorMsg = error?.message ?? String(error);
-      Logger.error('Migration failed', { action: 'executeContentMigration', error: errorMsg });
+      Logger.error('Migration failed', {
+        action: 'executeContentMigration',
+        result: 'failure',
+        error: errorMsg,
+      });
       throw error; // Re-throw to let handler handle the error response format
     } finally {
       // 5. Cleanup
@@ -464,10 +742,14 @@ export class MigrationService {
     const existingTab = tabs.find(tab => tab.url === url);
 
     if (existingTab) {
-      Logger.log('Using existing tab', {
+      Logger.info('Using existing tab', {
         action: 'executeContentMigration',
+        result: 'success',
         tabId: existingTab.id,
       });
+      if (existingTab.status !== 'complete') {
+        await this.tabService.waitForTabComplete(existingTab.id);
+      }
       return { tab: existingTab, createdTabId: null };
     }
 
@@ -475,7 +757,11 @@ export class MigrationService {
       url,
       active: false,
     });
-    Logger.log('Created new tab', { action: 'executeContentMigration', tabId: newTab.id });
+    Logger.info('Created new tab', {
+      action: 'executeContentMigration',
+      result: 'success',
+      tabId: newTab.id,
+    });
 
     // Wait for tab to load if not already complete
     // 即使 createTab 返回時 status 為 complete，仍建議確保其內容腳本環境準備就緒
@@ -494,8 +780,9 @@ export class MigrationService {
    * @private
    */
   async _injectAndVerifyExecutor(tabId) {
-    Logger.log('Injecting migration executor', {
+    Logger.start('Injecting migration executor', {
       action: 'executeContentMigration',
+      result: 'started',
       tabId,
     });
     await this.injectionService.injectAndExecute(tabId, ['dist/migration-executor.js'], null, {
@@ -514,8 +801,9 @@ export class MigrationService {
    * @private
    */
   async _runPageMigration(tabId) {
-    Logger.log('Executing DOM migration', {
+    Logger.start('Executing DOM migration', {
       action: 'executeContentMigration',
+      result: 'started',
       tabId,
     });
     const migrationResult = await this.injectionService.injectWithResponse(
@@ -590,8 +878,9 @@ export class MigrationService {
    * @private
    */
   _formatMigrationSuccessResponse(url, stats) {
-    Logger.log('Migration completed', {
+    Logger.success('Migration completed', {
       action: 'executeContentMigration',
+      result: 'success',
       url: sanitizeUrlForLogging(url),
       ...stats,
     });
@@ -613,7 +902,11 @@ export class MigrationService {
    */
   async _cleanupMigrationTabSafe(createdTabId) {
     if (createdTabId) {
-      Logger.log('Closing tab', { action: 'executeContentMigration', tabId: createdTabId });
+      Logger.info('Closing tab', {
+        action: 'executeContentMigration',
+        result: 'success',
+        tabId: createdTabId,
+      });
       await this.tabService.removeTab(createdTabId).catch(() => {});
     }
   }
@@ -725,19 +1018,22 @@ export class MigrationService {
   async _buildStorageSnapshot(url) {
     const stableUrl = computeStableUrl(url);
     const hasStableUrl = this._hasStableUrlCandidate(url, stableUrl);
-    const [legacyData, stableData] = await Promise.all([
+    const [legacyData, stableData, stableSavedData] = await Promise.all([
       this.storageService.getHighlights(url),
       hasStableUrl ? this.storageService.getHighlights(stableUrl) : Promise.resolve(null),
+      hasStableUrl ? this.storageService.getSavedPageData(stableUrl) : Promise.resolve(null),
     ]);
-    const shouldMigrateToStable = this._shouldMigrateSnapshotToStable(hasStableUrl, stableData);
+    const shouldMigrateToStable = this._shouldMigrateSnapshotToStable(
+      hasStableUrl,
+      stableData,
+      stableSavedData
+    );
 
     return {
       stableUrl,
       hasStableUrl,
       legacyData,
-      // 僅在 stable key 完全不存在時（null）才遷移。
-      // 若 stable 已有資料（即使是 []），不應覆蓋——
-      // 這樣可以區分「stable 鍵未設定」和「highlights 已清空」兩種語義。
+      // stable key 不存在，或 stable side 只有 saved metadata 且無 highlights 時才遷移。
       shouldMigrateToStable,
     };
   }
@@ -762,14 +1058,19 @@ export class MigrationService {
    *
    * @param {boolean} hasStableUrl
    * @param {any} stableData
+   * @param {object|null} stableSavedData
    * @returns {boolean}
    * @private
    */
-  _shouldMigrateSnapshotToStable(hasStableUrl, stableData) {
+  _shouldMigrateSnapshotToStable(hasStableUrl, stableData, stableSavedData = null) {
     if (!hasStableUrl) {
       return false;
     }
-    return stableData == null;
+    if (stableData == null) {
+      return true;
+    }
+    const stableHighlights = this._normalizeHighlights(stableData);
+    return stableHighlights.length === 0 && Boolean(stableSavedData);
   }
 
   /**
@@ -930,6 +1231,7 @@ export class MigrationService {
     } catch (error) {
       Logger.warn('遷移至穩定 URL 失敗，回退為原地轉換', {
         action: 'migration_batch',
+        result: 'failure',
         url: sanitizeUrlForLogging(url),
         error: error?.message ?? String(error),
       });

--- a/scripts/background/services/MigrationService.js
+++ b/scripts/background/services/MigrationService.js
@@ -27,14 +27,10 @@ export class MigrationService {
    * @param {string} stableUrl - 新的穩定 URL (目標 Key)
    * @param {string} legacyUrl - 舊的 URL (來源 Key)
    * @param {object} [options={}] - 遷移選項
-   * @param {boolean} [options.convertFormat=false] - 是否在遷移時轉換 highlights 格式
-   * @param {Function|null} [options.formatConverter=null] - highlights 格式轉換函式（可為 sync 或 async）
    * @returns {Promise<boolean>} - 是否執行了遷移
    */
   async migrateStorageKey(stableUrl, legacyUrl, options = {}) {
-    const { convertFormat = false, formatConverter = null } = options;
-
-    if (!stableUrl || !legacyUrl || stableUrl === legacyUrl) {
+    if (this._isInvalidMigrationTarget(stableUrl, legacyUrl)) {
       return false;
     }
 
@@ -56,7 +52,7 @@ export class MigrationService {
       const legacyHighlights = this._normalizeHighlights(legacyHighlightsRaw);
 
       // 兩者皆無 → 不需遷移
-      if (!pageData && legacyHighlights.length === 0) {
+      if (this._isNoDataToMigrate(pageData, legacyHighlights)) {
         return false;
       }
 
@@ -66,30 +62,20 @@ export class MigrationService {
         this.storageService.getSavedPageData(stableUrl),
       ]);
       const existingHighlights = this._normalizeHighlights(existingHighlightsRaw);
-      if (existingHighlights.length > 0 || existingPageData) {
-        const supplementedNotion = await this._supplementStableNotionIfNeeded({
+      if (this._hasExistingData(existingHighlights, existingPageData)) {
+        return this._handleMigrationTargetConflict({
           stableUrl,
           legacyUrl,
-          stableSavedData: existingPageData,
-          legacySavedData: pageData,
-        });
-
-        await this._setUrlAliasSafe(legacyUrl, stableUrl);
-
-        Logger.warn('Migration target already has data, skipping highlight overwrite', {
-          stable: sanitizeUrlForLogging(stableUrl),
-          legacy: sanitizeUrlForLogging(legacyUrl),
+          existingPageData,
+          pageData,
           existingHighlightsCount: existingHighlights.length,
-          hasExistingPageData: Boolean(existingPageData),
-          supplementedNotion,
         });
-        return supplementedNotion;
       }
 
       const { migratedHighlights, formatConverted } = await this._resolveMigratedHighlights({
         highlights: legacyHighlights,
-        convertFormat,
-        formatConverter,
+        convertFormat: options.convertFormat,
+        formatConverter: options.formatConverter,
         stableUrl,
         legacyUrl,
       });
@@ -102,19 +88,7 @@ export class MigrationService {
         formatConverted,
       });
 
-      // 1. 原子寫入新 Key（全部成功後才刪除舊 key）
-      await this.storageService.savePageDataAndHighlights(stableUrl, pageData, migratedHighlights);
-
-      await this._setUrlAliasSafe(legacyUrl, stableUrl);
-
-      // 2. 刪除舊 Key（使用 clearLegacyKeys 避免誤刪新寫入的 stable URL key）
-      // clearLegacyKeys 僅刪除 saved_<normalizedUrl> 和 highlights_<normalizedUrl>，
-      // 不會呼叫 computeStableUrl，確保不會與新寫入的 stableUrl key 衝突
-      await this.storageService.clearLegacyKeys(legacyUrl);
-
-      Logger.info('Migration successful', {
-        url: sanitizeUrlForLogging(stableUrl),
-      });
+      await this._applyMigrationWriteAndCleanup(stableUrl, legacyUrl, pageData, migratedHighlights);
 
       return true;
     } catch (error) {
@@ -129,14 +103,114 @@ export class MigrationService {
   }
 
   /**
+   * 判斷是否為無效的遷移目標
+   *
+   * @param {string} stableUrl - 目標穩定 URL
+   * @param {string} legacyUrl - 來源舊版 URL
+   * @returns {boolean} 是否無效
+   * @private
+   */
+  _isInvalidMigrationTarget(stableUrl, legacyUrl) {
+    return !stableUrl || !legacyUrl || stableUrl === legacyUrl;
+  }
+
+  /**
+   * 判斷是否無數據需要遷移
+   *
+   * @param {object|null} pageData - 頁面數據
+   * @param {Array} legacyHighlights - 標註數據
+   * @returns {boolean} 是否無數據
+   * @private
+   */
+  _isNoDataToMigrate(pageData, legacyHighlights) {
+    return !pageData && legacyHighlights.length === 0;
+  }
+
+  /**
+   * 判斷目標 key 是否已有數據
+   *
+   * @param {Array} existingHighlights - 目標已有標註
+   * @param {object|null} existingPageData - 目標已有頁面數據
+   * @returns {boolean} 是否已有數據
+   * @private
+   */
+  _hasExistingData(existingHighlights, existingPageData) {
+    return existingHighlights.length > 0 || existingPageData;
+  }
+
+  /**
+   * 處理遷移目標已有數據之衝突（輔助函式）
+   *
+   * @param {object} params - 參數對象
+   * @param {string} params.stableUrl - 目標穩定 URL
+   * @param {string} params.legacyUrl - 來源舊版 URL
+   * @param {object|null} params.existingPageData - 目標已有頁面數據
+   * @param {object|null} params.pageData - 來源頁面數據
+   * @param {number} params.existingHighlightsCount - 目標已有標註數量
+   * @returns {Promise<boolean>} 是否有補遷移 saved metadata
+   * @private
+   */
+  async _handleMigrationTargetConflict({
+    stableUrl,
+    legacyUrl,
+    existingPageData,
+    pageData,
+    existingHighlightsCount,
+  }) {
+    const supplementedNotion = await this._supplementStableNotionIfNeeded({
+      stableUrl,
+      legacyUrl,
+      stableSavedData: existingPageData,
+      legacySavedData: pageData,
+    });
+
+    await this._setUrlAliasSafe(legacyUrl, stableUrl);
+
+    Logger.warn('Migration target already has data, skipping highlight overwrite', {
+      stable: sanitizeUrlForLogging(stableUrl),
+      legacy: sanitizeUrlForLogging(legacyUrl),
+      existingHighlightsCount,
+      hasExistingPageData: Boolean(existingPageData),
+      supplementedNotion,
+    });
+    return supplementedNotion;
+  }
+
+  /**
+   * 執行遷移數據寫入與清除舊 Key（輔助函式）
+   *
+   * @param {string} stableUrl - 目標穩定 URL
+   * @param {string} legacyUrl - 來源舊版 URL
+   * @param {object|null} pageData - 頁面數據
+   * @param {Array} migratedHighlights - 遷移後標註
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _applyMigrationWriteAndCleanup(stableUrl, legacyUrl, pageData, migratedHighlights) {
+    // 1. 原子寫入新 Key（全部成功後才刪除舊 key）
+    await this.storageService.savePageDataAndHighlights(stableUrl, pageData, migratedHighlights);
+
+    await this._setUrlAliasSafe(legacyUrl, stableUrl);
+
+    // 2. 刪除舊 Key（使用 clearLegacyKeys 避免誤刪新寫入的 stable URL key）
+    // clearLegacyKeys 僅刪除 saved_<normalizedUrl> 和 highlights_<normalizedUrl>，
+    // 不會呼叫 computeStableUrl，確保不會與新寫入的 stableUrl key 衝突
+    await this.storageService.clearLegacyKeys(legacyUrl);
+
+    Logger.info('Migration successful', {
+      url: sanitizeUrlForLogging(stableUrl),
+    });
+  }
+
+  /**
    * stable 已有 highlights 時，只補 notion metadata（不覆寫 highlights）
    *
-   * @param {object} params
-   * @param {string} params.stableUrl
-   * @param {string} params.legacyUrl
-   * @param {object|null} params.stableSavedData
-   * @param {object|null} params.legacySavedData
-   * @param {object} [options={}]
+   * @param {object} params - 參數對象
+   * @param {string} params.stableUrl - 目標穩定 URL
+   * @param {string} params.legacyUrl - 來源舊版 URL
+   * @param {object|null} params.stableSavedData - 目標頁面數據
+   * @param {object|null} params.legacySavedData - 來源頁面數據
+   * @param {object} [options={}] - 其他選項
    * @param {object} [options.logContext={}] - 額外日志上下文
    * @param {object} [options.logMessages={}] - 自訂日志文案
    * @param {string} [options.logMessages.supplemented] - 補遷移成功文案
@@ -147,17 +221,13 @@ export class MigrationService {
   async _supplementStableNotionIfNeeded(params, options = {}) {
     const { stableUrl, legacyUrl, stableSavedData, legacySavedData } = params;
     const { logContext = {}, logMessages = {} } = options;
-    const supplementedMessage =
-      logMessages.supplemented ?? 'Supplemented notion metadata on stable URL';
-    const conflictMessage =
-      logMessages.conflict ?? 'Stable/legacy notion metadata conflict, keeping stable data';
 
     const hasStableNotion = hasNotionData(stableSavedData);
     const hasLegacyNotion = hasNotionData(legacySavedData);
 
-    if (!hasStableNotion && hasLegacyNotion) {
+    if (this._shouldSupplement(hasStableNotion, hasLegacyNotion)) {
       await this.storageService.setSavedPageData(stableUrl, legacySavedData);
-      Logger.info(supplementedMessage, {
+      Logger.info(logMessages.supplemented || 'Supplemented notion metadata on stable URL', {
         stable: sanitizeUrlForLogging(stableUrl),
         legacy: sanitizeUrlForLogging(legacyUrl),
         ...logContext,
@@ -166,22 +236,50 @@ export class MigrationService {
     }
 
     const samePage = isSameNotionPage(stableSavedData, legacySavedData);
-    if (hasStableNotion && hasLegacyNotion && samePage === false) {
-      Logger.warn(conflictMessage, {
-        stable: sanitizeUrlForLogging(stableUrl),
-        legacy: sanitizeUrlForLogging(legacyUrl),
-        ...logContext,
-      });
+    if (this._hasConflict(hasStableNotion, hasLegacyNotion, samePage)) {
+      Logger.warn(
+        logMessages.conflict || 'Stable/legacy notion metadata conflict, keeping stable data',
+        {
+          stable: sanitizeUrlForLogging(stableUrl),
+          legacy: sanitizeUrlForLogging(legacyUrl),
+          ...logContext,
+        }
+      );
     }
 
     return false;
   }
 
   /**
+   * 判斷是否需要補 Notion 詮釋數據
+   *
+   * @param {boolean} hasStable - 目標是否有 Notion 數據
+   * @param {boolean} hasLegacy - 來源是否有 Notion 數據
+   * @returns {boolean} 是否需要補詮釋數據
+   * @private
+   */
+  _shouldSupplement(hasStable, hasLegacy) {
+    return !hasStable && hasLegacy;
+  }
+
+  /**
+   * 判斷 Notion 詮釋數據是否衝突
+   *
+   * @param {boolean} hasStable - 目標是否有 Notion 數據
+   * @param {boolean} hasLegacy - 來源是否有 Notion 數據
+   * @param {boolean} samePage - 是否為相同頁面
+   * @returns {boolean} 是否衝突
+   * @private
+   */
+  _hasConflict(hasStable, hasLegacy, samePage) {
+    return hasStable && hasLegacy && samePage === false;
+  }
+
+  /**
    * 設定 url_alias（失敗不阻斷主流程）
    *
-   * @param {string} legacyUrl
-   * @param {string} stableUrl
+   * @param {string} legacyUrl - 來源舊版 URL
+   * @param {string} stableUrl - 目標穩定 URL
    * @returns {Promise<void>}
    * @private
    */
@@ -287,114 +385,192 @@ export class MigrationService {
       }
 
       // 2. Find or create tab
-      // 使用 queryTabs({}) 獲取所有 tabs 後手動過濾，避免 chrome.tabs.query({ url }) 的 match patterns 行為
-      // 導致特殊字符 URL 匹配失敗或誤匹配
-      const tabs = await this.tabService.queryTabs({});
-      let targetTab = tabs.find(tab => tab.url === url);
+      const tabResolution = await this._resolveMigrationTab(url);
+      const targetTab = tabResolution.tab;
+      createdTabId = tabResolution.createdTabId;
 
-      if (targetTab) {
-        Logger.log('Using existing tab', {
-          action: 'executeContentMigration',
-          tabId: targetTab.id,
-        });
-      } else {
-        targetTab = await this.tabService.createTab({
-          url,
-          active: false,
-        });
-        createdTabId = targetTab.id;
-        Logger.log('Created new tab', { action: 'executeContentMigration', tabId: targetTab.id });
-
-        // Wait for tab to load if not already complete
-        // 即使 createTab 返回時 status 為 complete，仍建議確保其內容腳本環境準備就緒
-        if (targetTab.status !== 'complete') {
-          await this.tabService.waitForTabComplete(targetTab.id);
-        }
-      }
-
-      // 3. Inject migration-executor.js using InjectionService
-      // We rely on InjectionService to handle the injection details
-      Logger.log('Injecting migration executor', {
-        action: 'executeContentMigration',
-        tabId: targetTab.id,
-      });
-      await this.injectionService.injectAndExecute(
-        targetTab.id,
-        ['dist/migration-executor.js'],
-        null,
-        { errorMessage: 'Failed to inject migration executor' }
-      );
-
-      // Wait for script readiness
-      await this._waitForScriptReady(targetTab.id);
+      // 3. Inject migration-executor.js and wait for readiness
+      await this._injectAndVerifyExecutor(targetTab.id);
 
       // 4. Execute migration
-      Logger.log('Executing DOM migration', {
-        action: 'executeContentMigration',
-        tabId: targetTab.id,
-      });
-      const migrationResult = await this.injectionService.injectWithResponse(
-        targetTab.id,
-        async (executorErrorMsg, managerErrorMsg) => {
-          // Execute in page context
-          if (!globalThis.MigrationExecutor) {
-            return { error: executorErrorMsg };
-          }
+      const stats = await this._runPageMigration(targetTab.id);
 
-          if (!globalThis.HighlighterV2?.manager) {
-            return { error: managerErrorMsg };
-          }
-
-          const executor = new globalThis.MigrationExecutor();
-          const manager = globalThis.HighlighterV2.manager;
-
-          const outcome = await executor.migrate(manager);
-          const stats = executor.getStatistics();
-
-          return {
-            success: true,
-            result: outcome,
-            statistics: stats,
-          };
-        },
-        [],
-        [
-          ERROR_MESSAGES.USER_MESSAGES.MIGRATION_EXECUTOR_NOT_LOADED,
-          ERROR_MESSAGES.USER_MESSAGES.HIGHLIGHTER_MANAGER_NOT_INITIALIZED,
-        ]
-      );
-
-      if (migrationResult?.error) {
-        throw new Error(migrationResult.error);
-      }
-      const migrationExecutionError = this._resolveMigrationExecutionError(migrationResult);
-      if (migrationExecutionError) {
-        throw new Error(migrationExecutionError);
-      }
-
-      const stats = migrationResult?.statistics || {};
-      Logger.log('Migration completed', {
-        action: 'executeContentMigration',
-        url: sanitizeUrlForLogging(url),
-        ...stats,
-      });
-
-      return {
-        success: true,
-        count: stats.newHighlightsCreated || 0,
-        message: `Successfully migrated ${stats.newHighlightsCreated || 0} highlights`,
-        statistics: stats,
-      };
+      return this._formatMigrationSuccessResponse(url, stats);
     } catch (error) {
       const errorMsg = error?.message ?? String(error);
       Logger.error('Migration failed', { action: 'executeContentMigration', error: errorMsg });
       throw error; // Re-throw to let handler handle the error response format
     } finally {
       // 5. Cleanup
-      if (createdTabId) {
-        Logger.log('Closing tab', { action: 'executeContentMigration', tabId: createdTabId });
-        await this.tabService.removeTab(createdTabId).catch(() => {});
-      }
+      await this._cleanupMigrationTabSafe(createdTabId);
+    }
+  }
+
+  /**
+   * 取得或建立用於遷移的分頁（輔助函式）
+   *
+   * @param {string} url - 目標遷移網址
+   * @returns {Promise<{ tab: object, createdTabId: number|null }>} 包含分頁對象與新建分頁 ID
+   * @private
+   */
+  async _resolveMigrationTab(url) {
+    // 使用 queryTabs({}) 獲取所有 tabs 後手動過濾，避免 chrome.tabs.query({ url }) 的 match patterns 行為
+    // 導致特殊字符 URL 匹配失敗或誤匹配
+    const tabs = await this.tabService.queryTabs({});
+    const existingTab = tabs.find(tab => tab.url === url);
+
+    if (existingTab) {
+      Logger.log('Using existing tab', {
+        action: 'executeContentMigration',
+        tabId: existingTab.id,
+      });
+      return { tab: existingTab, createdTabId: null };
+    }
+
+    const newTab = await this.tabService.createTab({
+      url,
+      active: false,
+    });
+    Logger.log('Created new tab', { action: 'executeContentMigration', tabId: newTab.id });
+
+    // Wait for tab to load if not already complete
+    // 即使 createTab 返回時 status 為 complete，仍建議確保其內容腳本環境準備就緒
+    if (newTab.status !== 'complete') {
+      await this.tabService.waitForTabComplete(newTab.id);
+    }
+
+    return { tab: newTab, createdTabId: newTab.id };
+  }
+
+  /**
+   * 注入並驗證 migration-executor（輔助函式）
+   *
+   * @param {number} tabId - 分頁 ID
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _injectAndVerifyExecutor(tabId) {
+    Logger.log('Injecting migration executor', {
+      action: 'executeContentMigration',
+      tabId,
+    });
+    await this.injectionService.injectAndExecute(tabId, ['dist/migration-executor.js'], null, {
+      errorMessage: 'Failed to inject migration executor',
+    });
+
+    // Wait for script readiness
+    await this._waitForScriptReady(tabId);
+  }
+
+  /**
+   * 在頁面端執行 DOM 遷移（輔助函式）
+   *
+   * @param {number} tabId - 分頁 ID
+   * @returns {Promise<object>} 頁面端返回之統計數據
+   * @private
+   */
+  async _runPageMigration(tabId) {
+    Logger.log('Executing DOM migration', {
+      action: 'executeContentMigration',
+      tabId,
+    });
+    const migrationResult = await this.injectionService.injectWithResponse(
+      tabId,
+      MigrationService._executeMigrationInPage,
+      [],
+      [
+        ERROR_MESSAGES.USER_MESSAGES.MIGRATION_EXECUTOR_NOT_LOADED,
+        ERROR_MESSAGES.USER_MESSAGES.HIGHLIGHTER_MANAGER_NOT_INITIALIZED,
+      ]
+    );
+
+    return this._extractSuccessfulMigrationStats(migrationResult);
+  }
+
+  /**
+   * 在頁面 context 中執行 DOM 遷移。此函式會被 chrome scripting 序列化，必須保持自足。
+   *
+   * @param {string} executorErrorMsg - executor 未載入時的錯誤訊息
+   * @param {string} managerErrorMsg - highlighter manager 未初始化時的錯誤訊息
+   * @returns {Promise<object>} 頁面端遷移結果
+   * @private
+   */
+  static async _executeMigrationInPage(executorErrorMsg, managerErrorMsg) {
+    if (!globalThis.MigrationExecutor) {
+      return { error: executorErrorMsg };
+    }
+
+    if (!globalThis.HighlighterV2?.manager) {
+      return { error: managerErrorMsg };
+    }
+
+    const executor = new globalThis.MigrationExecutor();
+    const manager = globalThis.HighlighterV2.manager;
+
+    const outcome = await executor.migrate(manager);
+    const stats = executor.getStatistics();
+
+    return {
+      success: true,
+      result: outcome,
+      statistics: stats,
+    };
+  }
+
+  /**
+   * 驗證頁面端遷移結果並取出統計數據。
+   *
+   * @param {object} migrationResult - 頁面端遷移結果
+   * @returns {object} 遷移統計數據
+   * @throws {Error} 當頁面端回傳錯誤或 rollback 結果時拋出
+   * @private
+   */
+  _extractSuccessfulMigrationStats(migrationResult) {
+    if (migrationResult?.error) {
+      throw new Error(migrationResult.error);
+    }
+    const migrationExecutionError = this._resolveMigrationExecutionError(migrationResult);
+    if (migrationExecutionError) {
+      throw new Error(migrationExecutionError);
+    }
+
+    return migrationResult?.statistics || {};
+  }
+
+  /**
+   * 格式化成功的遷移響應結果（輔助函式）
+   *
+   * @param {string} url - 遷移目標網址
+   * @param {object} stats - 遷移統計數據
+   * @returns {object} 響應結果
+   * @private
+   */
+  _formatMigrationSuccessResponse(url, stats) {
+    Logger.log('Migration completed', {
+      action: 'executeContentMigration',
+      url: sanitizeUrlForLogging(url),
+      ...stats,
+    });
+
+    return {
+      success: true,
+      count: stats.newHighlightsCreated || 0,
+      message: `Successfully migrated ${stats.newHighlightsCreated || 0} highlights`,
+      statistics: stats,
+    };
+  }
+
+  /**
+   * 安全關閉為遷移而建立的分頁（輔助函式）
+   *
+   * @param {number|null} createdTabId - 建立的分頁 ID
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _cleanupMigrationTabSafe(createdTabId) {
+    if (createdTabId) {
+      Logger.log('Closing tab', { action: 'executeContentMigration', tabId: createdTabId });
+      await this.tabService.removeTab(createdTabId).catch(() => {});
     }
   }
 

--- a/scripts/background/services/MigrationService.js
+++ b/scripts/background/services/MigrationService.js
@@ -14,6 +14,11 @@ const MIGRATION_WRITE_RESULTS = Object.freeze({
   CLEANUP_NEEDED: 'cleanup_needed',
 });
 
+const MIGRATION_CONFLICT_RESULTS = Object.freeze({
+  STABLE_KEPT: 'stable_kept',
+  SUPPLEMENTED: 'supplemented',
+});
+
 /**
  * Migration 服務
  * 負責處理跨版本升級的數據遷移與初始化
@@ -127,7 +132,7 @@ export class MigrationService {
     });
 
     if (this._hasExistingHighlights(existingHighlights)) {
-      return this._handleMigrationTargetConflict({
+      const conflictResult = await this._handleMigrationTargetConflict({
         stableUrl,
         legacyUrl,
         existingPageData,
@@ -136,6 +141,7 @@ export class MigrationService {
         migratedHighlights,
         existingHighlightsCount: existingHighlights.length,
       });
+      return Boolean(conflictResult);
     }
 
     await this._writeMigrationData({
@@ -302,7 +308,7 @@ export class MigrationService {
    * @param {Array} params.existingHighlights - 目標已有標註
    * @param {Array} params.migratedHighlights - 來源遷移後標註
    * @param {number} params.existingHighlightsCount - 目標已有標註數量
-   * @returns {Promise<boolean>} 是否有補遷移 saved metadata
+   * @returns {Promise<boolean|string>} 是否已完成衝突處理
    * @private
    */
   async _handleMigrationTargetConflict({
@@ -345,7 +351,9 @@ export class MigrationService {
       hasExistingPageData: Boolean(existingPageData),
       supplementedNotion,
     });
-    return supplementedNotion;
+    return supplementedNotion
+      ? MIGRATION_CONFLICT_RESULTS.SUPPLEMENTED
+      : MIGRATION_CONFLICT_RESULTS.STABLE_KEPT;
   }
 
   /**
@@ -432,14 +440,12 @@ export class MigrationService {
     const existingIds = this._extractHighlightIds(existingHighlights);
     const migratedIds = this._extractHighlightIds(migratedHighlights);
     if (existingIds && migratedIds) {
-      return this._haveSameHighlightIds(existingIds, migratedIds);
+      return this._haveSameHighlightIds(existingIds, migratedIds)
+        ? this._haveEquivalentHighlightPayloads(existingHighlights, migratedHighlights)
+        : false;
     }
 
-    try {
-      return JSON.stringify(existingHighlights) === JSON.stringify(migratedHighlights);
-    } catch {
-      return false;
-    }
+    return this._areValuesEquivalent(existingHighlights, migratedHighlights);
   }
 
   /**
@@ -467,6 +473,33 @@ export class MigrationService {
       return false;
     }
     return firstIds.every(id => secondSet.has(id));
+  }
+
+  /**
+   * @param {Array} existingHighlights
+   * @param {Array} migratedHighlights
+   * @returns {boolean}
+   * @private
+   */
+  _haveEquivalentHighlightPayloads(existingHighlights, migratedHighlights) {
+    const migratedById = new Map(migratedHighlights.map(highlight => [highlight.id, highlight]));
+    return existingHighlights.every(existingHighlight =>
+      this._areValuesEquivalent(existingHighlight, migratedById.get(existingHighlight.id))
+    );
+  }
+
+  /**
+   * @param {any} firstValue
+   * @param {any} secondValue
+   * @returns {boolean}
+   * @private
+   */
+  _areValuesEquivalent(firstValue, secondValue) {
+    try {
+      return JSON.stringify(firstValue) === JSON.stringify(secondValue);
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -568,7 +601,8 @@ export class MigrationService {
     if (typeof this.storageService.setUrlAlias !== 'function') {
       return;
     }
-    await Promise.resolve(this.storageService.setUrlAlias(legacyUrl, stableUrl))
+    await Promise.resolve()
+      .then(() => this.storageService.setUrlAlias(legacyUrl, stableUrl))
       .then(() => {
         Logger.info('Set URL alias during migration', {
           action: 'migrate:set-alias',
@@ -699,7 +733,7 @@ export class MigrationService {
       const data = await this.storageService.getHighlights(url);
 
       if (!data) {
-        return { success: true, message: 'No data to migrate' };
+        return { success: true, message: '沒有可遷移的資料' };
       }
 
       // 2. Find or create tab
@@ -888,7 +922,7 @@ export class MigrationService {
     return {
       success: true,
       count: stats.newHighlightsCreated ?? 0,
-      message: `Successfully migrated ${stats.newHighlightsCreated ?? 0} highlights`,
+      message: `已成功遷移 ${stats.newHighlightsCreated ?? 0} 筆標註`,
       statistics: stats,
     };
   }

--- a/scripts/background/services/MigrationService.js
+++ b/scripts/background/services/MigrationService.js
@@ -653,9 +653,8 @@ export class MigrationService {
           tabId,
           () => ({
             ready:
-              globalThis.MigrationExecutor === undefined
-                ? false
-                : globalThis.HighlighterV2?.manager !== undefined,
+              globalThis.MigrationExecutor !== undefined &&
+              globalThis.HighlighterV2?.manager !== undefined,
           }),
           [],
           []

--- a/scripts/background/services/MigrationService.js
+++ b/scripts/background/services/MigrationService.js
@@ -111,7 +111,13 @@ export class MigrationService {
    * @private
    */
   _isInvalidMigrationTarget(stableUrl, legacyUrl) {
-    return !stableUrl || !legacyUrl || stableUrl === legacyUrl;
+    if (!stableUrl) {
+      return true;
+    }
+    if (!legacyUrl) {
+      return true;
+    }
+    return stableUrl === legacyUrl;
   }
 
   /**
@@ -123,7 +129,10 @@ export class MigrationService {
    * @private
    */
   _isNoDataToMigrate(pageData, legacyHighlights) {
-    return !pageData && legacyHighlights.length === 0;
+    if (pageData) {
+      return false;
+    }
+    return legacyHighlights.length === 0;
   }
 
   /**
@@ -135,7 +144,10 @@ export class MigrationService {
    * @private
    */
   _hasExistingData(existingHighlights, existingPageData) {
-    return existingHighlights.length > 0 || existingPageData;
+    if (existingHighlights.length > 0) {
+      return true;
+    }
+    return Boolean(existingPageData);
   }
 
   /**
@@ -227,7 +239,7 @@ export class MigrationService {
 
     if (this._shouldSupplement(hasStableNotion, hasLegacyNotion)) {
       await this.storageService.setSavedPageData(stableUrl, legacySavedData);
-      Logger.info(logMessages.supplemented || 'Supplemented notion metadata on stable URL', {
+      Logger.info(logMessages.supplemented ?? 'Supplemented notion metadata on stable URL', {
         stable: sanitizeUrlForLogging(stableUrl),
         legacy: sanitizeUrlForLogging(legacyUrl),
         ...logContext,
@@ -238,7 +250,7 @@ export class MigrationService {
     const samePage = isSameNotionPage(stableSavedData, legacySavedData);
     if (this._hasConflict(hasStableNotion, hasLegacyNotion, samePage)) {
       Logger.warn(
-        logMessages.conflict || 'Stable/legacy notion metadata conflict, keeping stable data',
+        logMessages.conflict ?? 'Stable/legacy notion metadata conflict, keeping stable data',
         {
           stable: sanitizeUrlForLogging(stableUrl),
           legacy: sanitizeUrlForLogging(legacyUrl),
@@ -259,7 +271,10 @@ export class MigrationService {
    * @private
    */
   _shouldSupplement(hasStable, hasLegacy) {
-    return !hasStable && hasLegacy;
+    if (hasStable) {
+      return false;
+    }
+    return hasLegacy;
   }
 
   /**
@@ -272,7 +287,13 @@ export class MigrationService {
    * @private
    */
   _hasConflict(hasStable, hasLegacy, samePage) {
-    return hasStable && hasLegacy && samePage === false;
+    if (!hasStable) {
+      return false;
+    }
+    if (!hasLegacy) {
+      return false;
+    }
+    return samePage === false;
   }
 
   /**
@@ -310,7 +331,13 @@ export class MigrationService {
     if (Array.isArray(value)) {
       return value;
     }
-    if (value && typeof value === 'object' && Array.isArray(value.highlights)) {
+    if (!value) {
+      return [];
+    }
+    if (typeof value !== 'object') {
+      return [];
+    }
+    if (Array.isArray(value.highlights)) {
       return value.highlights;
     }
     return [];
@@ -334,8 +361,7 @@ export class MigrationService {
     stableUrl,
     legacyUrl,
   }) {
-    const canConvert = convertFormat && Array.isArray(highlights) && highlights.length > 0;
-    if (!canConvert) {
+    if (!this._hasHighlightsToConvert(convertFormat, highlights)) {
       return { migratedHighlights: highlights, formatConverted: false };
     }
 
@@ -353,6 +379,24 @@ export class MigrationService {
     }
 
     return { migratedHighlights, formatConverted: true };
+  }
+
+  /**
+   * 判斷是否有 highlights 需要格式轉換。
+   *
+   * @param {boolean} convertFormat - 是否啟用格式轉換
+   * @param {Array} highlights - 待遷移標註
+   * @returns {boolean} 是否需要轉換
+   * @private
+   */
+  _hasHighlightsToConvert(convertFormat, highlights) {
+    if (!convertFormat) {
+      return false;
+    }
+    if (!Array.isArray(highlights)) {
+      return false;
+    }
+    return highlights.length > 0;
   }
 
   /**
@@ -534,7 +578,7 @@ export class MigrationService {
       throw new Error(migrationExecutionError);
     }
 
-    return migrationResult?.statistics || {};
+    return migrationResult?.statistics ?? {};
   }
 
   /**
@@ -554,8 +598,8 @@ export class MigrationService {
 
     return {
       success: true,
-      count: stats.newHighlightsCreated || 0,
-      message: `Successfully migrated ${stats.newHighlightsCreated || 0} highlights`,
+      count: stats.newHighlightsCreated ?? 0,
+      message: `Successfully migrated ${stats.newHighlightsCreated ?? 0} highlights`,
       statistics: stats,
     };
   }
@@ -609,8 +653,9 @@ export class MigrationService {
           tabId,
           () => ({
             ready:
-              globalThis.MigrationExecutor !== undefined &&
-              globalThis.HighlighterV2?.manager !== undefined,
+              globalThis.MigrationExecutor === undefined
+                ? false
+                : globalThis.HighlighterV2?.manager !== undefined,
           }),
           [],
           []
@@ -680,11 +725,12 @@ export class MigrationService {
    */
   async _buildStorageSnapshot(url) {
     const stableUrl = computeStableUrl(url);
-    const hasStableUrl = Boolean(stableUrl && stableUrl !== url);
+    const hasStableUrl = this._hasStableUrlCandidate(url, stableUrl);
     const [legacyData, stableData] = await Promise.all([
       this.storageService.getHighlights(url),
       hasStableUrl ? this.storageService.getHighlights(stableUrl) : Promise.resolve(null),
     ]);
+    const shouldMigrateToStable = this._shouldMigrateSnapshotToStable(hasStableUrl, stableData);
 
     return {
       stableUrl,
@@ -693,8 +739,38 @@ export class MigrationService {
       // 僅在 stable key 完全不存在時（null）才遷移。
       // 若 stable 已有資料（即使是 []），不應覆蓋——
       // 這樣可以區分「stable 鍵未設定」和「highlights 已清空」兩種語義。
-      shouldMigrateToStable: Boolean(hasStableUrl && stableData == null),
+      shouldMigrateToStable,
     };
+  }
+
+  /**
+   * 判斷 URL 是否有不同於原始 URL 的 stable URL 候選。
+   *
+   * @param {string} originalUrl
+   * @param {string} stableUrl
+   * @returns {boolean}
+   * @private
+   */
+  _hasStableUrlCandidate(originalUrl, stableUrl) {
+    if (!stableUrl) {
+      return false;
+    }
+    return stableUrl !== originalUrl;
+  }
+
+  /**
+   * 判斷 storage snapshot 是否應遷移到 stable URL。
+   *
+   * @param {boolean} hasStableUrl
+   * @param {any} stableData
+   * @returns {boolean}
+   * @private
+   */
+  _shouldMigrateSnapshotToStable(hasStableUrl, stableData) {
+    if (!hasStableUrl) {
+      return false;
+    }
+    return stableData == null;
   }
 
   /**
@@ -768,7 +844,13 @@ export class MigrationService {
    * @private
    */
   _isValidStableAliasTarget(originalUrl, stableUrl) {
-    return Boolean(stableUrl && stableUrl !== originalUrl && !isRootUrl(stableUrl));
+    if (!stableUrl) {
+      return false;
+    }
+    if (stableUrl === originalUrl) {
+      return false;
+    }
+    return !isRootUrl(stableUrl);
   }
 
   /**

--- a/tests/unit/background/services/MigrationService.test.js
+++ b/tests/unit/background/services/MigrationService.test.js
@@ -13,6 +13,8 @@ jest.mock('../../../../scripts/utils/Logger.js', () => ({
     error: jest.fn(),
     warn: jest.fn(),
     log: jest.fn(),
+    start: jest.fn(),
+    success: jest.fn(),
   },
 }));
 
@@ -188,6 +190,101 @@ describe('MigrationService', () => {
       expect(mockStorageService.setSavedPageData).toHaveBeenCalledWith(stableUrl, pageData);
       expect(mockStorageService.savePageDataAndHighlights).not.toHaveBeenCalled();
       expect(mockStorageService.clearLegacyKeys).not.toHaveBeenCalled();
+    });
+
+    test('should migrate legacy highlights when stable side only has saved metadata', async () => {
+      const legacyHighlights = [{ id: 'legacy-highlight' }];
+      const stablePageData = { notionPageId: 'stable-page-id', title: 'Stable Page' };
+
+      mockStorageService.getSavedPageData.mockImplementation(url => {
+        if (url === legacyUrl) {
+          return Promise.resolve(pageData);
+        }
+        if (url === stableUrl) {
+          return Promise.resolve(stablePageData);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.getHighlights.mockImplementation(url => {
+        if (url === legacyUrl) {
+          return Promise.resolve(legacyHighlights);
+        }
+        if (url === stableUrl) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.savePageDataAndHighlights.mockResolvedValue();
+      mockStorageService.clearLegacyKeys.mockResolvedValue();
+
+      const result = await service.migrateStorageKey(stableUrl, legacyUrl);
+
+      expect(result).toBe(true);
+      expect(mockStorageService.savePageDataAndHighlights).toHaveBeenCalledWith(
+        stableUrl,
+        stablePageData,
+        legacyHighlights
+      );
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(legacyUrl);
+      expect(Logger.warn).not.toHaveBeenCalledWith(
+        'Migration target already has data, skipping highlight overwrite',
+        expect.anything()
+      );
+    });
+
+    test('should report partial migration when cleanup fails after stable write', async () => {
+      mockStorageService.getSavedPageData.mockImplementation(url =>
+        url === legacyUrl ? Promise.resolve(pageData) : Promise.resolve(null)
+      );
+      mockStorageService.getHighlights.mockResolvedValue(null);
+      mockStorageService.savePageDataAndHighlights.mockResolvedValue();
+      mockStorageService.clearLegacyKeys.mockRejectedValue(new Error('cleanup failed'));
+
+      const result = await service.migrateStorageKey(stableUrl, legacyUrl);
+
+      expect(result).toBe(true);
+      expect(mockStorageService.savePageDataAndHighlights).toHaveBeenCalledWith(
+        stableUrl,
+        pageData,
+        []
+      );
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Migration stable write completed but legacy cleanup failed',
+        expect.objectContaining({
+          action: 'migrate:clear-legacy',
+          result: 'failure',
+          error: 'cleanup failed',
+        })
+      );
+    });
+
+    test('should complete cleanup on retry when stable highlights already match migrated legacy highlights', async () => {
+      const legacyHighlights = [{ id: 'legacy-highlight', text: 'same' }];
+      const stablePageData = { notionPageId: 'stable-page-id' };
+
+      mockStorageService.getSavedPageData.mockImplementation(url => {
+        if (url === legacyUrl) {
+          return Promise.resolve(pageData);
+        }
+        return Promise.resolve(stablePageData);
+      });
+      mockStorageService.getHighlights.mockImplementation(url => {
+        if (url === legacyUrl) {
+          return Promise.resolve(legacyHighlights);
+        }
+        if (url === stableUrl) {
+          return Promise.resolve([...legacyHighlights]);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.clearLegacyKeys.mockResolvedValue();
+
+      const result = await service.migrateStorageKey(stableUrl, legacyUrl);
+
+      expect(result).toBe(true);
+      expect(mockStorageService.savePageDataAndHighlights).not.toHaveBeenCalled();
+      expect(mockStorageService.setUrlAlias).toHaveBeenCalledWith(legacyUrl, stableUrl);
+      expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(legacyUrl);
     });
 
     test('should log conflict warning when stable/legacy notion are determined as different pages', async () => {
@@ -560,6 +657,48 @@ describe('MigrationService', () => {
         pending: 0,
       });
     });
+
+    test('should migrate batch highlights when stable side only has saved metadata', async () => {
+      const { computeStableUrl } = require('../../../../scripts/utils/urlUtils.js');
+      const stableUrl = 'https://example.com/stable';
+      const oldHighlights = [{ id: 'legacy-3', rangeInfo: { start: 1 } }];
+      const stablePageData = { notionPageId: 'stable-page-id' };
+
+      computeStableUrl.mockReturnValueOnce(stableUrl);
+      mockStorageService.getHighlights.mockImplementation(lookupUrl => {
+        if (lookupUrl === url) {
+          return Promise.resolve(oldHighlights);
+        }
+        if (lookupUrl === stableUrl) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.getSavedPageData.mockImplementation(lookupUrl => {
+        if (lookupUrl === stableUrl) {
+          return Promise.resolve(stablePageData);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.savePageDataAndHighlights.mockResolvedValue();
+      mockStorageService.clearLegacyKeys.mockResolvedValue();
+      service._applyInPlaceConversion = jest.fn().mockResolvedValue();
+
+      const result = await service.migrateBatchUrl(url);
+
+      expect(result).toEqual({
+        status: 'success',
+        url: `safe://${stableUrl}`,
+        count: 1,
+        pending: 0,
+      });
+      expect(mockStorageService.savePageDataAndHighlights).toHaveBeenCalledWith(
+        stableUrl,
+        stablePageData,
+        [{ id: 'legacy-3', rangeInfo: { start: 1 }, needsRangeInfo: false }]
+      );
+      expect(service._applyInPlaceConversion).not.toHaveBeenCalled();
+    });
   });
 
   describe('_supplementBatchSavedMetadata', () => {
@@ -823,6 +962,30 @@ describe('MigrationService', () => {
         expect.anything()
       );
       expect(mockTabService.removeTab).not.toHaveBeenCalled();
+    });
+
+    test('should wait for an existing tab to complete before injecting migration executor', async () => {
+      const existingTab = { id: 889, status: 'loading', url: targetUrl };
+      mockStorageService.getHighlights.mockResolvedValue(['highlight1']);
+      mockTabService.queryTabs.mockResolvedValue([existingTab]);
+      mockInjectionService.injectAndExecute.mockResolvedValue();
+      mockInjectionService.injectWithResponse
+        .mockResolvedValueOnce({ ready: true })
+        .mockResolvedValueOnce({
+          success: true,
+          statistics: { newHighlightsCreated: 1 },
+        });
+
+      const result = await service.executeContentMigration({ url: targetUrl }, sender);
+
+      expect(result.success).toBe(true);
+      expect(mockTabService.waitForTabComplete).toHaveBeenCalledWith(existingTab.id);
+      expect(mockInjectionService.injectAndExecute).toHaveBeenCalledWith(
+        existingTab.id,
+        expect.arrayContaining(['dist/migration-executor.js']),
+        null,
+        expect.anything()
+      );
     });
 
     test('should create new tab if none exists and clean it up', async () => {

--- a/tests/unit/background/services/MigrationService.test.js
+++ b/tests/unit/background/services/MigrationService.test.js
@@ -14,6 +14,8 @@ jest.mock('../../../../scripts/utils/Logger.js', () => ({
     warn: jest.fn(),
     log: jest.fn(),
     start: jest.fn(),
+    ready: jest.fn(),
+    debug: jest.fn(),
     success: jest.fn(),
   },
 }));
@@ -287,6 +289,36 @@ describe('MigrationService', () => {
       expect(mockStorageService.clearLegacyKeys).toHaveBeenCalledWith(legacyUrl);
     });
 
+    test('should not treat same highlight ids with different payloads as completed migration', async () => {
+      const legacyHighlights = [{ id: 'legacy-highlight', text: 'new payload' }];
+      const stableHighlights = [{ id: 'legacy-highlight', text: 'old payload' }];
+
+      mockStorageService.getSavedPageData.mockImplementation(url =>
+        url === legacyUrl ? Promise.resolve(pageData) : Promise.resolve(null)
+      );
+      mockStorageService.getHighlights.mockImplementation(url => {
+        if (url === legacyUrl) {
+          return Promise.resolve(legacyHighlights);
+        }
+        if (url === stableUrl) {
+          return Promise.resolve(stableHighlights);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await service.migrateStorageKey(stableUrl, legacyUrl);
+
+      expect(result).toBe(true);
+      expect(mockStorageService.clearLegacyKeys).not.toHaveBeenCalled();
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Migration target already has data, skipping highlight overwrite',
+        expect.objectContaining({
+          action: 'migrate:skip-overwrite',
+          supplementedNotion: true,
+        })
+      );
+    });
+
     test('should log conflict warning when stable/legacy notion are determined as different pages', async () => {
       const {
         hasNotionData,
@@ -375,6 +407,24 @@ describe('MigrationService', () => {
       expect(Logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to set URL alias'),
         expect.anything()
+      );
+    });
+
+    test('should not throw when setUrlAlias throws synchronously', async () => {
+      mockStorageService.setUrlAlias.mockImplementation(() => {
+        throw new Error('sync alias fail');
+      });
+
+      await expect(service._setUrlAliasSafe(legacyUrl, stableUrl)).resolves.toBeUndefined();
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Failed to set URL alias during migration',
+        expect.objectContaining({
+          action: 'migrate:set-alias',
+          result: 'failure',
+          legacy: `safe://${legacyUrl}`,
+          stable: `safe://${stableUrl}`,
+          error: 'sync alias fail',
+        })
       );
     });
 
@@ -849,6 +899,29 @@ describe('MigrationService', () => {
       expect(result).toBe(stableUrl);
     });
 
+    test('should return stableUrl when stable highlights already win without metadata supplement', async () => {
+      const migratedHighlights = [{ id: 'legacy-1', needsRangeInfo: true }];
+
+      mockStorageService.getSavedPageData.mockResolvedValue(null);
+      mockStorageService.getHighlights.mockImplementation(lookupUrl => {
+        if (lookupUrl === url) {
+          return Promise.resolve(oldHighlights);
+        }
+        if (lookupUrl === stableUrl) {
+          return Promise.resolve(migratedHighlights);
+        }
+        return Promise.resolve(null);
+      });
+      mockStorageService.clearLegacyKeys.mockResolvedValue();
+      service._applyInPlaceConversion = jest.fn().mockResolvedValue();
+
+      const result = await service._tryBatchStableMigration({ url, stableUrl, oldHighlights });
+
+      expect(mockStorageService.setUrlAlias).toHaveBeenCalledWith(url, stableUrl);
+      expect(service._applyInPlaceConversion).not.toHaveBeenCalled();
+      expect(result).toBe(stableUrl);
+    });
+
     test('should return stableUrl when migrateStorageKey fails but metadata is supplemented', async () => {
       service.migrateStorageKey = jest.fn().mockResolvedValue(false);
       service._supplementBatchSavedMetadata = jest.fn().mockResolvedValue(true);
@@ -926,9 +999,7 @@ describe('MigrationService', () => {
       const result = await service.executeContentMigration({ url: targetUrl }, sender);
 
       expect(result.success).toBe(true);
-      expect(result.message).toContain('No data');
-      expect(mockStorageService.getHighlights).toHaveBeenCalledWith(targetUrl);
-      expect(result.message).toContain('No data');
+      expect(result.message).toBe('沒有可遷移的資料');
       expect(mockStorageService.getHighlights).toHaveBeenCalledWith(targetUrl);
       expect(mockTabService.queryTabs).not.toHaveBeenCalled();
     });
@@ -951,6 +1022,7 @@ describe('MigrationService', () => {
 
       expect(result.success).toBe(true);
       expect(result.count).toBe(5);
+      expect(result.message).toBe('已成功遷移 5 筆標註');
       expect(mockTabService.queryTabs).toHaveBeenCalledWith({}); // Verify precise match logic
       expect(mockTabService.createTab).not.toHaveBeenCalled();
 


### PR DESCRIPTION
### 摘要
重構 MigrationService 以降低其複雜性和簡化條件邏輯。

### 變更內容
- 減少 MigrationService 的複雜性，提升可讀性。
- 簡化條件判斷邏輯，增強代碼的可維護性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

