### PR TITLE
refactor: simplify range handling logic

### DIFF
--- a/scripts/highlighter/core/Range.js
+++ b/scripts/highlighter/core/Range.js
@@ -60,50 +60,68 @@ function createBoundaryRange(container, startOffset, endOffset) {
   return boundaryRange;
 }
 
-function extractElementPrefix(container, offset) {
-  let startOffset = 0;
-  for (let i = offset - 1; i >= 0; i--) {
-    if (isBlockBoundaryNode(container.childNodes[i])) {
-      startOffset = i + 1;
-      break;
-    }
-  }
-
-  const text = createBoundaryRange(container, startOffset, offset).toString();
-  if (text.trim().length === 0) {
-    return '';
-  }
-  return text.slice(Math.max(0, text.length - CONTEXT_LENGTH));
+function isPrefixContext(direction) {
+  return direction === CONTEXT_DIRECTION.PREFIX;
 }
 
-function extractElementSuffix(container, offset) {
-  let endOffset = container.childNodes.length;
-  for (let i = offset; i < container.childNodes.length; i++) {
-    if (isBlockBoundaryNode(container.childNodes[i])) {
-      endOffset = i;
-      break;
-    }
-  }
-
-  const text = createBoundaryRange(container, offset, endOffset).toString();
-  if (text.trim().length === 0) {
-    return '';
-  }
-  return text.slice(0, CONTEXT_LENGTH);
+function getElementContextSearchWindow(childNodes, offset, direction) {
+  const children = Array.from(childNodes);
+  return isPrefixContext(direction)
+    ? children.slice(0, offset).toReversed()
+    : children.slice(offset);
 }
 
-function extractTextContext(text, offset, direction) {
-  if (direction === CONTEXT_DIRECTION.PREFIX) {
+function resolveDefaultElementBoundary(childNodes, direction) {
+  return isPrefixContext(direction) ? 0 : childNodes.length;
+}
+
+function resolveMatchedElementBoundary(offset, relativeIndex, direction) {
+  return isPrefixContext(direction) ? offset - relativeIndex : offset + relativeIndex;
+}
+
+function findElementContextBoundary(childNodes, offset, direction) {
+  const relativeIndex = getElementContextSearchWindow(childNodes, offset, direction).findIndex(
+    node => isBlockBoundaryNode(node)
+  );
+
+  if (relativeIndex === -1) {
+    return resolveDefaultElementBoundary(childNodes, direction);
+  }
+
+  return resolveMatchedElementBoundary(offset, relativeIndex, direction);
+}
+
+function createElementContextText(container, offset, direction) {
+  const boundaryOffset = findElementContextBoundary(container.childNodes, offset, direction);
+  const startOffset = isPrefixContext(direction) ? boundaryOffset : offset;
+  const endOffset = isPrefixContext(direction) ? offset : boundaryOffset;
+
+  return createBoundaryRange(container, startOffset, endOffset).toString();
+}
+
+function sliceContextText(text, offset, direction) {
+  if (isPrefixContext(direction)) {
     return text.slice(Math.max(0, offset - CONTEXT_LENGTH), offset);
   }
   return text.slice(offset, Math.min(text.length, offset + CONTEXT_LENGTH));
 }
 
-function extractElementContext(container, offset, direction) {
-  if (direction === CONTEXT_DIRECTION.PREFIX) {
-    return extractElementPrefix(container, offset);
+function trimElementContextText(text, direction) {
+  if (text.trim().length === 0) {
+    return '';
   }
-  return extractElementSuffix(container, offset);
+  return isPrefixContext(direction)
+    ? text.slice(Math.max(0, text.length - CONTEXT_LENGTH))
+    : text.slice(0, CONTEXT_LENGTH);
+}
+
+function extractTextContext(text, offset, direction) {
+  return sliceContextText(text, offset, direction);
+}
+
+function extractElementContext(container, offset, direction) {
+  const text = createElementContextText(container, offset, direction);
+  return trimElementContextText(text, direction);
 }
 
 function extractRangeContext(container, offset, direction) {
@@ -114,6 +132,35 @@ function extractRangeContext(container, offset, direction) {
     return extractElementContext(container, offset, direction);
   } catch {
     return '';
+  }
+}
+
+function resolveSerializedRangeNodes(rangeInfo) {
+  const startNode = getNodeByPath(rangeInfo.startContainerPath);
+  const endNode = getNodeByPath(rangeInfo.endContainerPath);
+
+  return startNode && endNode ? { startNode, endNode } : null;
+}
+
+function createRangeFromSerializedNodes(rangeInfo, nodes) {
+  const range = document.createRange();
+  range.setStart(nodes.startNode, rangeInfo.startOffset);
+  range.setEnd(nodes.endNode, rangeInfo.endOffset);
+  return range;
+}
+
+function matchExpectedRangeText(range, expectedText) {
+  return range.toString() === expectedText ? range : null;
+}
+
+function safelyDeserializeRange(rangeInfo, expectedText) {
+  try {
+    const nodes = resolveSerializedRangeNodes(rangeInfo);
+    return nodes
+      ? matchExpectedRangeText(createRangeFromSerializedNodes(rangeInfo, nodes), expectedText)
+      : null;
+  } catch {
+    return null;
   }
 }
 
@@ -142,32 +189,7 @@ export function serializeRange(range) {
  * @returns {Range|null} 恢復的 Range 或 null
  */
 export function deserializeRange(rangeInfo, expectedText) {
-  if (!rangeInfo) {
-    return null;
-  }
-
-  try {
-    const startNode = getNodeByPath(rangeInfo.startContainerPath);
-    const endNode = getNodeByPath(rangeInfo.endContainerPath);
-
-    if (!startNode || !endNode) {
-      return null;
-    }
-
-    const range = document.createRange();
-    range.setStart(startNode, rangeInfo.startOffset);
-    range.setEnd(endNode, rangeInfo.endOffset);
-
-    // 驗證文本
-    const actualText = range.toString();
-    if (actualText !== expectedText) {
-      return null;
-    }
-
-    return range;
-  } catch {
-    return null;
-  }
+  return rangeInfo ? safelyDeserializeRange(rangeInfo, expectedText) : null;
 }
 
 /**
@@ -204,6 +226,25 @@ function findRangeByTextWithSerializedContext(rangeInfo, text) {
   });
 }
 
+async function restoreRangeAttempt(rangeInfo, text, isFinalAttempt) {
+  const retriedRange = await retryDeserializeAfterDOMStability(rangeInfo, text);
+
+  return (
+    retriedRange || (isFinalAttempt ? findRangeByTextWithSerializedContext(rangeInfo, text) : null)
+  );
+}
+
+async function restoreRangeWithDOMRetries(rangeInfo, text, maxRetries) {
+  for (let retryIndex = 0; retryIndex < maxRetries; retryIndex++) {
+    const range = await restoreRangeAttempt(rangeInfo, text, retryIndex === maxRetries - 1);
+    if (range) {
+      return range;
+    }
+  }
+
+  return null;
+}
+
 /**
  * 帶重試機制的 Range 恢復
  *
@@ -214,28 +255,9 @@ function findRangeByTextWithSerializedContext(rangeInfo, text) {
  */
 export async function restoreRangeWithRetry(rangeInfo, text, maxRetries = 3) {
   // 嘗試直接反序列化
-  const range = deserializeRange(rangeInfo, text);
-  if (range) {
-    return range;
-  }
-
-  // 等待 DOM 穩定後重試
-  for (let i = 0; i < maxRetries; i++) {
-    const retriedRange = await retryDeserializeAfterDOMStability(rangeInfo, text);
-    if (retriedRange) {
-      return retriedRange;
-    }
-
-    // 最後嘗試：使用文本搜索（傳入上下文交由 findTextInPage 處理）
-    if (i === maxRetries - 1) {
-      const fallbackRange = findRangeByTextWithSerializedContext(rangeInfo, text);
-      if (fallbackRange) {
-        return fallbackRange;
-      }
-    }
-  }
-
-  return null;
+  return (
+    deserializeRange(rangeInfo, text) || restoreRangeWithDOMRetries(rangeInfo, text, maxRetries)
+  );
 }
 
 /**

--- a/scripts/highlighter/core/Range.js
+++ b/scripts/highlighter/core/Range.js
@@ -88,6 +88,40 @@ function extractElementSuffix(container, offset) {
   return text.slice(0, CONTEXT_LENGTH);
 }
 
+function extractTextPrefix(text, offset) {
+  return text.slice(Math.max(0, offset - CONTEXT_LENGTH), offset);
+}
+
+function extractTextSuffix(text, offset) {
+  return text.slice(offset, Math.min(text.length, offset + CONTEXT_LENGTH));
+}
+
+function extractRangePrefix(range) {
+  const container = range.startContainer;
+  const offset = range.startOffset;
+  if (container.nodeType === Node.TEXT_NODE) {
+    return extractTextPrefix(container.textContent, offset);
+  }
+  try {
+    return extractElementPrefix(container, offset);
+  } catch {
+    return '';
+  }
+}
+
+function extractRangeSuffix(range) {
+  const container = range.endContainer;
+  const offset = range.endOffset;
+  if (container.nodeType === Node.TEXT_NODE) {
+    return extractTextSuffix(container.textContent, offset);
+  }
+  try {
+    return extractElementSuffix(container, offset);
+  } catch {
+    return '';
+  }
+}
+
 /**
  * 序列化 Range 對象
  *
@@ -95,42 +129,13 @@ function extractElementSuffix(container, offset) {
  * @returns {object} 序列化的 Range 資訊
  */
 export function serializeRange(range) {
-  let prefix = '';
-  if (range.startContainer.nodeType === Node.TEXT_NODE) {
-    const text = range.startContainer.textContent;
-    prefix = text.slice(Math.max(0, range.startOffset - CONTEXT_LENGTH), range.startOffset);
-  } else {
-    // Element-node offsets are child indexes; clip context to the current text run
-    // so adjacent block text does not become a misleading prefix.
-    try {
-      prefix = extractElementPrefix(range.startContainer, range.startOffset);
-    } catch {
-      prefix = '';
-    }
-  }
-
-  // 提取後文 (suffix)
-  let suffix = '';
-  if (range.endContainer.nodeType === Node.TEXT_NODE) {
-    const text = range.endContainer.textContent;
-    suffix = text.slice(range.endOffset, Math.min(text.length, range.endOffset + CONTEXT_LENGTH));
-  } else {
-    // Element-node offsets are child indexes; clip context to the current text run
-    // so adjacent block text does not become a misleading suffix.
-    try {
-      suffix = extractElementSuffix(range.endContainer, range.endOffset);
-    } catch {
-      suffix = '';
-    }
-  }
-
   return {
     startContainerPath: getNodePath(range.startContainer),
     startOffset: range.startOffset,
     endContainerPath: getNodePath(range.endContainer),
     endOffset: range.endOffset,
-    prefix, // 新增：用於模糊匹配消歧義
-    suffix, // 新增：用於模糊匹配消歧義
+    prefix: extractRangePrefix(range), // 新增：用於模糊匹配消歧義
+    suffix: extractRangeSuffix(range), // 新增：用於模糊匹配消歧義
   };
 }
 
@@ -171,6 +176,40 @@ export function deserializeRange(rangeInfo, expectedText) {
 }
 
 /**
+ * 在 DOM 穩定後重試反序列化 Range
+ *
+ * @param {object} rangeInfo - Range 資訊
+ * @param {string} text - 文本內容
+ * @returns {Promise<Range|null>}
+ */
+async function retryDeserializeAfterDOMStability(rangeInfo, text) {
+  const isStable = await waitForDOMStability({
+    stabilityThresholdMs: 150,
+    maxWaitMs: 2000,
+  });
+
+  if (!isStable) {
+    return null;
+  }
+
+  return deserializeRange(rangeInfo, text);
+}
+
+/**
+ * 使用序列化的上下文查找 Range
+ *
+ * @param {object} rangeInfo - Range 資訊
+ * @param {string} text - 文本內容
+ * @returns {Range|null}
+ */
+function findRangeByTextWithSerializedContext(rangeInfo, text) {
+  return findTextInPage(text, {
+    prefix: rangeInfo?.prefix,
+    suffix: rangeInfo?.suffix,
+  });
+}
+
+/**
  * 帶重試機制的 Range 恢復
  *
  * @param {object} rangeInfo - Range 資訊
@@ -180,36 +219,23 @@ export function deserializeRange(rangeInfo, expectedText) {
  */
 export async function restoreRangeWithRetry(rangeInfo, text, maxRetries = 3) {
   // 嘗試直接反序列化
-  let range = deserializeRange(rangeInfo, text);
+  const range = deserializeRange(rangeInfo, text);
   if (range) {
     return range;
   }
 
-  // 提取上下文，以便在文本搜索時進行消歧義
-  const context = {
-    prefix: rangeInfo?.prefix,
-    suffix: rangeInfo?.suffix,
-  };
-
   // 等待 DOM 穩定後重試
   for (let i = 0; i < maxRetries; i++) {
-    const isStable = await waitForDOMStability({
-      stabilityThresholdMs: 150,
-      maxWaitMs: 2000,
-    });
-
-    if (isStable) {
-      range = deserializeRange(rangeInfo, text);
-      if (range) {
-        return range;
-      }
+    const retriedRange = await retryDeserializeAfterDOMStability(rangeInfo, text);
+    if (retriedRange) {
+      return retriedRange;
     }
 
     // 最後嘗試：使用文本搜索（傳入上下文交由 findTextInPage 處理）
     if (i === maxRetries - 1) {
-      range = findTextInPage(text, context);
-      if (range) {
-        return range;
+      const fallbackRange = findRangeByTextWithSerializedContext(rangeInfo, text);
+      if (fallbackRange) {
+        return fallbackRange;
       }
     }
   }

--- a/scripts/highlighter/core/Range.js
+++ b/scripts/highlighter/core/Range.js
@@ -66,9 +66,15 @@ function isPrefixContext(direction) {
 
 function getElementContextSearchWindow(childNodes, offset, direction) {
   const children = Array.from(childNodes);
-  return isPrefixContext(direction)
-    ? children.slice(0, offset).toReversed()
-    : children.slice(offset);
+  if (!isPrefixContext(direction)) {
+    return children.slice(offset);
+  }
+
+  const previousChildren = [];
+  for (let index = offset - 1; index >= 0; index--) {
+    previousChildren.push(children[index]);
+  }
+  return previousChildren;
 }
 
 function resolveDefaultElementBoundary(childNodes, direction) {

--- a/scripts/highlighter/core/Range.js
+++ b/scripts/highlighter/core/Range.js
@@ -8,6 +8,10 @@ import { findTextInPage, HIGHLIGHT_ANCHORING } from '../utils/textSearch.js';
 import { waitForDOMStability } from '../utils/domStability.js';
 
 const { CONTEXT_LENGTH } = HIGHLIGHT_ANCHORING;
+const CONTEXT_DIRECTION = {
+  PREFIX: 'prefix',
+  SUFFIX: 'suffix',
+};
 
 const BLOCK_BOUNDARY_TAGS = new Set([
   'ADDRESS',
@@ -88,35 +92,26 @@ function extractElementSuffix(container, offset) {
   return text.slice(0, CONTEXT_LENGTH);
 }
 
-function extractTextPrefix(text, offset) {
-  return text.slice(Math.max(0, offset - CONTEXT_LENGTH), offset);
-}
-
-function extractTextSuffix(text, offset) {
+function extractTextContext(text, offset, direction) {
+  if (direction === CONTEXT_DIRECTION.PREFIX) {
+    return text.slice(Math.max(0, offset - CONTEXT_LENGTH), offset);
+  }
   return text.slice(offset, Math.min(text.length, offset + CONTEXT_LENGTH));
 }
 
-function extractRangePrefix(range) {
-  const container = range.startContainer;
-  const offset = range.startOffset;
-  if (container.nodeType === Node.TEXT_NODE) {
-    return extractTextPrefix(container.textContent, offset);
-  }
-  try {
+function extractElementContext(container, offset, direction) {
+  if (direction === CONTEXT_DIRECTION.PREFIX) {
     return extractElementPrefix(container, offset);
-  } catch {
-    return '';
   }
+  return extractElementSuffix(container, offset);
 }
 
-function extractRangeSuffix(range) {
-  const container = range.endContainer;
-  const offset = range.endOffset;
+function extractRangeContext(container, offset, direction) {
   if (container.nodeType === Node.TEXT_NODE) {
-    return extractTextSuffix(container.textContent, offset);
+    return extractTextContext(container.textContent, offset, direction);
   }
   try {
-    return extractElementSuffix(container, offset);
+    return extractElementContext(container, offset, direction);
   } catch {
     return '';
   }
@@ -134,8 +129,8 @@ export function serializeRange(range) {
     startOffset: range.startOffset,
     endContainerPath: getNodePath(range.endContainer),
     endOffset: range.endOffset,
-    prefix: extractRangePrefix(range), // 新增：用於模糊匹配消歧義
-    suffix: extractRangeSuffix(range), // 新增：用於模糊匹配消歧義
+    prefix: extractRangeContext(range.startContainer, range.startOffset, CONTEXT_DIRECTION.PREFIX), // 新增：用於模糊匹配消歧義
+    suffix: extractRangeContext(range.endContainer, range.endOffset, CONTEXT_DIRECTION.SUFFIX), // 新增：用於模糊匹配消歧義
   };
 }
 

--- a/tests/unit/highlighter/core/Range.edge-cases.test.js
+++ b/tests/unit/highlighter/core/Range.edge-cases.test.js
@@ -236,6 +236,25 @@ describe('Range Module Coverage Tests', () => {
 
       expect(range).toBeNull();
     });
+
+    test('should not attempt DOM stability or text search when maxRetries is zero', async () => {
+      const rangeInfo = {
+        startContainerPath: [{ type: 'element', tag: 'div', index: 0 }],
+        startOffset: 0,
+        endContainerPath: [{ type: 'element', tag: 'div', index: 0 }],
+        endOffset: 4,
+        prefix: 'before',
+        suffix: 'after',
+      };
+
+      pathUtils.getNodeByPath.mockReturnValue(null);
+
+      const range = await restoreRangeWithRetry(rangeInfo, 'Test', 0);
+
+      expect(range).toBeNull();
+      expect(domStabilityUtils.waitForDOMStability).not.toHaveBeenCalled();
+      expect(textSearchUtils.findTextInPage).not.toHaveBeenCalled();
+    });
   });
 
   describe('findRangeByTextContent', () => {

--- a/tests/unit/highlighter/core/Range.edge-cases.test.js
+++ b/tests/unit/highlighter/core/Range.edge-cases.test.js
@@ -67,6 +67,36 @@ describe('Range Module Coverage Tests', () => {
       });
       expect(pathUtils.getNodePath).toHaveBeenCalledTimes(2);
     });
+
+    test('should extract element-node prefix when toReversed is unavailable', () => {
+      const toReversedDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'toReversed');
+      const article = document.createElement('article');
+      article.innerHTML = '<span>Lead context </span><span>Target</span><span> tail</span>';
+      document.body.append(article);
+
+      Object.defineProperty(Array.prototype, 'toReversed', {
+        configurable: true,
+        value: undefined,
+        writable: true,
+      });
+
+      try {
+        const range = document.createRange();
+        range.setStart(article, 1);
+        range.setEnd(article, 2);
+
+        pathUtils.getNodePath
+          .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
+          .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
+
+        const serialized = serializeRange(range);
+
+        expect(serialized.prefix).toBe('Lead context ');
+        expect(serialized.suffix).toBe(' tail');
+      } finally {
+        Object.defineProperty(Array.prototype, 'toReversed', toReversedDescriptor);
+      }
+    });
   });
 
   describe('deserializeRange', () => {
@@ -217,6 +247,72 @@ describe('Range Module Coverage Tests', () => {
       expect(textSearchUtils.findTextInPage).toHaveBeenCalledWith('Test', {
         prefix: undefined,
         suffix: undefined,
+      });
+    });
+
+    test('should restore an element-container range through final text search fallback', async () => {
+      const article = document.createElement('article');
+      article.innerHTML = [
+        '<p>Outside previous Target.</p>',
+        '<span>before </span>',
+        '<span>Target</span>',
+        '<span> after</span>',
+        '<p>Outside next Target.</p>',
+      ].join('');
+      document.body.append(article);
+
+      const selectedRange = document.createRange();
+      selectedRange.setStart(article, 2);
+      selectedRange.setEnd(article, 3);
+
+      pathUtils.getNodePath
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
+      const rangeInfo = serializeRange(selectedRange);
+
+      const fallbackRange = document.createRange();
+      fallbackRange.setStart(article.children[2].firstChild, 0);
+      fallbackRange.setEnd(article.children[2].firstChild, 'Target'.length);
+
+      pathUtils.getNodeByPath.mockReturnValue(null);
+      domStabilityUtils.waitForDOMStability.mockResolvedValue(false);
+      textSearchUtils.findTextInPage.mockReturnValue(fallbackRange);
+
+      const restoredRange = await restoreRangeWithRetry(rangeInfo, 'Target', 1);
+
+      expect(restoredRange).toBe(fallbackRange);
+      expect(restoredRange.toString()).toBe('Target');
+    });
+
+    test('should pass serialized prefix and suffix to final text search fallback', async () => {
+      const article = document.createElement('article');
+      article.innerHTML = [
+        '<p>Outside previous Target.</p>',
+        '<span>before </span>',
+        '<span>Target</span>',
+        '<span> after</span>',
+        '<p>Outside next Target.</p>',
+      ].join('');
+      document.body.append(article);
+
+      const selectedRange = document.createRange();
+      selectedRange.setStart(article, 2);
+      selectedRange.setEnd(article, 3);
+
+      pathUtils.getNodePath
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
+      const rangeInfo = serializeRange(selectedRange);
+
+      pathUtils.getNodeByPath.mockReturnValue(null);
+      domStabilityUtils.waitForDOMStability.mockResolvedValue(false);
+      textSearchUtils.findTextInPage.mockReturnValue(null);
+
+      await restoreRangeWithRetry(rangeInfo, 'Target', 1);
+
+      expect(textSearchUtils.findTextInPage).toHaveBeenCalledWith('Target', {
+        prefix: 'before ',
+        suffix: ' after',
       });
     });
 

--- a/tests/unit/highlighter/core/Range.edge-cases.test.js
+++ b/tests/unit/highlighter/core/Range.edge-cases.test.js
@@ -175,6 +175,31 @@ describe('Range Module Coverage Tests', () => {
   });
 
   describe('restoreRangeWithRetry', () => {
+    function createElementContainerFallbackFixture() {
+      const article = document.createElement('article');
+      article.innerHTML = [
+        '<p>Outside previous Target.</p>',
+        '<span>before </span>',
+        '<span>Target</span>',
+        '<span> after</span>',
+        '<p>Outside next Target.</p>',
+      ].join('');
+      document.body.append(article);
+
+      const selectedRange = document.createRange();
+      selectedRange.setStart(article, 2);
+      selectedRange.setEnd(article, 3);
+
+      pathUtils.getNodePath
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
+        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
+
+      return {
+        article,
+        rangeInfo: serializeRange(selectedRange),
+      };
+    }
+
     test('should restore range on first try', async () => {
       const div = document.createElement('div');
       div.textContent = 'Test content';
@@ -251,24 +276,7 @@ describe('Range Module Coverage Tests', () => {
     });
 
     test('should restore an element-container range through final text search fallback', async () => {
-      const article = document.createElement('article');
-      article.innerHTML = [
-        '<p>Outside previous Target.</p>',
-        '<span>before </span>',
-        '<span>Target</span>',
-        '<span> after</span>',
-        '<p>Outside next Target.</p>',
-      ].join('');
-      document.body.append(article);
-
-      const selectedRange = document.createRange();
-      selectedRange.setStart(article, 2);
-      selectedRange.setEnd(article, 3);
-
-      pathUtils.getNodePath
-        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
-        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
-      const rangeInfo = serializeRange(selectedRange);
+      const { article, rangeInfo } = createElementContainerFallbackFixture();
 
       const fallbackRange = document.createRange();
       fallbackRange.setStart(article.children[2].firstChild, 0);
@@ -285,24 +293,7 @@ describe('Range Module Coverage Tests', () => {
     });
 
     test('should pass serialized prefix and suffix to final text search fallback', async () => {
-      const article = document.createElement('article');
-      article.innerHTML = [
-        '<p>Outside previous Target.</p>',
-        '<span>before </span>',
-        '<span>Target</span>',
-        '<span> after</span>',
-        '<p>Outside next Target.</p>',
-      ].join('');
-      document.body.append(article);
-
-      const selectedRange = document.createRange();
-      selectedRange.setStart(article, 2);
-      selectedRange.setEnd(article, 3);
-
-      pathUtils.getNodePath
-        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }])
-        .mockReturnValueOnce([{ type: 'element', tag: 'article', index: 0 }]);
-      const rangeInfo = serializeRange(selectedRange);
+      const { rangeInfo } = createElementContainerFallbackFixture();
 
       pathUtils.getNodeByPath.mockReturnValue(null);
       domStabilityUtils.waitForDOMStability.mockResolvedValue(false);


### PR DESCRIPTION
### 摘要
重構範圍處理邏輯以簡化代碼結構，提升可讀性和維護性。

### 變更內容
- 簡化 `serializeRange` 和 `restoreRangeWithRetry` 的邏輯。
- 移除重複的範圍上下文輔助函數。
- 扁平化範圍邊界流程，減少複雜性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

