### PR TITLE
refactor: reduce text search complexity

### DIFF
--- a/scripts/highlighter/utils/textSearch.js
+++ b/scripts/highlighter/utils/textSearch.js
@@ -20,12 +20,17 @@ const SKIPPED_SEARCH_PARENT_TAGS = new Set(['SCRIPT', 'STYLE']);
 /**
  * 記錄 text search 錯誤
  *
+ * @param {string} action - 發生錯誤的搜尋動作
  * @param {string} message - 錯誤訊息
  * @param {Error} error - 原始錯誤
  */
-function logTextSearchError(message, error) {
+function logTextSearchError(action, message, error) {
   if (globalThis.Logger !== undefined) {
-    globalThis.Logger?.error(SEARCH_LOG_TAG, message, error);
+    globalThis.Logger?.error(`${SEARCH_LOG_TAG} ${message}`, {
+      action,
+      result: 'failed',
+      error,
+    });
   }
 }
 
@@ -65,10 +70,24 @@ function hasContextAnchors(context) {
  * @returns {Range|null}
  */
 function findTextWithWindowSelection(cleanText) {
-  const selection = globalThis.getSelection();
-  selection.removeAllRanges();
+  let selection = null;
 
   try {
+    if (typeof globalThis.getSelection !== 'function') {
+      return null;
+    }
+
+    selection = globalThis.getSelection();
+    if (!selection) {
+      return null;
+    }
+
+    clearSelection(selection);
+
+    if (typeof globalThis.find !== 'function') {
+      return null;
+    }
+
     const found = globalThis.find(cleanText, false, false, false, false, true, false);
     if (!found) {
       return null;
@@ -77,9 +96,19 @@ function findTextWithWindowSelection(cleanText) {
       return null;
     }
     return selection.getRangeAt(0).cloneRange();
+  } catch {
+    return null;
   } finally {
     // 覆蓋 getRangeAt/cloneRange 例外與一般路徑，確保選區副作用被清理
-    selection.removeAllRanges();
+    clearSelection(selection);
+  }
+}
+
+function clearSelection(selection) {
+  try {
+    selection?.removeAllRanges?.();
+  } catch {
+    // Selection cleanup failure should not block the fallback search chain.
   }
 }
 
@@ -139,7 +168,7 @@ export function findTextInPage(textToFind, context = {}) {
 
     return findTextWithoutContextFallback(cleanText, context);
   } catch (error) {
-    logTextSearchError('查找文本失敗:', error);
+    logTextSearchError('findTextInPage', '查找文本失敗:', error);
     return null;
   }
 }
@@ -375,7 +404,7 @@ export function findTextWithTreeWalker(textToFind) {
     // 嘗試跨文本節點匹配
     return findRangeAcrossNodes(textToFind, textNodes);
   } catch (error) {
-    logTextSearchError('findTextWithTreeWalker error:', error);
+    logTextSearchError('findTextWithTreeWalker', 'findTextWithTreeWalker error:', error);
     return null;
   }
 }
@@ -664,9 +693,10 @@ function buildCandidateDebugInfo(candidateInfo) {
  */
 function logFuzzyDisambiguationFailure(candidates, bestCandidate, maxScore, context) {
   globalThis.Logger?.debug(
-    SEARCH_LOG_TAG,
-    'calculateCandidateScore failed to disambiguate. maxScore <= 0.',
+    `${SEARCH_LOG_TAG} calculateCandidateScore failed to disambiguate. maxScore <= 0.`,
     {
+      action: 'findTextFuzzy',
+      result: 'disambiguation_failed',
       prefixLength: getOptionalTextLength(context.prefix),
       suffixLength: getOptionalTextLength(context.suffix),
       candidateCount: candidates.length,
@@ -712,7 +742,7 @@ export function findTextFuzzy(textToFind, context = {}) {
 
     return bestCandidate.range;
   } catch (error) {
-    logTextSearchError('findTextFuzzy error:', error);
+    logTextSearchError('findTextFuzzy', 'findTextFuzzy error:', error);
     return null;
   }
 }

--- a/scripts/highlighter/utils/textSearch.js
+++ b/scripts/highlighter/utils/textSearch.js
@@ -15,6 +15,7 @@ const PARTIAL_MATCH_LENGTH = 10;
 const MAX_COMBINED_NODES = 5;
 
 const SEARCH_LOG_TAG = '[textSearch]';
+const SKIPPED_SEARCH_PARENT_TAGS = new Set(['SCRIPT', 'STYLE']);
 
 /**
  * 記錄 text search 錯誤
@@ -48,7 +49,13 @@ function logTextSearchError(message, error) {
  * @returns {boolean}
  */
 function hasContextAnchors(context) {
-  return Boolean(context && (context.prefix || context.suffix));
+  if (!context) {
+    return false;
+  }
+  if (context.prefix) {
+    return true;
+  }
+  return Boolean(context.suffix);
 }
 
 /**
@@ -60,19 +67,20 @@ function hasContextAnchors(context) {
 function findTextWithWindowSelection(cleanText) {
   const selection = globalThis.getSelection();
   selection.removeAllRanges();
-  let matchedRange = null;
 
   try {
     const found = globalThis.find(cleanText, false, false, false, false, true, false);
-    if (found && selection.rangeCount > 0) {
-      matchedRange = selection.getRangeAt(0).cloneRange();
+    if (!found) {
+      return null;
     }
+    if (selection.rangeCount === 0) {
+      return null;
+    }
+    return selection.getRangeAt(0).cloneRange();
   } finally {
     // 覆蓋 getRangeAt/cloneRange 例外與一般路徑，確保選區副作用被清理
     selection.removeAllRanges();
   }
-
-  return matchedRange;
 }
 
 /**
@@ -142,13 +150,26 @@ export function findTextInPage(textToFind, context = {}) {
  */
 const SEARCH_NODE_FILTER = {
   acceptNode(node) {
-    const parent = node.parentElement;
-    if (parent && (parent.tagName === 'SCRIPT' || parent.tagName === 'STYLE')) {
+    if (shouldSkipSearchTextNode(node)) {
       return NodeFilter.FILTER_SKIP;
     }
     return NodeFilter.FILTER_ACCEPT;
   },
 };
+
+/**
+ * 判斷文字節點是否位於不應搜尋的父元素中
+ *
+ * @param {Node} node - 文字節點
+ * @returns {boolean}
+ */
+function shouldSkipSearchTextNode(node) {
+  const parent = node.parentElement;
+  if (!parent) {
+    return false;
+  }
+  return SKIPPED_SEARCH_PARENT_TAGS.has(parent.tagName);
+}
 
 /**
  * 獲取頁面中用於搜索的所有文本節點，過濾掉不需要的元素
@@ -214,13 +235,27 @@ function findNodeForOffset(nodesInRange, targetOffset) {
       // 在嚴格的大於判斷下可以微調，這裡採取統一計算：偏移 = 總目標 - 已走過長度
       const offset = targetOffset - currentLength;
       // 確保偏移不會超過節點內容，或為負數
-      if (offset >= 0 && offset <= nodeLength) {
+      if (isOffsetWithinNode(offset, nodeLength)) {
         return { node, offset };
       }
     }
     currentLength += nodeLength;
   }
   return null;
+}
+
+/**
+ * 判斷偏移量是否位於單一文字節點範圍內
+ *
+ * @param {number} offset - 節點內偏移量
+ * @param {number} nodeLength - 節點文字長度
+ * @returns {boolean}
+ */
+function isOffsetWithinNode(offset, nodeLength) {
+  if (offset < 0) {
+    return false;
+  }
+  return offset <= nodeLength;
 }
 
 /**
@@ -266,23 +301,54 @@ function createRangeFromNodesMatch(nodesInRange, matchIndex, textLength) {
  */
 function findRangeAcrossNodes(textToFind, textNodes) {
   for (let i = 0; i < textNodes.length; i++) {
-    let combinedText = '';
-    const nodesInRange = [];
-
-    for (let j = i; j < Math.min(i + MAX_COMBINED_NODES, textNodes.length); j++) {
-      combinedText += textNodes[j].textContent;
-      nodesInRange.push(textNodes[j]);
-
-      const matchIndex = combinedText.indexOf(textToFind);
-      if (matchIndex !== -1) {
-        const range = createRangeFromNodesMatch(nodesInRange, matchIndex, textToFind.length);
-        if (range) {
-          return range;
-        }
-      }
+    const range = findRangeStartingAtNode(textToFind, textNodes, i);
+    if (range) {
+      return range;
     }
   }
   return null;
+}
+
+/**
+ * 從指定文字節點開始嘗試建立跨節點 Range
+ *
+ * @param {string} textToFind - 要查找的文本
+ * @param {Node[]} textNodes - 文本節點陣列
+ * @param {number} startIndex - 起始節點索引
+ * @returns {Range|null}
+ */
+function findRangeStartingAtNode(textToFind, textNodes, startIndex) {
+  let combinedText = '';
+  const nodesInRange = [];
+  const endIndex = Math.min(startIndex + MAX_COMBINED_NODES, textNodes.length);
+
+  for (let nodeIndex = startIndex; nodeIndex < endIndex; nodeIndex++) {
+    combinedText += textNodes[nodeIndex].textContent;
+    nodesInRange.push(textNodes[nodeIndex]);
+
+    const range = createRangeFromCombinedText(textToFind, nodesInRange, combinedText);
+    if (range) {
+      return range;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 從合併文字建立匹配 Range
+ *
+ * @param {string} textToFind - 要查找的文本
+ * @param {Node[]} nodesInRange - 範圍內的節點陣列
+ * @param {string} combinedText - 已合併的節點文字
+ * @returns {Range|null}
+ */
+function createRangeFromCombinedText(textToFind, nodesInRange, combinedText) {
+  const matchIndex = combinedText.indexOf(textToFind);
+  if (matchIndex === -1) {
+    return null;
+  }
+  return createRangeFromNodesMatch(nodesInRange, matchIndex, textToFind.length);
 }
 
 /**
@@ -361,7 +427,10 @@ function getPrefixFromNodes(textNodes, nodeIndex, initialText) {
   let prefixText = initialText;
   let idx = nodeIndex - 1;
 
-  while (prefixText.length < CONTEXT_SEARCH_WINDOW && idx >= 0) {
+  while (prefixText.length < CONTEXT_SEARCH_WINDOW) {
+    if (idx < 0) {
+      break;
+    }
     const nodeText = textNodes[idx].textContent;
     const missingLength = CONTEXT_SEARCH_WINDOW - prefixText.length;
     prefixText =
@@ -384,7 +453,10 @@ function getSuffixFromNodes(textNodes, nodeIndex, initialText) {
   let suffixText = initialText;
   let idx = nodeIndex + 1;
 
-  while (suffixText.length < CONTEXT_SEARCH_WINDOW && idx < textNodes.length) {
+  while (suffixText.length < CONTEXT_SEARCH_WINDOW) {
+    if (idx >= textNodes.length) {
+      break;
+    }
     const nodeText = textNodes[idx].textContent;
     const missingLength = CONTEXT_SEARCH_WINDOW - suffixText.length;
     suffixText += nodeText.length > missingLength ? nodeText.slice(0, missingLength) : nodeText;
@@ -497,7 +569,10 @@ function createWhitespaceFlexibleRegex(cleanText) {
  * @returns {boolean}
  */
 function shouldUseFirstFuzzyCandidate(candidates, context) {
-  return candidates.length === 1 || !hasContextAnchors(context);
+  if (candidates.length === 1) {
+    return true;
+  }
+  return !hasContextAnchors(context);
 }
 
 /**
@@ -531,7 +606,13 @@ function selectBestFuzzyCandidate(candidates, context, textNodes) {
  * @returns {boolean}
  */
 function shouldReportFuzzyDisambiguationFailure(maxScore, context) {
-  return maxScore <= 0 && hasContextAnchors(context) && globalThis.Logger !== undefined;
+  if (maxScore > 0) {
+    return false;
+  }
+  if (!hasContextAnchors(context)) {
+    return false;
+  }
+  return globalThis.Logger !== undefined;
 }
 
 /**
@@ -552,7 +633,10 @@ function getOptionalTextLength(text) {
  */
 function getBestCandidateRangeLength(bestCandidate) {
   const range = bestCandidate.range;
-  if (!range || typeof range.toString !== 'function') {
+  if (!range) {
+    return 0;
+  }
+  if (typeof range.toString !== 'function') {
     return 0;
   }
   return range.toString().length;

--- a/scripts/highlighter/utils/textSearch.js
+++ b/scripts/highlighter/utils/textSearch.js
@@ -17,6 +17,18 @@ const MAX_COMBINED_NODES = 5;
 const SEARCH_LOG_TAG = '[textSearch]';
 
 /**
+ * 記錄 text search 錯誤
+ *
+ * @param {string} message - 錯誤訊息
+ * @param {Error} error - 原始錯誤
+ */
+function logTextSearchError(message, error) {
+  if (globalThis.Logger !== undefined) {
+    globalThis.Logger?.error(SEARCH_LOG_TAG, message, error);
+  }
+}
+
+/**
  * 在頁面中查找文本並返回 Range
  * 使用多種策略：window.find()、TreeWalker、模糊匹配
  *
@@ -119,9 +131,7 @@ export function findTextInPage(textToFind, context = {}) {
 
     return findTextWithoutContextFallback(cleanText, context);
   } catch (error) {
-    if (globalThis.Logger !== undefined) {
-      globalThis.Logger?.error(SEARCH_LOG_TAG, '查找文本失敗:', error);
-    }
+    logTextSearchError('查找文本失敗:', error);
     return null;
   }
 }
@@ -299,9 +309,7 @@ export function findTextWithTreeWalker(textToFind) {
     // 嘗試跨文本節點匹配
     return findRangeAcrossNodes(textToFind, textNodes);
   } catch (error) {
-    if (globalThis.Logger !== undefined) {
-      globalThis.Logger?.error(SEARCH_LOG_TAG, 'findTextWithTreeWalker error:', error);
-    }
+    logTextSearchError('findTextWithTreeWalker error:', error);
     return null;
   }
 }
@@ -527,6 +535,42 @@ function shouldReportFuzzyDisambiguationFailure(maxScore, context) {
 }
 
 /**
+ * 取得可選上下文文字長度
+ *
+ * @param {string|undefined} text - 上下文文字
+ * @returns {number}
+ */
+function getOptionalTextLength(text) {
+  return text ? text.length : 0;
+}
+
+/**
+ * 取得最佳候選者 Range 文字長度
+ *
+ * @param {object} bestCandidate - 最佳候選者
+ * @returns {number}
+ */
+function getBestCandidateRangeLength(bestCandidate) {
+  const range = bestCandidate.range;
+  if (!range || typeof range.toString !== 'function') {
+    return 0;
+  }
+  return range.toString().length;
+}
+
+/**
+ * 建立候選者偵錯摘要
+ *
+ * @param {object} candidateInfo - 候選者
+ * @returns {object}
+ */
+function buildCandidateDebugInfo(candidateInfo) {
+  return {
+    matchIndex: candidateInfo.matchIndex,
+  };
+}
+
+/**
  * 記錄模糊匹配消歧義失敗的偵錯日誌
  *
  * @param {Array} candidates - 候選者
@@ -539,15 +583,13 @@ function logFuzzyDisambiguationFailure(candidates, bestCandidate, maxScore, cont
     SEARCH_LOG_TAG,
     'calculateCandidateScore failed to disambiguate. maxScore <= 0.',
     {
-      prefixLength: context.prefix?.length || 0,
-      suffixLength: context.suffix?.length || 0,
+      prefixLength: getOptionalTextLength(context.prefix),
+      suffixLength: getOptionalTextLength(context.suffix),
       candidateCount: candidates.length,
-      bestCandidateRangeLength: bestCandidate.range?.toString?.()?.length || 0,
+      bestCandidateRangeLength: getBestCandidateRangeLength(bestCandidate),
       maxScore,
       scoringFunction: calculateCandidateScore.name,
-      candidatesInfo: candidates.map(candidateInfo => ({
-        matchIndex: candidateInfo.matchIndex,
-      })),
+      candidatesInfo: candidates.map(candidateInfo => buildCandidateDebugInfo(candidateInfo)),
     }
   );
 }
@@ -586,9 +628,7 @@ export function findTextFuzzy(textToFind, context = {}) {
 
     return bestCandidate.range;
   } catch (error) {
-    if (globalThis.Logger !== undefined) {
-      globalThis.Logger?.error(SEARCH_LOG_TAG, 'findTextFuzzy error:', error);
-    }
+    logTextSearchError('findTextFuzzy error:', error);
     return null;
   }
 }

--- a/scripts/highlighter/utils/textSearch.js
+++ b/scripts/highlighter/utils/textSearch.js
@@ -29,6 +29,80 @@ const SEARCH_LOG_TAG = '[textSearch]';
  *   // 使用 range
  * }
  */
+/**
+ * 檢查是否包含上下文資訊
+ *
+ * @param {object} context - 上下文
+ * @returns {boolean}
+ */
+function hasContextAnchors(context) {
+  return Boolean(context && (context.prefix || context.suffix));
+}
+
+/**
+ * 使用 window.find() API 查找文本並清理選區副作用
+ *
+ * @param {string} cleanText - 已清理的文本
+ * @returns {Range|null}
+ */
+function findTextWithWindowSelection(cleanText) {
+  const selection = globalThis.getSelection();
+  selection.removeAllRanges();
+  let matchedRange = null;
+
+  try {
+    const found = globalThis.find(cleanText, false, false, false, false, true, false);
+    if (found && selection.rangeCount > 0) {
+      matchedRange = selection.getRangeAt(0).cloneRange();
+    }
+  } finally {
+    // 覆蓋 getRangeAt/cloneRange 例外與一般路徑，確保選區副作用被清理
+    selection.removeAllRanges();
+  }
+
+  return matchedRange;
+}
+
+/**
+ * 當有上下文時的尋找策略：先模糊，後 TreeWalker 跨節點
+ *
+ * @param {string} cleanText - 已清理的文本
+ * @param {object} context - 上下文
+ * @returns {Range|null}
+ */
+function findTextWithContextFallback(cleanText, context) {
+  const fuzzyRange = findTextFuzzy(cleanText, context);
+  if (fuzzyRange) {
+    return fuzzyRange;
+  }
+  // 若模糊匹配無法找到（例如因正則無法跨多個文字節點），則退回到 TreeWalker 的跨節點匹配
+  return findTextWithTreeWalker(cleanText);
+}
+
+/**
+ * 當無上下文時的尋找策略：先 window.find，次 TreeWalker，後模糊匹配
+ *
+ * @param {string} cleanText - 已清理的文本
+ * @param {object} context - 上下文
+ * @returns {Range|null}
+ */
+function findTextWithoutContextFallback(cleanText, context) {
+  // 方法1：使用 window.find() API（最快，但可能不夠精確）
+  const matchedRange = findTextWithWindowSelection(cleanText);
+  if (matchedRange) {
+    return matchedRange;
+  }
+
+  // 方法2：使用 TreeWalker 精確查找
+  const range = findTextWithTreeWalker(cleanText);
+  if (range) {
+    return range;
+  }
+
+  // 方法3：模糊匹配（處理空白字符差異），如果有多個匹配，使用上下文消歧義
+  return findTextFuzzy(cleanText, context);
+}
+
 export function findTextInPage(textToFind, context = {}) {
   try {
     // 清理文本（移除多餘空白）
@@ -39,44 +113,11 @@ export function findTextInPage(textToFind, context = {}) {
       return null;
     }
 
-    if (context.prefix || context.suffix) {
-      const fuzzyRange = findTextFuzzy(cleanText, context);
-      if (fuzzyRange) {
-        return fuzzyRange;
-      }
-      // 若模糊匹配無法找到（例如因正則無法跨多個文字節點），則退回到 TreeWalker 的跨節點匹配
-      return findTextWithTreeWalker(cleanText);
+    if (hasContextAnchors(context)) {
+      return findTextWithContextFallback(cleanText, context);
     }
 
-    // 方法1：使用 window.find() API（最快，但可能不夠精確）
-    // 副作用說明：window.find() 會修改瀏覽器的選區（Selection），
-    // 保留前置清理，並透過 finally 在成功/失敗/例外時統一清理。
-    const selection = globalThis.getSelection();
-    selection.removeAllRanges();
-    let matchedRange = null;
-
-    try {
-      const found = globalThis.find(cleanText, false, false, false, false, true, false);
-      if (found && selection.rangeCount > 0) {
-        matchedRange = selection.getRangeAt(0).cloneRange();
-      }
-    } finally {
-      // 覆蓋 getRangeAt/cloneRange 例外與一般路徑，確保選區副作用被清理
-      selection.removeAllRanges();
-    }
-
-    if (matchedRange) {
-      return matchedRange;
-    }
-
-    // 方法2：使用 TreeWalker 精確查找
-    const range = findTextWithTreeWalker(cleanText);
-    if (range) {
-      return range;
-    }
-
-    // 方法3：模糊匹配（處理空白字符差異），如果有多個匹配，使用上下文消歧義
-    return findTextFuzzy(cleanText, context);
+    return findTextWithoutContextFallback(cleanText, context);
   } catch (error) {
     if (globalThis.Logger !== undefined) {
       globalThis.Logger?.error(SEARCH_LOG_TAG, '查找文本失敗:', error);
@@ -346,6 +387,46 @@ function getSuffixFromNodes(textNodes, nodeIndex, initialText) {
 }
 
 /**
+ * 計算單一方向（前綴或後綴）上下文的匹配分數
+ *
+ * @param {string} contextText - 上下文常規文字 (prefix 或 suffix)
+ * @param {string} nodeContextText - 擷取自節點鏈的上下文文字
+ * @param {string} direction - 'prefix' 或 'suffix'
+ * @returns {number} 分數 (0, 1, 2)
+ */
+function calculateSingleContextScore(contextText, nodeContextText, direction) {
+  if (!contextText) {
+    return 0;
+  }
+
+  const lowerContextText = contextText.toLowerCase();
+  const lowerNodeContextText = nodeContextText.toLowerCase();
+
+  const isPrefix = direction === 'prefix';
+  const isExactMatch = isPrefix
+    ? lowerNodeContextText.endsWith(lowerContextText)
+    : lowerNodeContextText.startsWith(lowerContextText);
+
+  if (isExactMatch) {
+    return 2; // 精確匹配
+  }
+
+  const windowHalf = Math.floor(CONTEXT_SEARCH_WINDOW / 2);
+  const nodePart = isPrefix
+    ? lowerNodeContextText.slice(-windowHalf)
+    : lowerNodeContextText.slice(0, windowHalf);
+  const contextPart = isPrefix
+    ? lowerContextText.slice(-PARTIAL_MATCH_LENGTH)
+    : lowerContextText.slice(0, PARTIAL_MATCH_LENGTH);
+
+  if (nodePart.includes(contextPart)) {
+    return 1; // 局部匹配
+  }
+
+  return 0;
+}
+
+/**
  * 計算單個候選匹配項基於上下文的評分
  *
  * @param {object} candidate - 候選匹配項
@@ -356,27 +437,13 @@ function getSuffixFromNodes(textNodes, nodeIndex, initialText) {
 function calculateCandidateScore(candidate, context, textNodes) {
   let score = 0;
 
-  const windowHalf = Math.floor(CONTEXT_SEARCH_WINDOW / 2);
-
   if (context.prefix) {
     const initialPrefix = candidate.nodeText.slice(
       Math.max(0, candidate.matchIndex - CONTEXT_SEARCH_WINDOW),
       candidate.matchIndex
     );
     const nodePrefixText = getPrefixFromNodes(textNodes, candidate.nodeIndex, initialPrefix);
-
-    const lowerContextPrefix = context.prefix.toLowerCase();
-    const lowerNodePrefixText = nodePrefixText.toLowerCase();
-
-    if (lowerNodePrefixText.endsWith(lowerContextPrefix)) {
-      score += 2; // 精確匹配
-    } else if (
-      lowerNodePrefixText
-        .slice(-windowHalf)
-        .includes(lowerContextPrefix.slice(-PARTIAL_MATCH_LENGTH))
-    ) {
-      score += 1; // 局部匹配
-    }
+    score += calculateSingleContextScore(context.prefix, nodePrefixText, 'prefix');
   }
 
   if (context.suffix) {
@@ -385,19 +452,7 @@ function calculateCandidateScore(candidate, context, textNodes) {
       candidate.matchIndex + candidate.matchLength + CONTEXT_SEARCH_WINDOW
     );
     const nodeSuffixText = getSuffixFromNodes(textNodes, candidate.nodeIndex, initialSuffix);
-
-    const lowerContextSuffix = context.suffix.toLowerCase();
-    const lowerNodeSuffixText = nodeSuffixText.toLowerCase();
-
-    if (lowerNodeSuffixText.startsWith(lowerContextSuffix)) {
-      score += 2; // 精確匹配
-    } else if (
-      lowerNodeSuffixText
-        .slice(0, windowHalf)
-        .includes(lowerContextSuffix.slice(0, PARTIAL_MATCH_LENGTH))
-    ) {
-      score += 1; // 局部匹配
-    }
+    score += calculateSingleContextScore(context.suffix, nodeSuffixText, 'suffix');
   }
 
   return score;
@@ -410,6 +465,93 @@ function calculateCandidateScore(candidate, context, textNodes) {
  * @param {object} [context={}] - 包含 prefix 和 suffix
  * @returns {Range|null} 找到的最佳 Range 或 null
  */
+/**
+ * 建立具備空白字元彈性的正則表達式
+ *
+ * @param {string} cleanText - 清理過後的文本
+ * @returns {RegExp}
+ */
+function createWhitespaceFlexibleRegex(cleanText) {
+  // 首先轉義所有正則表達式元字符，使其被當作普通字符處理
+  const escapedText = cleanText.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
+
+  // 然後將連續的空白字符轉換為 \s+ 以實現寬鬆匹配
+  const normalizedSearch = escapedText.replaceAll(/\s+/g, String.raw`\s+`);
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  return new RegExp(normalizedSearch, 'ig'); // 改為全域比對
+}
+
+/**
+ * 判斷是否直接使用第一個候選者（只有一個候選者，或完全無上下文時）
+ *
+ * @param {Array} candidates - 候選者陣列
+ * @param {object} context - 上下文
+ * @returns {boolean}
+ */
+function shouldUseFirstFuzzyCandidate(candidates, context) {
+  return candidates.length === 1 || !hasContextAnchors(context);
+}
+
+/**
+ * 從多個候選者中評分並選出最佳的候選者
+ *
+ * @param {Array} candidates - 候選者陣列
+ * @param {object} context - 上下文
+ * @param {Text[]} textNodes - 文本節點
+ * @returns {object} 包含 bestCandidate 與 maxScore
+ */
+function selectBestFuzzyCandidate(candidates, context, textNodes) {
+  let bestCandidate = candidates[0];
+  let maxScore = -1;
+
+  for (const candidate of candidates) {
+    const score = calculateCandidateScore(candidate, context, textNodes);
+    if (score > maxScore) {
+      maxScore = score;
+      bestCandidate = candidate;
+    }
+  }
+
+  return { bestCandidate, maxScore };
+}
+
+/**
+ * 判斷是否應回報模糊匹配消歧義失敗
+ *
+ * @param {number} maxScore - 最高分
+ * @param {object} context - 上下文
+ * @returns {boolean}
+ */
+function shouldReportFuzzyDisambiguationFailure(maxScore, context) {
+  return maxScore <= 0 && hasContextAnchors(context) && globalThis.Logger !== undefined;
+}
+
+/**
+ * 記錄模糊匹配消歧義失敗的偵錯日誌
+ *
+ * @param {Array} candidates - 候選者
+ * @param {object} bestCandidate - 最佳候選者
+ * @param {number} maxScore - 最高分
+ * @param {object} context - 上下文
+ */
+function logFuzzyDisambiguationFailure(candidates, bestCandidate, maxScore, context) {
+  globalThis.Logger?.debug(
+    SEARCH_LOG_TAG,
+    'calculateCandidateScore failed to disambiguate. maxScore <= 0.',
+    {
+      prefixLength: context.prefix?.length || 0,
+      suffixLength: context.suffix?.length || 0,
+      candidateCount: candidates.length,
+      bestCandidateRangeLength: bestCandidate.range?.toString?.()?.length || 0,
+      maxScore,
+      scoringFunction: calculateCandidateScore.name,
+      candidatesInfo: candidates.map(candidateInfo => ({
+        matchIndex: candidateInfo.matchIndex,
+      })),
+    }
+  );
+}
+
 export function findTextFuzzy(textToFind, context = {}) {
   try {
     if (!document.body) {
@@ -424,52 +566,22 @@ export function findTextFuzzy(textToFind, context = {}) {
     // 取得所有文字節點（唯一一次 DOM 掃描）
     const textNodes = getTextNodesForSearch();
 
-    // 首先轉義所有正則表達式元字符，使其被當作普通字符處理
-    const escapedText = cleanText.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
-
-    // 然後將連續的空白字符轉換為 \s+ 以實現寬鬆匹配
-    const normalizedSearch = escapedText.replaceAll(/\s+/g, String.raw`\s+`);
-    // eslint-disable-next-line security/detect-non-literal-regexp
-    const regex = new RegExp(normalizedSearch, 'ig'); // 改為全域比對
-
+    const regex = createWhitespaceFlexibleRegex(cleanText);
     const candidates = findRegexCandidates(regex, textNodes);
 
     if (candidates.length === 0) {
       return null;
     }
 
-    if (candidates.length === 1 || !(context.prefix || context.suffix)) {
+    if (shouldUseFirstFuzzyCandidate(candidates, context)) {
       return candidates[0].range; // 只有一個候選者或無上下文，直接返回
     }
 
     // 多候選情況下的消歧義打分
-    let bestCandidate = candidates[0];
-    let maxScore = -1;
+    const { bestCandidate, maxScore } = selectBestFuzzyCandidate(candidates, context, textNodes);
 
-    for (const candidate of candidates) {
-      const score = calculateCandidateScore(candidate, context, textNodes);
-      if (score > maxScore) {
-        maxScore = score;
-        bestCandidate = candidate;
-      }
-    }
-
-    if (maxScore <= 0 && (context.prefix || context.suffix) && globalThis.Logger !== undefined) {
-      globalThis.Logger?.debug(
-        SEARCH_LOG_TAG,
-        'calculateCandidateScore failed to disambiguate. maxScore <= 0.',
-        {
-          prefixLength: context.prefix?.length || 0,
-          suffixLength: context.suffix?.length || 0,
-          candidateCount: candidates.length,
-          bestCandidateRangeLength: bestCandidate.range?.toString?.()?.length || 0,
-          maxScore,
-          scoringFunction: calculateCandidateScore.name,
-          candidatesInfo: candidates.map(candidateInfo => ({
-            matchIndex: candidateInfo.matchIndex,
-          })),
-        }
-      );
+    if (shouldReportFuzzyDisambiguationFailure(maxScore, context)) {
+      logFuzzyDisambiguationFailure(candidates, bestCandidate, maxScore, context);
     }
 
     return bestCandidate.range;

--- a/scripts/highlighter/utils/textSearch.js
+++ b/scripts/highlighter/utils/textSearch.js
@@ -315,7 +315,11 @@ function createRangeFromNodesMatch(nodesInRange, matchIndex, textLength) {
     return range;
   } catch (error) {
     if (globalThis.Logger !== undefined) {
-      globalThis.Logger?.warn(SEARCH_LOG_TAG, '創建跨節點 Range 失敗:', error);
+      globalThis.Logger?.warn(`${SEARCH_LOG_TAG} 創建跨節點 Range 失敗:`, {
+        action: 'createRangeFromNodesMatch',
+        result: 'failed',
+        error,
+      });
     }
     return null;
   }

--- a/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
+++ b/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
@@ -74,6 +74,30 @@ describe('TextSearch Utils Coverage Tests', () => {
       expect(range).toBeNull();
     });
 
+    test('should treat null context as no context', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      const mockSelection = {
+        removeAllRanges: jest.fn(),
+        getRangeAt: jest.fn(() => {
+          const range = document.createRange();
+          const textNode = document.body.firstChild.firstChild;
+          range.setStart(textNode, 0);
+          range.setEnd(textNode, 4);
+          return range;
+        }),
+        rangeCount: 1,
+      };
+
+      globalThis.getSelection = jest.fn(() => mockSelection);
+      globalThis.find = jest.fn(() => true);
+
+      const range = findTextInPage('Test', null);
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+    });
+
     test('should clean text before searching', () => {
       document.body.innerHTML = '<p>Hello World</p>';
 
@@ -120,7 +144,72 @@ describe('TextSearch Utils Coverage Tests', () => {
       expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
     });
 
-    test('should cleanup selection when cloneRange throws', () => {
+    test('should fallback to TreeWalker when getSelection returns null', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      globalThis.getSelection = jest.fn(() => null);
+      globalThis.find = jest.fn(() => true);
+
+      const range = findTextInPage('Test');
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+      expect(globalThis.find).not.toHaveBeenCalled();
+    });
+
+    test('should fallback to TreeWalker when getSelection is unavailable', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      const originalGetSelection = globalThis.getSelection;
+      globalThis.getSelection = undefined;
+      globalThis.find = jest.fn(() => true);
+
+      const range = findTextInPage('Test');
+
+      globalThis.getSelection = originalGetSelection;
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+      expect(globalThis.find).not.toHaveBeenCalled();
+    });
+
+    test('should fallback to TreeWalker when window.find is unavailable', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      const mockSelection = {
+        removeAllRanges: jest.fn(),
+        rangeCount: 0,
+      };
+
+      globalThis.getSelection = jest.fn(() => mockSelection);
+      globalThis.find = undefined;
+
+      const range = findTextInPage('Test');
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+      expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+    });
+
+    test('should fallback to TreeWalker when window.find leaves no selection range', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      const mockSelection = {
+        removeAllRanges: jest.fn(),
+        rangeCount: 0,
+      };
+
+      globalThis.getSelection = jest.fn(() => mockSelection);
+      globalThis.find = jest.fn(() => true);
+
+      const range = findTextInPage('Test');
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+      expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+    });
+
+    test('should cleanup selection and fallback to TreeWalker when cloneRange throws', () => {
       document.body.innerHTML = '<p>Test content</p>';
 
       const mockSelection = {
@@ -138,20 +227,31 @@ describe('TextSearch Utils Coverage Tests', () => {
 
       const range = findTextInPage('Test');
 
-      expect(range).toBeNull();
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
       expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
-      expect(globalThis.Logger.error).toHaveBeenCalled();
     });
 
-    test('should handle errors gracefully', () => {
+    test('should continue fallback search when getSelection throws', () => {
+      document.body.innerHTML = '<p>Test content</p>';
+
       globalThis.getSelection = jest.fn(() => {
         throw new Error('Test error');
       });
 
       const range = findTextInPage('Test');
 
-      expect(range).toBeNull();
-      expect(globalThis.Logger.error).toHaveBeenCalled();
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+    });
+
+    test('should fallback to TreeWalker when contextual fuzzy search misses', () => {
+      document.body.innerHTML = '<p><span>Test</span><span>ing</span></p>';
+
+      const range = findTextInPage('Testing', { prefix: 'missing-prefix' });
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Testing');
     });
   });
 
@@ -240,6 +340,27 @@ describe('TextSearch Utils Coverage Tests', () => {
 
       document.createRange = originalCreateRange;
     });
+
+    test('should log structured context when TreeWalker search throws', () => {
+      const treeWalkerError = new Error('TreeWalker error');
+      const originalCreateTreeWalker = document.createTreeWalker;
+      document.createTreeWalker = jest.fn(() => {
+        throw treeWalkerError;
+      });
+
+      const range = findTextWithTreeWalker('Test');
+      document.createTreeWalker = originalCreateTreeWalker;
+
+      expect(range).toBeNull();
+      expect(globalThis.Logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('[textSearch] findTextWithTreeWalker error:'),
+        expect.objectContaining({
+          action: 'findTextWithTreeWalker',
+          result: 'failed',
+          error: treeWalkerError,
+        })
+      );
+    });
   });
 
   describe('findTextFuzzy', () => {
@@ -281,6 +402,26 @@ describe('TextSearch Utils Coverage Tests', () => {
       const range = findTextFuzzy('Test content');
 
       expect(range).not.toBeNull();
+    });
+
+    test('should log structured context when fuzzy disambiguation fails', () => {
+      document.body.innerHTML = '<p>target middle target</p>';
+
+      const range = findTextFuzzy('target', {
+        prefix: 'missing-prefix',
+        suffix: 'missing-suffix',
+      });
+
+      expect(range).not.toBeNull();
+      expect(globalThis.Logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('[textSearch]'),
+        expect.objectContaining({
+          action: 'findTextFuzzy',
+          result: 'disambiguation_failed',
+          candidateCount: 2,
+          maxScore: 0,
+        })
+      );
     });
   });
 });

--- a/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
+++ b/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
@@ -323,43 +323,53 @@ describe('TextSearch Utils Coverage Tests', () => {
     test('should log warning when creating cross-node range fails', () => {
       document.body.innerHTML = '<p><span>Test</span><span>content</span></p>';
 
-      // Mock Range.setStart to throw error
+      const setStartError = new Error('setStart error');
       const originalCreateRange = document.createRange;
-      document.createRange = jest.fn(() => {
+      const createRangeSpy = jest.spyOn(document, 'createRange').mockImplementation(() => {
         const range = originalCreateRange.call(document);
         range.setStart = jest.fn(() => {
-          throw new Error('setStart error');
+          throw setStartError;
         });
         return range;
       });
 
-      findTextWithTreeWalker('Testcontent');
+      try {
+        const range = findTextWithTreeWalker('Testcontent');
 
-      // Should try and fail, logging warning
-      expect(globalThis.Logger.warn).toHaveBeenCalled();
-
-      document.createRange = originalCreateRange;
+        expect(range).toBeNull();
+        expect(globalThis.Logger.warn).toHaveBeenCalledWith('[textSearch] 創建跨節點 Range 失敗:', {
+          action: 'createRangeFromNodesMatch',
+          result: 'failed',
+          error: setStartError,
+        });
+      } finally {
+        createRangeSpy.mockRestore();
+      }
     });
 
     test('should log structured context when TreeWalker search throws', () => {
       const treeWalkerError = new Error('TreeWalker error');
-      const originalCreateTreeWalker = document.createTreeWalker;
-      document.createTreeWalker = jest.fn(() => {
-        throw treeWalkerError;
-      });
+      const createTreeWalkerSpy = jest
+        .spyOn(document, 'createTreeWalker')
+        .mockImplementation(() => {
+          throw treeWalkerError;
+        });
 
-      const range = findTextWithTreeWalker('Test');
-      document.createTreeWalker = originalCreateTreeWalker;
+      try {
+        const range = findTextWithTreeWalker('Test');
 
-      expect(range).toBeNull();
-      expect(globalThis.Logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('[textSearch] findTextWithTreeWalker error:'),
-        expect.objectContaining({
-          action: 'findTextWithTreeWalker',
-          result: 'failed',
-          error: treeWalkerError,
-        })
-      );
+        expect(range).toBeNull();
+        expect(globalThis.Logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('[textSearch] findTextWithTreeWalker error:'),
+          expect.objectContaining({
+            action: 'findTextWithTreeWalker',
+            result: 'failed',
+            error: treeWalkerError,
+          })
+        );
+      } finally {
+        createTreeWalkerSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
+++ b/tests/unit/highlighter/utils/textSearch.edge-cases.test.js
@@ -30,6 +30,24 @@ describe('TextSearch Utils Coverage Tests', () => {
   });
 
   describe('findTextInPage', () => {
+    function createSelectionWithoutRange() {
+      return {
+        removeAllRanges: jest.fn(),
+        rangeCount: 0,
+      };
+    }
+
+    function expectTreeWalkerFallback(configureFallback) {
+      document.body.innerHTML = '<p>Test content</p>';
+
+      const state = configureFallback();
+      const range = findTextInPage('Test');
+
+      expect(range).not.toBeNull();
+      expect(range.toString()).toBe('Test');
+      return state;
+    }
+
     test('should find simple text using window.find', () => {
       document.body.innerHTML = '<p>Hello World</p>';
 
@@ -127,86 +145,68 @@ describe('TextSearch Utils Coverage Tests', () => {
       expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
     });
 
-    test('should fallback to TreeWalker when window.find fails', () => {
-      document.body.innerHTML = '<p>Test content</p>';
-
-      const mockSelection = {
-        removeAllRanges: jest.fn(),
-        rangeCount: 0,
-      };
-
-      globalThis.getSelection = jest.fn(() => mockSelection);
-      globalThis.find = jest.fn(() => false);
-
-      const range = findTextInPage('Test');
-
-      expect(range).not.toBeNull();
-      expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
-    });
-
-    test('should fallback to TreeWalker when getSelection returns null', () => {
-      document.body.innerHTML = '<p>Test content</p>';
-
-      globalThis.getSelection = jest.fn(() => null);
-      globalThis.find = jest.fn(() => true);
-
-      const range = findTextInPage('Test');
-
-      expect(range).not.toBeNull();
-      expect(range.toString()).toBe('Test');
-      expect(globalThis.find).not.toHaveBeenCalled();
-    });
-
-    test('should fallback to TreeWalker when getSelection is unavailable', () => {
-      document.body.innerHTML = '<p>Test content</p>';
-
-      const originalGetSelection = globalThis.getSelection;
-      globalThis.getSelection = undefined;
-      globalThis.find = jest.fn(() => true);
-
-      const range = findTextInPage('Test');
-
-      globalThis.getSelection = originalGetSelection;
-
-      expect(range).not.toBeNull();
-      expect(range.toString()).toBe('Test');
-      expect(globalThis.find).not.toHaveBeenCalled();
-    });
-
-    test('should fallback to TreeWalker when window.find is unavailable', () => {
-      document.body.innerHTML = '<p>Test content</p>';
-
-      const mockSelection = {
-        removeAllRanges: jest.fn(),
-        rangeCount: 0,
-      };
-
-      globalThis.getSelection = jest.fn(() => mockSelection);
-      globalThis.find = undefined;
-
-      const range = findTextInPage('Test');
-
-      expect(range).not.toBeNull();
-      expect(range.toString()).toBe('Test');
-      expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
-    });
-
-    test('should fallback to TreeWalker when window.find leaves no selection range', () => {
-      document.body.innerHTML = '<p>Test content</p>';
-
-      const mockSelection = {
-        removeAllRanges: jest.fn(),
-        rangeCount: 0,
-      };
-
-      globalThis.getSelection = jest.fn(() => mockSelection);
-      globalThis.find = jest.fn(() => true);
-
-      const range = findTextInPage('Test');
-
-      expect(range).not.toBeNull();
-      expect(range.toString()).toBe('Test');
-      expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+    test.each([
+      [
+        'window.find fails',
+        () => {
+          const mockSelection = createSelectionWithoutRange();
+          globalThis.getSelection = jest.fn(() => mockSelection);
+          globalThis.find = jest.fn(() => false);
+          return { mockSelection };
+        },
+        ({ mockSelection }) => {
+          expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+        },
+      ],
+      [
+        'getSelection returns null',
+        () => {
+          globalThis.getSelection = jest.fn(() => null);
+          globalThis.find = jest.fn(() => true);
+          return {};
+        },
+        () => {
+          expect(globalThis.find).not.toHaveBeenCalled();
+        },
+      ],
+      [
+        'getSelection is unavailable',
+        () => {
+          globalThis.getSelection = undefined;
+          globalThis.find = jest.fn(() => true);
+          return {};
+        },
+        () => {
+          expect(globalThis.find).not.toHaveBeenCalled();
+        },
+      ],
+      [
+        'window.find is unavailable',
+        () => {
+          const mockSelection = createSelectionWithoutRange();
+          globalThis.getSelection = jest.fn(() => mockSelection);
+          globalThis.find = undefined;
+          return { mockSelection };
+        },
+        ({ mockSelection }) => {
+          expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+        },
+      ],
+      [
+        'window.find leaves no selection range',
+        () => {
+          const mockSelection = createSelectionWithoutRange();
+          globalThis.getSelection = jest.fn(() => mockSelection);
+          globalThis.find = jest.fn(() => true);
+          return { mockSelection };
+        },
+        ({ mockSelection }) => {
+          expect(mockSelection.removeAllRanges).toHaveBeenCalledTimes(2);
+        },
+      ],
+    ])('should fallback to TreeWalker when %s', (_name, configureFallback, assertFallback) => {
+      const state = expectTreeWalkerFallback(configureFallback);
+      assertFallback(state);
     });
 
     test('should cleanup selection and fallback to TreeWalker when cloneRange throws', () => {


### PR DESCRIPTION
### 摘要
重構文本搜索邏輯以降低複雜性，提升可讀性和維護性。

### 變更內容
- 簡化 `findTextInPage` 和 `findTextFuzzy` 函數的邏輯。
- 減少文本搜索日誌的複雜性。
- 扁平化文本搜索的條件判斷。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

