### PR TITLE
refactor: reduce path utils complexity

### DIFF
--- a/scripts/highlighter/utils/path.js
+++ b/scripts/highlighter/utils/path.js
@@ -13,12 +13,18 @@ function isTextNode(node) {
 function buildTextNodePathStep(parent, node) {
   const textNodes = Array.from(parent.childNodes).filter(childNode => isTextNode(childNode));
   const index = textNodes.indexOf(node);
+  if (index === -1) {
+    return null;
+  }
   return `text[${index}]`;
 }
 
 function buildElementPathStep(parent, node) {
   const siblings = Array.from(parent.children);
   const index = siblings.indexOf(node);
+  if (index === -1) {
+    return null;
+  }
   return `${node.tagName.toLowerCase()}[${index}]`;
 }
 
@@ -29,11 +35,13 @@ function buildNodePathStep(node) {
   }
 
   if (isTextNode(node)) {
-    return { parent, step: buildTextNodePathStep(parent, node) };
+    const step = buildTextNodePathStep(parent, node);
+    return step ? { parent, step } : null;
   }
 
   if (node.nodeType === Node.ELEMENT_NODE) {
-    return { parent, step: buildElementPathStep(parent, node) };
+    const step = buildElementPathStep(parent, node);
+    return step ? { parent, step } : null;
   }
 
   return null;
@@ -129,7 +137,7 @@ function normalizePathTag(tag) {
 }
 
 function getElementTagName(element) {
-  return element.tagName?.toLowerCase();
+  return element?.tagName?.toLowerCase();
 }
 
 function getIndexedElementMatch(children, index, tag) {
@@ -196,12 +204,20 @@ export function resolveTextNode(current, step) {
 }
 
 function parsePathInput(path) {
-  if (typeof path !== 'string') {
+  if (typeof path === 'string') {
+    const steps = parsePathFromString(path);
+    return { isValid: steps !== null, steps };
+  }
+
+  if (Array.isArray(path)) {
     return { isValid: true, steps: path };
   }
 
-  const steps = parsePathFromString(path);
-  return { isValid: steps !== null, steps };
+  if (path == null) {
+    return { isValid: true, steps: [] };
+  }
+
+  return { isValid: false, steps: null };
 }
 
 const PATH_STEP_RESOLVERS = {

--- a/scripts/highlighter/utils/path.js
+++ b/scripts/highlighter/utils/path.js
@@ -6,6 +6,39 @@
 /** 匹配路徑步驟格式 'tagName[index]' 的正則表達式（支援含連字號的自訂元素，如 my-widget） */
 const PATH_REGEX = /^([\w-]+)\[(\d+)\]$/;
 
+function isTextNode(node) {
+  return node.nodeType === Node.TEXT_NODE;
+}
+
+function buildTextNodePathStep(parent, node) {
+  const textNodes = Array.from(parent.childNodes).filter(childNode => isTextNode(childNode));
+  const index = textNodes.indexOf(node);
+  return `text[${index}]`;
+}
+
+function buildElementPathStep(parent, node) {
+  const siblings = Array.from(parent.children);
+  const index = siblings.indexOf(node);
+  return `${node.tagName.toLowerCase()}[${index}]`;
+}
+
+function buildNodePathStep(node) {
+  const parent = node.parentNode;
+  if (!parent) {
+    return null;
+  }
+
+  if (isTextNode(node)) {
+    return { parent, step: buildTextNodePathStep(parent, node) };
+  }
+
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    return { parent, step: buildElementPathStep(parent, node) };
+  }
+
+  return null;
+}
+
 /**
  * 獲取節點的路徑（從當前節點到 document.body）
  *
@@ -24,35 +57,13 @@ export function getNodePath(node) {
   let current = node;
 
   while (current && current !== document.body) {
-    if (current.nodeType === Node.TEXT_NODE) {
-      // 文本節點：記錄所在位置
-      const parent = current.parentNode;
-      if (parent) {
-        const textNodes = Array.from(parent.childNodes).filter(
-          childNode => childNode.nodeType === Node.TEXT_NODE
-        );
-        const index = textNodes.indexOf(current);
-        pathSteps.unshift(`text[${index}]`);
-        current = parent;
-      } else {
-        // 文本節點沒有父節點，終止迴圈
-        break;
-      }
-    } else if (current.nodeType === Node.ELEMENT_NODE) {
-      // 元素節點:記錄標籤名和在父節點中的索引
-      const parent = current.parentNode;
-      if (parent) {
-        const siblings = Array.from(parent.children);
-        const index = siblings.indexOf(current);
-        pathSteps.unshift(`${current.tagName.toLowerCase()}[${index}]`);
-        current = parent;
-      } else {
-        // 元素節點沒有父節點，終止迴圈
-        break;
-      }
-    } else {
+    const pathStep = buildNodePathStep(current);
+    if (!pathStep) {
       break;
     }
+
+    pathSteps.unshift(pathStep.step);
+    current = pathStep.parent;
   }
 
   // 返回字符串格式 "div[0]/p[2]/text[0]"
@@ -105,6 +116,35 @@ export function parsePathFromString(pathString) {
   return path;
 }
 
+function getElementChildren(current) {
+  return current?.children ? Array.from(current.children) : null;
+}
+
+function isValidPathIndex(index) {
+  return Number.isInteger(index) && index >= 0;
+}
+
+function normalizePathTag(tag) {
+  return tag?.toLowerCase();
+}
+
+function getElementTagName(element) {
+  return element.tagName?.toLowerCase();
+}
+
+function getIndexedElementMatch(children, index, tag) {
+  if (index >= children.length) {
+    return null;
+  }
+
+  const child = children[index];
+  return getElementTagName(child) === tag ? child : null;
+}
+
+function findFirstElementByTag(children, tag) {
+  return children.find(child => getElementTagName(child) === tag) || null;
+}
+
 /**
  * 根據 element 類型的路徑步驟，從當前節點導覽到下一個子元素
  *
@@ -114,24 +154,15 @@ export function parsePathFromString(pathString) {
  */
 export function resolveElementNode(current, step) {
   try {
-    if (!current?.children) {
+    const children = getElementChildren(current);
+    if (!children || !isValidPathIndex(step.index)) {
       return null;
     }
 
-    if (!Number.isInteger(step.index) || step.index < 0) {
-      return null;
-    }
-
-    const children = Array.from(current.children);
-    const tag = step.tag?.toLowerCase();
-
-    if (step.index < children.length && children[step.index].tagName?.toLowerCase() === tag) {
-      return children[step.index];
-    }
-
-    // 模糊匹配：查找具有相同標籤名的元素
-    const matchingElements = children.filter(child => child.tagName?.toLowerCase() === tag);
-    return matchingElements.length > 0 ? matchingElements[0] : null;
+    const tag = normalizePathTag(step.tag);
+    return (
+      getIndexedElementMatch(children, step.index, tag) || findFirstElementByTag(children, tag)
+    );
   } catch {
     return null;
   }
@@ -164,6 +195,38 @@ export function resolveTextNode(current, step) {
   }
 }
 
+function parsePathInput(path) {
+  if (typeof path !== 'string') {
+    return { isValid: true, steps: path };
+  }
+
+  const steps = parsePathFromString(path);
+  return { isValid: steps !== null, steps };
+}
+
+const PATH_STEP_RESOLVERS = {
+  element: resolveElementNode,
+  text: resolveTextNode,
+};
+
+function resolvePathStep(current, step) {
+  const resolver = PATH_STEP_RESOLVERS[step.type];
+  return resolver ? resolver(current, step) : null;
+}
+
+function resolvePathSteps(startNode, path) {
+  let current = startNode;
+
+  for (const step of path) {
+    current = resolvePathStep(current, step);
+    if (!current) {
+      return null;
+    }
+  }
+
+  return current;
+}
+
 /**
  * 根據路徑對象數組獲取 DOM 節點
  *
@@ -173,40 +236,17 @@ export function resolveTextNode(current, step) {
  * const node = getNodeByPath('div[0]/p[2]/text[0]');
  */
 export function getNodeByPath(path) {
-  // 如果是字符串格式，先解析
-  if (typeof path === 'string') {
-    path = parsePathFromString(path);
-    if (!path) {
-      return null;
-    }
-  }
+  const { isValid, steps } = parsePathInput(path);
 
-  // 確保 document.body 存在
-  if (!document?.body) {
+  if (!isValid || !document?.body) {
     return null;
   }
 
-  // 空路徑返回 document.body
-  if (!path || path.length === 0) {
+  if (!steps || steps.length === 0) {
     return document.body;
   }
 
-  let current = document.body;
-
-  for (const step of path) {
-    if (step.type === 'element') {
-      current = resolveElementNode(current, step);
-    } else if (step.type === 'text') {
-      current = resolveTextNode(current, step);
-    } else {
-      return null;
-    }
-    if (!current) {
-      return null;
-    }
-  }
-
-  return current;
+  return resolvePathSteps(document.body, steps);
 }
 
 /**

--- a/tests/unit/highlighter/utils/path.test.js
+++ b/tests/unit/highlighter/utils/path.test.js
@@ -76,6 +76,36 @@ describe('utils/path', () => {
       const path = getNodePath(comment);
       expect(path).toBe('');
     });
+
+    test('should stop path building when an element is missing from its parent children', () => {
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      parent.append(child);
+      document.body.append(parent);
+
+      Object.defineProperty(parent, 'children', {
+        value: [],
+        configurable: true,
+      });
+
+      const path = getNodePath(child);
+      expect(path).toBe('');
+    });
+
+    test('should stop path building when a text node is missing from its parent childNodes', () => {
+      const parent = document.createElement('div');
+      const textNode = document.createTextNode('Hello');
+      parent.append(textNode);
+      document.body.append(parent);
+
+      Object.defineProperty(parent, 'childNodes', {
+        value: [],
+        configurable: true,
+      });
+
+      const path = getNodePath(textNode);
+      expect(path).toBe('');
+    });
   });
 
   describe('parsePathFromString', () => {
@@ -193,6 +223,11 @@ describe('utils/path', () => {
 
       expect(node).toBeNull();
     });
+
+    test('should return null for unsupported path input objects', () => {
+      expect(() => getNodeByPath({})).not.toThrow();
+      expect(getNodeByPath({})).toBeNull();
+    });
   });
 
   describe('resolveElementNode', () => {
@@ -260,6 +295,15 @@ describe('utils/path', () => {
       const result = resolveElementNode(div, { type: 'element', tag: 'p', index: 0.5 });
 
       expect(result).toBeNull();
+    });
+
+    test('should skip missing children while fuzzy matching by tag', () => {
+      const paragraph = document.createElement('p');
+      const current = { children: [null, paragraph] };
+
+      const result = resolveElementNode(current, { type: 'element', tag: 'p', index: 0 });
+
+      expect(result).toBe(paragraph);
     });
   });
 

--- a/tests/unit/highlighter/utils/path.test.js
+++ b/tests/unit/highlighter/utils/path.test.js
@@ -66,6 +66,16 @@ describe('utils/path', () => {
       const path = getNodePath(el);
       expect(path).toBe('my-widget[0]');
     });
+
+    test('should stop path building for unsupported node types', () => {
+      const div = document.createElement('div');
+      const comment = document.createComment('metadata');
+      div.append(comment);
+      document.body.append(div);
+
+      const path = getNodePath(comment);
+      expect(path).toBe('');
+    });
   });
 
   describe('parsePathFromString', () => {
@@ -177,6 +187,12 @@ describe('utils/path', () => {
       expect(node).not.toBe(null);
       expect(node.tagName.toLowerCase()).toBe('p');
     });
+
+    test('should return null for unknown path step type', () => {
+      const node = getNodeByPath([{ type: 'comment', index: 0 }]);
+
+      expect(node).toBeNull();
+    });
   });
 
   describe('resolveElementNode', () => {
@@ -226,6 +242,24 @@ describe('utils/path', () => {
       expect(result).not.toBeNull();
       expect(result.tagName.toLowerCase()).toBe('p');
       expect(result.textContent).toBe('Right');
+    });
+
+    test('should return null for negative element index', () => {
+      document.body.innerHTML = '<div><p>First</p></div>';
+      const div = document.body.firstElementChild;
+
+      const result = resolveElementNode(div, { type: 'element', tag: 'p', index: -1 });
+
+      expect(result).toBeNull();
+    });
+
+    test('should return null for non-integer element index', () => {
+      document.body.innerHTML = '<div><p>First</p></div>';
+      const div = document.body.firstElementChild;
+
+      const result = resolveElementNode(div, { type: 'element', tag: 'p', index: 0.5 });
+
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
### 摘要
重構路徑工具以簡化邏輯，提升可讀性和維護性。

### 變更內容
- 將路徑步驟的構建邏輯分解為多個輔助函數。
- 增加對不支持的節點類型的處理，確保路徑構建的穩定性。
- 改進元素和文本節點的解析邏輯，簡化主函數的結構。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

