### PR TITLE
refactor: simplify account callback logic and enhance error handling

### DIFF
--- a/scripts/auth/auth.js
+++ b/scripts/auth/auth.js
@@ -45,12 +45,27 @@ async function handleResponseError(res, prefix) {
 }
 
 /**
+ * 驗證 data 是否為有效的物件（非 null、非陣列、非 primitive）。
+ *
+ * @param {any} data
+ * @param {string} context
+ * @throws {Error} 若 data 不是有效的物件
+ */
+function ensureValidObject(data, context) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`${context} response is not a valid object`);
+  }
+}
+
+/**
  * 驗證並正規化 exchange ticket 的回應資料。
  *
  * @param {any} data
  * @returns {{accessToken: string; refreshToken: string; expiresAt: number; userId: string}}
  */
 function normalizeExchangeResponse(data) {
+  ensureValidObject(data, 'Exchange');
+
   if (!data.access_token) {
     throw new Error('Exchange response missing required field (access_token)');
   }
@@ -75,6 +90,8 @@ function normalizeExchangeResponse(data) {
  * @returns {{userId: string; email: string; displayName: string | null; avatarUrl: string | null}}
  */
 function normalizeMeResponse(data) {
+  ensureValidObject(data, 'Account/me');
+
   if (!data.email) {
     throw new Error('Account/me response missing required field (email)');
   }

--- a/scripts/auth/auth.js
+++ b/scripts/auth/auth.js
@@ -6,7 +6,7 @@
  * 2. POST /v1/account/session/exchange → 取得 tokens
  * 3. GET /v1/account/me → 取得 profile
  * 4. 成功：寫入 account session + profile，發送 account_session_updated，關閉頁面
- * 5. 任一步驟失敗：清除已取得的 token，顯示錯誤頁面，不關閉
+ * 5. 任一步驟失敗：清除已取得 spacing/tokens，顯示錯誤頁面，不關閉
  *
  * 設計原則（MUST NOT 違反）：
  * - 不使用任何 Notion OAuth 邏輯
@@ -25,6 +25,72 @@ import { RUNTIME_ACTIONS } from '../config/shared/runtimeActions.js';
 import { setAccountSession, setAccountProfile, clearAccountSession } from './accountSession.js';
 import { buildAccountApiUrl } from './accountLogin.js';
 import { showError, showLoading, showSuccess } from './callbackStatusView.js';
+
+// =============================================================================
+// Helper Functions (Network & Parsing)
+// =============================================================================
+
+/**
+ * 處理 HTTP 錯誤回應並拋出帶有詳細錯誤資訊的 Error。
+ *
+ * @param {Response} res
+ * @param {string} prefix
+ * @returns {Promise<never>}
+ * @throws {Error}
+ */
+async function handleResponseError(res, prefix) {
+  const errText = await res.text().catch(() => '');
+  const detail = errText ? ` — ${errText}` : '';
+  throw new Error(`${prefix}: HTTP ${res.status}${detail}`);
+}
+
+/**
+ * 驗證並正規化 exchange ticket 的回應資料。
+ *
+ * @param {any} data
+ * @returns {{accessToken: string; refreshToken: string; expiresAt: number; userId: string}}
+ */
+function normalizeExchangeResponse(data) {
+  if (!data.access_token) {
+    throw new Error('Exchange response missing required field (access_token)');
+  }
+
+  const expiresAt = Number(data.expires_at);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
+    throw new Error('Exchange response contains invalid expires_at');
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? '',
+    expiresAt,
+    userId: data.user_id ?? '',
+  };
+}
+
+/**
+ * 驗證並正規化 account/me 的回應資料。
+ *
+ * @param {any} data
+ * @returns {{userId: string; email: string; displayName: string | null; avatarUrl: string | null}}
+ */
+function normalizeMeResponse(data) {
+  if (!data.email) {
+    throw new Error('Account/me response missing required field (email)');
+  }
+
+  const userId = data.user_id ?? data.userId;
+  if (!userId) {
+    throw new Error('Account/me response missing required field (user_id)');
+  }
+
+  return {
+    userId,
+    email: data.email,
+    displayName: data.display_name ?? data.displayName ?? null,
+    avatarUrl: data.avatar_url ?? data.avatarUrl ?? null,
+  };
+}
 
 // =============================================================================
 // Auth flow
@@ -74,29 +140,11 @@ async function exchangeTicket(ticket, baseUrl) {
   });
 
   if (!res.ok) {
-    const errText = await res.text().catch(() => '');
-    const detail = errText ? ` — ${errText}` : '';
-    throw new Error(`Exchange failed: HTTP ${res.status}${detail}`);
+    await handleResponseError(res, 'Exchange failed');
   }
 
   const data = await res.json();
-
-  // 驗證必要欄位
-  if (!data.access_token) {
-    throw new Error('Exchange response missing required field (access_token)');
-  }
-
-  const expiresAt = Number(data.expires_at);
-  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
-    throw new Error('Exchange response contains invalid expires_at');
-  }
-
-  return {
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token ?? '',
-    expiresAt,
-    userId: data.user_id ?? '',
-  };
+  return normalizeExchangeResponse(data);
 }
 
 /**
@@ -116,28 +164,11 @@ async function fetchAccountMe(accessToken, baseUrl) {
   });
 
   if (!res.ok) {
-    const errText = await res.text().catch(() => '');
-    const detail = errText ? ` — ${errText}` : '';
-    throw new Error(`Account/me failed: HTTP ${res.status}${detail}`);
+    await handleResponseError(res, 'Account/me failed');
   }
 
   const data = await res.json();
-
-  if (!data.email) {
-    throw new Error('Account/me response missing required field (email)');
-  }
-
-  const userId = data.user_id ?? data.userId;
-  if (!userId) {
-    throw new Error('Account/me response missing required field (user_id)');
-  }
-
-  return {
-    userId,
-    email: data.email,
-    displayName: data.display_name ?? data.displayName ?? null,
-    avatarUrl: data.avatar_url ?? data.avatarUrl ?? null,
-  };
+  return normalizeMeResponse(data);
 }
 
 /**
@@ -156,6 +187,97 @@ function broadcastSessionUpdated(userId, email) {
     .catch(() => {
       // background 若未就緒，忽略錯誤；options 頁自行監聽 storage 變化
     });
+}
+
+// =============================================================================
+// Stage-level Orchestration Helpers
+// =============================================================================
+
+/**
+ * 執行票據交換階段。
+ * 若失敗，顯示錯誤並回傳 null。
+ *
+ * @param {string} ticket
+ * @param {string} baseUrl
+ * @param {any} messages
+ * @returns {Promise<any | null>}
+ */
+async function performTicketExchange(ticket, baseUrl, messages) {
+  showLoading(messages.STATUS_VERIFYING);
+  try {
+    return await exchangeTicket(ticket, baseUrl);
+  } catch (error) {
+    showError(
+      messages.TITLE_EXCHANGE_FAILED,
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * 載入帳號 profile 階段。
+ * 若失敗，清除 session、顯示錯誤並回傳 null。
+ *
+ * @param {string} accessToken
+ * @param {string} baseUrl
+ * @param {any} messages
+ * @returns {Promise<any | null>}
+ */
+async function performProfileLoading(accessToken, baseUrl, messages) {
+  showLoading(messages.STATUS_FETCHING_PROFILE);
+  try {
+    return await fetchAccountMe(accessToken, baseUrl);
+  } catch (error) {
+    await clearAccountSession().catch(() => {});
+    showError(
+      messages.TITLE_PROFILE_FAILED,
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * 持久化儲存帳號 Session 與 Profile，並發送廣播。
+ * 若失敗，清除 session、顯示錯誤並回傳 false。
+ *
+ * @param {any} tokens
+ * @param {any} profile
+ * @param {any} messages
+ * @returns {Promise<boolean>}
+ */
+async function persistAccountSession(tokens, profile, messages) {
+  try {
+    const resolvedUserId = profile.userId || tokens.userId;
+
+    await setAccountSession({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      userId: resolvedUserId,
+      email: profile.email,
+      displayName: profile.displayName,
+      avatarUrl: profile.avatarUrl,
+    });
+
+    await setAccountProfile({
+      userId: resolvedUserId,
+      email: profile.email,
+      displayName: profile.displayName,
+      avatarUrl: profile.avatarUrl,
+    });
+
+    broadcastSessionUpdated(resolvedUserId, profile.email);
+    return true;
+  } catch (error) {
+    await clearAccountSession().catch(() => {});
+    showError(
+      messages.TITLE_STORAGE_FAILED,
+      error instanceof Error ? error.message : String(error)
+    );
+    return false;
+  }
 }
 
 /**
@@ -177,70 +299,21 @@ async function runAuthFlow() {
     return;
   }
 
-  showLoading(messages.STATUS_VERIFYING);
-
-  let tokens;
-
   // 步驟 2：exchange ticket → tokens
-  try {
-    tokens = await exchangeTicket(ticket, baseUrl);
-  } catch (error) {
-    showError(
-      messages.TITLE_EXCHANGE_FAILED,
-      error instanceof Error ? error.message : String(error)
-    );
-    return; // 無 token，無需清理
-  }
-
-  showLoading(messages.STATUS_FETCHING_PROFILE);
-
-  let profile;
-
-  // 步驟 3：GET /v1/account/me
-  try {
-    profile = await fetchAccountMe(tokens.accessToken, baseUrl);
-  } catch (error) {
-    // Phase 1 保守策略：account/me 失敗 → 清除已取得的 token，回退未登入狀態
-    // （token 尚未寫入 storage，此處僅做防禦性清除）
-    await clearAccountSession().catch(() => {});
-    showError(
-      messages.TITLE_PROFILE_FAILED,
-      error instanceof Error ? error.message : String(error)
-    );
+  const tokens = await performTicketExchange(ticket, baseUrl, messages);
+  if (!tokens) {
     return;
   }
 
-  // 步驟 4：合併寫入 storage
-  // 由於上方 account/me 已成功，此時可安全寫入，不留下半登入狀態
-  try {
-    const resolvedUserId = profile.userId || tokens.userId;
+  // 步驟 3：GET /v1/account/me
+  const profile = await performProfileLoading(tokens.accessToken, baseUrl, messages);
+  if (!profile) {
+    return;
+  }
 
-    await setAccountSession({
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
-      expiresAt: tokens.expiresAt,
-      userId: resolvedUserId,
-      email: profile.email,
-      displayName: profile.displayName,
-      avatarUrl: profile.avatarUrl,
-    });
-
-    await setAccountProfile({
-      userId: resolvedUserId,
-      email: profile.email,
-      displayName: profile.displayName,
-      avatarUrl: profile.avatarUrl,
-    });
-
-    // 步驟 5：廣播 account_session_updated
-    broadcastSessionUpdated(resolvedUserId, profile.email);
-  } catch (error) {
-    // 寫入 storage 失敗：清除確保不留下半登入狀態
-    await clearAccountSession().catch(() => {});
-    showError(
-      messages.TITLE_STORAGE_FAILED,
-      error instanceof Error ? error.message : String(error)
-    );
+  // 步驟 4 & 5：合併寫入 storage 與廣播
+  const success = await persistAccountSession(tokens, profile, messages);
+  if (!success) {
     return;
   }
 

--- a/tests/unit/auth/auth.test.js
+++ b/tests/unit/auth/auth.test.js
@@ -276,4 +276,58 @@ describe('auth.js', () => {
     expect(document.querySelector('#status-area').textContent).toContain('user_id');
     expect(globalThis.close).not.toHaveBeenCalled();
   });
+
+  it('exchangeTicket 失敗時應顯示錯誤且不寫入 storage', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'invalid ticket',
+    });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(mockClearAccountSession).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('寫入 storage 失敗時應清除 session 並顯示錯誤', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access_123',
+          refresh_token: 'refresh_123',
+          expires_at: 1_700_000_000,
+          user_id: 'user_123',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          user_id: 'user_123',
+          email: 'user@example.com',
+          display_name: 'Test User',
+          avatar_url: 'https://cdn.example.com/avatar.png',
+        }),
+      });
+
+    mockSetAccountSession.mockRejectedValueOnce(new Error('storage quota exceeded'));
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockClearAccountSession).toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法儲存 Session');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/auth/auth.test.js
+++ b/tests/unit/auth/auth.test.js
@@ -297,6 +297,66 @@ describe('auth.js', () => {
     expect(globalThis.close).not.toHaveBeenCalled();
   });
 
+  it('exchangeTicket 回傳 null 時應顯示錯誤', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => null,
+    });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(mockClearAccountSession).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('exchangeTicket 回傳 primitive 值時應顯示錯誤', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => 'invalid response',
+    });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(mockClearAccountSession).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('exchangeTicket 回傳陣列時應顯示錯誤', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ['not', 'an', 'object'],
+    });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(mockClearAccountSession).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
   it('寫入 storage 失敗時應清除 session 並顯示錯誤', async () => {
     globalThis.fetch
       .mockResolvedValueOnce({
@@ -328,6 +388,96 @@ describe('auth.js', () => {
     expect(mockClearAccountSession).toHaveBeenCalled();
     expect(document.querySelector('#status-area').className).toContain('status-error');
     expect(document.querySelector('#status-area').textContent).toContain('無法儲存 Session');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('account/me 回傳 null 時應清除 session 並顯示錯誤', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access_123',
+          refresh_token: 'refresh_123',
+          expires_at: 1_700_000_000,
+          user_id: 'user_123',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => null,
+      });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockClearAccountSession).toHaveBeenCalled();
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('account/me 回傳 primitive 值時應清除 session 並顯示錯誤', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access_123',
+          refresh_token: 'refresh_123',
+          expires_at: 1_700_000_000,
+          user_id: 'user_123',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => 42,
+      });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockClearAccountSession).toHaveBeenCalled();
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
+    expect(globalThis.close).not.toHaveBeenCalled();
+  });
+
+  it('account/me 回傳陣列時應清除 session 並顯示錯誤', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access_123',
+          refresh_token: 'refresh_123',
+          expires_at: 1_700_000_000,
+          user_id: 'user_123',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ email: 'user@example.com' }],
+      });
+
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+
+    expect(mockClearAccountSession).toHaveBeenCalled();
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    expect(document.querySelector('#status-area').className).toContain('status-error');
+    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
+    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
     expect(globalThis.close).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### 摘要
重構帳號回調邏輯，提升可讀性與可維護性，並增強錯誤處理機制。

### 變更內容
- 將票據交換和帳號資料加載的邏輯重構為獨立的輔助函數。
- 增加對 HTTP 錯誤的處理，確保在交換票據或獲取帳號資料失敗時能正確顯示錯誤訊息。
- 在測試中新增對於交換票據失敗和寫入儲存失敗的情境測試，確保錯誤處理邏輯的正確性。

### 測試方式
已新增測試案例以驗證錯誤處理邏輯。

### 潛在風險
無顯著風險。

