### PR TITLE
refactor: reduce ProfileManager createProfile complexity

### DIFF
--- a/scripts/destinations/ProfileManager.js
+++ b/scripts/destinations/ProfileManager.js
@@ -68,35 +68,11 @@ export class ProfileManager {
   async createProfile(input) {
     const profiles = await this.listProfiles();
     const entitlement = await this.getDestinationEntitlement();
-    if (profiles.length >= entitlement.maxProfiles) {
-      const error = new Error(DESTINATION_PROFILE_ERRORS.LIMIT_REACHED);
-      error.code = DESTINATION_PROFILE_ERROR_CODES.LIMIT_REACHED;
-      throw error;
-    }
+
+    assertProfileCreationAllowed(profiles, entitlement);
 
     const timestamp = nowTimestamp();
-    const profileId = pickNonEmptyString(input?.id) || createProfileId();
-    if (profiles.some(profile => profile.id === profileId)) {
-      throw new Error(DESTINATION_PROFILE_ERRORS.DUPLICATE_ID);
-    }
-    const profile = normalizeProfile(
-      {
-        id: profileId,
-        name: input?.name,
-        icon: input?.icon || DEFAULT_PROFILE_ICON,
-        color:
-          input?.color || CREATE_PROFILE_COLORS[profiles.length % CREATE_PROFILE_COLORS.length],
-        notionDataSourceId: input?.notionDataSourceId,
-        notionDataSourceType: input?.notionDataSourceType,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      },
-      profiles.length
-    );
-
-    if (!profile) {
-      throw new Error(DESTINATION_PROFILE_ERRORS.TARGET_REQUIRED);
-    }
+    const profile = buildProfileCreationDraft(input, profiles, timestamp);
 
     const nextProfiles = [...profiles, profile];
     await this.repository.writeProfiles(nextProfiles);
@@ -154,4 +130,67 @@ export class ProfileManager {
     });
     return nextProfiles;
   }
+}
+
+/**
+ * Asserts that profile creation is allowed under the current entitlement limit.
+ *
+ * @param {Array} profiles
+ * @param {object} entitlement
+ * @throws {Error} LIMIT_REACHED if limit is exceeded
+ */
+function assertProfileCreationAllowed(profiles, entitlement) {
+  if (profiles.length >= entitlement.maxProfiles) {
+    const error = new Error(DESTINATION_PROFILE_ERRORS.LIMIT_REACHED);
+    error.code = DESTINATION_PROFILE_ERROR_CODES.LIMIT_REACHED;
+    throw error;
+  }
+}
+
+/**
+ * Asserts that the requested profile ID is not already in use.
+ *
+ * @param {Array} profiles
+ * @param {string} profileId
+ * @throws {Error} DUPLICATE_ID if the ID is already taken
+ */
+function assertProfileIdAvailable(profiles, profileId) {
+  if (profiles.some(profile => profile.id === profileId)) {
+    throw new Error(DESTINATION_PROFILE_ERRORS.DUPLICATE_ID);
+  }
+}
+
+/**
+ * Builds and normalizes a next profile draft.
+ *
+ * @param {object} input
+ * @param {Array} profiles
+ * @param {number} timestamp
+ * @returns {object} Normalized profile
+ * @throws {Error} TARGET_REQUIRED if normalization fails
+ */
+function buildProfileCreationDraft(input, profiles, timestamp) {
+  const draft = input || {};
+  const profileId = pickNonEmptyString(draft.id) || createProfileId();
+  assertProfileIdAvailable(profiles, profileId);
+
+  const profile = normalizeProfile(
+    {
+      id: profileId,
+      name: draft.name,
+      icon: draft.icon || DEFAULT_PROFILE_ICON,
+      color: draft.color || CREATE_PROFILE_COLORS[profiles.length % CREATE_PROFILE_COLORS.length],
+      notionDataSourceId: draft.notionDataSourceId,
+      notionDataSourceType: draft.notionDataSourceType,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    profiles.length
+  );
+
+  if (!profile) {
+    throw new Error(DESTINATION_PROFILE_ERRORS.TARGET_REQUIRED);
+  }
+
+  return profile;
 }

--- a/scripts/destinations/ProfileManager.js
+++ b/scripts/destinations/ProfileManager.js
@@ -4,8 +4,6 @@
 
 import {
   AccountGatedDestinationEntitlementProvider,
-  CREATE_PROFILE_COLORS,
-  DEFAULT_PROFILE_ICON,
   DEFAULT_PROFILE_ID,
   DESTINATION_PROFILE_ERROR_CODES,
   DESTINATION_PROFILE_ERRORS,
@@ -178,8 +176,8 @@ function buildProfileCreationDraft(input, profiles, timestamp) {
     {
       id: profileId,
       name: draft.name,
-      icon: draft.icon || DEFAULT_PROFILE_ICON,
-      color: draft.color || CREATE_PROFILE_COLORS[profiles.length % CREATE_PROFILE_COLORS.length],
+      icon: draft.icon,
+      color: draft.color,
       notionDataSourceId: draft.notionDataSourceId,
       notionDataSourceType: draft.notionDataSourceType,
       createdAt: timestamp,


### PR DESCRIPTION
### 摘要
簡化 `ProfileManager` 中 `createProfile` 方法的邏輯，提升可讀性與可維護性。

### 變更內容
- 將檢查配置檔案數量的邏輯提取至 `assertProfileCreationAllowed` 函數。
- 將檢查配置檔案 ID 的邏輯提取至 `assertProfileIdAvailable` 函數。
- 將配置檔案的建立邏輯提取至 `buildProfileCreationDraft` 函數。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

