### PR TITLE
refactor: reduce complexity in popup destination selector

### DIFF
--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -172,6 +172,77 @@ function renderDestinationMenu(destinationMenu, profiles, selectedProfileId) {
   destinationMenu.append(fragment);
 }
 
+function getParsedSvgElement(svgDoc) {
+  if (svgDoc.querySelector('parsererror')) {
+    return null;
+  }
+  return svgDoc.documentElement || null;
+}
+
+function createStatusSvgPart(content) {
+  const span = document.createElement('span');
+  const parser = new DOMParser();
+  const svgDoc = parser.parseFromString(content, 'image/svg+xml');
+  const svgElement = getParsedSvgElement(svgDoc);
+
+  if (svgElement) {
+    span.append(svgElement);
+  }
+
+  span.classList.add('status-icon-inline');
+  return span;
+}
+
+function renderTextStatus(status, content) {
+  status.textContent = content;
+}
+
+const STATUS_CONTENT_RENDERERS = [
+  {
+    matches: content => typeof content === 'string',
+    render: renderTextStatus,
+  },
+  {
+    matches: Array.isArray,
+    render: appendStructuredStatus,
+  },
+];
+
+const STATUS_PART_RENDERERS = [
+  {
+    matches: part => typeof part === 'string',
+    createNode: part => document.createTextNode(part),
+  },
+  {
+    matches: part => part?.type === 'svg',
+    createNode: part => createStatusSvgPart(part.content),
+  },
+];
+
+function createStatusPartNode(part) {
+  const renderer = STATUS_PART_RENDERERS.find(({ matches }) => matches(part));
+  return renderer?.createNode(part) || null;
+}
+
+function appendStatusPart(status, part) {
+  const node = createStatusPartNode(part);
+
+  if (!node) {
+    return;
+  }
+
+  status.append(node);
+}
+
+function appendStructuredStatus(status, parts) {
+  parts.forEach(part => appendStatusPart(status, part));
+}
+
+function renderStatusContent(status, content) {
+  const renderer = STATUS_CONTENT_RENDERERS.find(({ matches }) => matches(content));
+  renderer?.render(status, content);
+}
+
 /**
  * Render popup destination selector.
  *
@@ -201,42 +272,15 @@ export function renderDestinationSelector(elements, state) {
  * @param {string} [color=''] - 文字顏色（可選）
  */
 export function setStatus(elements, content, color = '') {
-  if (elements.status) {
-    elements.status.replaceChildren();
-    elements.status.style.color = color;
+  const status = elements.status;
 
-    // Support simple string
-    if (typeof content === 'string') {
-      elements.status.textContent = content;
-      return;
-    }
-
-    // Support structured content (array of parts)
-    if (Array.isArray(content)) {
-      content.forEach(part => {
-        if (typeof part === 'string') {
-          // Pure text part -> safe textContent
-          elements.status.append(document.createTextNode(part));
-        } else if (part?.type === 'svg') {
-          // 結構化 SVG 部分 -> 特殊處理
-          const span = document.createElement('span');
-
-          // 使用 DOMParser 安全地解析 SVG 字串，取代 innerHTML
-          const parser = new DOMParser();
-          const svgDoc = parser.parseFromString(part.content, 'image/svg+xml');
-
-          // 確保解析成功且無錯誤
-          if (!svgDoc.querySelector('parsererror') && svgDoc.documentElement) {
-            span.append(svgDoc.documentElement);
-          }
-
-          // 加入基本樣式以對齊
-          span.classList.add('status-icon-inline');
-          elements.status.append(span);
-        }
-      });
-    }
+  if (!status) {
+    return;
   }
+
+  status.replaceChildren();
+  status.style.color = color;
+  renderStatusContent(status, content);
 }
 
 /**
@@ -460,6 +504,64 @@ function formatCount(count, singular, plural) {
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
+function formatBlockImageDetails(response) {
+  const imageCount = response.imageCount || 0;
+  const blockCount = response.blockCount || 0;
+  const imagesText = formatCount(imageCount, 'image', 'images');
+  const blocksText = formatCount(blockCount, 'block', 'blocks');
+  return `(${blocksText}, ${imagesText})`;
+}
+
+function formatHighlightDetails(response) {
+  const highlightCount = response.highlightCount || 0;
+  const highlightsText = formatCount(highlightCount, 'highlight', 'highlights');
+  return `(${highlightsText})`;
+}
+
+function resolveSaveSuccessMessageParts(response) {
+  const blockImageDetails = formatBlockImageDetails(response);
+  const rules = [
+    {
+      matches: response.recreated,
+      action: UI_MESSAGES.POPUP.RECREATED,
+      details: blockImageDetails,
+    },
+    {
+      matches: response.highlightsUpdated,
+      action: UI_MESSAGES.POPUP.HIGHLIGHTS_UPDATED,
+      details: formatHighlightDetails(response),
+    },
+    {
+      matches: response.updated,
+      action: UI_MESSAGES.POPUP.UPDATED,
+      details: blockImageDetails,
+    },
+    {
+      matches: response.created,
+      action: UI_MESSAGES.POPUP.CREATED,
+      details: blockImageDetails,
+      warning: response.warning,
+    },
+  ];
+
+  return (
+    rules.find(rule => rule.matches) || {
+      action: UI_MESSAGES.POPUP.SAVE_SUCCESS,
+      details: '',
+    }
+  );
+}
+
+function buildSaveSuccessMessage({ action, details, warning }) {
+  const message = [action, details].filter(Boolean).join(' ');
+
+  if (!warning) {
+    return message;
+  }
+
+  return [message, { type: 'svg', content: UI_ICONS.WARNING }, warning];
+}
+
 /**
  * 格式化保存成功訊息
  *
@@ -467,43 +569,5 @@ function formatCount(count, singular, plural) {
  * @returns {string|Array<string|{type: string, content: string}>} 格式化的訊息或結構化內容（含 SVG 警告）
  */
 export function formatSaveSuccessMessage(response) {
-  let action = UI_MESSAGES.POPUP.SAVE_SUCCESS;
-  let details = '';
-
-  const imageCount = response.imageCount || 0;
-  const blockCount = response.blockCount || 0;
-
-  const imagesText = formatCount(imageCount, 'image', 'images');
-  const blocksText = formatCount(blockCount, 'block', 'blocks');
-  const countsDetails = `(${blocksText}, ${imagesText})`;
-
-  if (response.recreated) {
-    action = UI_MESSAGES.POPUP.RECREATED;
-    details = countsDetails;
-  } else if (response.highlightsUpdated) {
-    action = UI_MESSAGES.POPUP.HIGHLIGHTS_UPDATED;
-    const highlightCount = response.highlightCount || 0;
-    const highlightsText = formatCount(highlightCount, 'highlight', 'highlights');
-    details = `(${highlightsText})`;
-  } else if (response.updated) {
-    action = UI_MESSAGES.POPUP.UPDATED;
-    details = countsDetails;
-  } else if (response.created) {
-    action = UI_MESSAGES.POPUP.CREATED;
-    details = countsDetails;
-
-    if (response.warning) {
-      const warnIcon = UI_ICONS.WARNING;
-
-      // Return structured array for safe rendering
-      return [
-        [action, details].filter(Boolean).join(' '),
-        { type: 'svg', content: warnIcon },
-        response.warning,
-      ];
-    }
-  }
-
-  // Default return string
-  return [action, details].filter(Boolean).join(' ');
+  return buildSaveSuccessMessage(resolveSaveSuccessMessageParts(response));
 }

--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -7,6 +7,7 @@
 import { UI_ICONS } from '../../scripts/config/shared/ui.js';
 import { UI_MESSAGES } from '../../scripts/config/shared/messages.js';
 import { resolveAccountDisplayProfile } from '../../scripts/utils/accountDisplayUtils.js';
+import { sanitizeSvgIcon } from '../../scripts/highlighter/utils/safeIcon.js';
 
 const ACCOUNT_STATUS_ERROR_CLASS = 'account-status-error';
 const ARIA_LABEL_ATTR = 'aria-label';
@@ -179,17 +180,33 @@ function getParsedSvgElement(svgDoc) {
   return svgDoc.documentElement || null;
 }
 
+/**
+ * 建立安全的 SVG 狀態圖標容器
+ *
+ * 使用 DOMPurify 消毒 SVG 內容以防止 XSS 攻擊。
+ * 雖然當前僅用於 UI_ICONS 硬編碼常量，但防禦性措施確保未來擴展時的安全性。
+ *
+ * @param {string} content - SVG 字串（將被消毒處理）
+ * @returns {HTMLSpanElement} 包含安全 SVG 的 span 元素
+ */
 function createStatusSvgPart(content) {
   const span = document.createElement('span');
+  span.classList.add('status-icon-inline');
+
+  // 使用現有的 DOMPurify 消毒邏輯
+  const sanitized = sanitizeSvgIcon(content);
+  if (!sanitized) {
+    return span;
+  }
+
   const parser = new DOMParser();
-  const svgDoc = parser.parseFromString(content, 'image/svg+xml');
+  const svgDoc = parser.parseFromString(sanitized, 'image/svg+xml');
   const svgElement = getParsedSvgElement(svgDoc);
 
   if (svgElement) {
     span.append(svgElement);
   }
 
-  span.classList.add('status-icon-inline');
   return span;
 }
 

--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -556,7 +556,7 @@ function buildSaveSuccessMessage({ action, details, warning }) {
   const message = [action, details].filter(Boolean).join(' ');
 
   if (!warning) {
-    return message;
+    return [message];
   }
 
   return [message, { type: 'svg', content: UI_ICONS.WARNING }, warning];
@@ -566,7 +566,7 @@ function buildSaveSuccessMessage({ action, details, warning }) {
  * 格式化保存成功訊息
  *
  * @param {object} response - 保存響應
- * @returns {string|Array<string|{type: string, content: string}>} 格式化的訊息或結構化內容（含 SVG 警告）
+ * @returns {Array<string|{type: string, content: string}>} 結構化內容數組（可含 SVG 警告）
  */
 export function formatSaveSuccessMessage(response) {
   return buildSaveSuccessMessage(resolveSaveSuccessMessageParts(response));

--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -524,14 +524,14 @@ function formatCount(count, singular, plural) {
 function formatBlockImageDetails(response) {
   const imageCount = response.imageCount || 0;
   const blockCount = response.blockCount || 0;
-  const imagesText = formatCount(imageCount, 'image', 'images');
-  const blocksText = formatCount(blockCount, 'block', 'blocks');
+  const imagesText = formatCount(imageCount, '張圖片', '張圖片');
+  const blocksText = formatCount(blockCount, '個區塊', '個區塊');
   return `(${blocksText}, ${imagesText})`;
 }
 
 function formatHighlightDetails(response) {
   const highlightCount = response.highlightCount || 0;
-  const highlightsText = formatCount(highlightCount, 'highlight', 'highlights');
+  const highlightsText = formatCount(highlightCount, '條標註', '條標註');
   return `(${highlightsText})`;
 }
 

--- a/pages/popup/popupUI.js
+++ b/pages/popup/popupUI.js
@@ -67,59 +67,130 @@ function formatDestinationLabel(profile) {
 }
 
 /**
+ * 獲取有效的儲存目標 Profiles 列表
+ *
+ * @param {object} state - UI 狀態
+ * @returns {Array<object>}
+ */
+function getDestinationProfiles(state) {
+  return Array.isArray(state?.profiles) ? state.profiles : [];
+}
+
+/**
+ * 判斷是否可渲染儲存目標選擇器
+ *
+ * @param {PopupElements} elements - DOM 元素集合
+ * @param {Array<object>} profiles - Profiles 列表
+ * @param {object|null} selectedProfile - 已選擇的 Profile
+ * @returns {boolean}
+ */
+function canRenderDestinationSelector(elements, profiles, selectedProfile) {
+  return Boolean(elements.destinationSection && profiles.length > 0 && selectedProfile);
+}
+
+/**
+ * 隱藏儲存目標區域
+ *
+ * @param {HTMLElement} destinationSection - 儲存目標容器
+ */
+function hideDestinationSection(destinationSection) {
+  if (destinationSection) {
+    destinationSection.style.display = 'none';
+  }
+}
+
+/**
+ * 渲染當前儲存目標標籤
+ *
+ * @param {HTMLElement} destinationCurrent - 當前儲存目標元素
+ * @param {object} selectedProfile - 已選擇的 Profile
+ */
+function renderDestinationCurrent(destinationCurrent, selectedProfile) {
+  if (destinationCurrent) {
+    destinationCurrent.textContent = `${
+      UI_MESSAGES.POPUP.DESTINATION_LABEL_PREFIX
+    }${formatDestinationLabel(selectedProfile)}`;
+    destinationCurrent.dataset.profileId = selectedProfile.id;
+    destinationCurrent.style.borderColor = selectedProfile.color || '';
+  }
+}
+
+/**
+ * 渲染儲存目標切換按鈕
+ *
+ * @param {HTMLButtonElement} destinationToggle - 切換按鈕元素
+ * @param {object} selectedProfile - 已選擇的 Profile
+ * @param {number} profileCount - Profiles 數量
+ */
+function renderDestinationToggle(destinationToggle, selectedProfile, profileCount) {
+  if (destinationToggle) {
+    destinationToggle.style.display = profileCount > 1 ? 'inline-flex' : 'none';
+    destinationToggle.disabled = profileCount <= 1;
+    destinationToggle.dataset.profileId = selectedProfile.id;
+    destinationToggle.setAttribute?.('aria-expanded', 'false');
+  }
+}
+
+/**
+ * 建立儲存目標選單單一按鈕
+ *
+ * @param {object} profile - Profile 資料
+ * @param {string} selectedProfileId - 已選擇的 Profile ID
+ * @returns {HTMLButtonElement}
+ */
+function createDestinationMenuItem(profile, selectedProfileId) {
+  const item = document.createElement('button');
+  item.type = 'button';
+  item.className = 'destination-menu-item';
+  item.dataset.profileId = profile.id;
+  item.textContent = formatDestinationLabel(profile);
+  item.setAttribute('aria-pressed', String(profile.id === selectedProfileId));
+  return item;
+}
+
+/**
+ * 渲染儲存目標下拉選單
+ *
+ * @param {HTMLElement} destinationMenu - 選單元素
+ * @param {Array<object>} profiles - Profiles 列表
+ * @param {string} selectedProfileId - 已選擇的 Profile ID
+ */
+function renderDestinationMenu(destinationMenu, profiles, selectedProfileId) {
+  if (!destinationMenu) {
+    return;
+  }
+
+  destinationMenu.replaceChildren();
+  destinationMenu.style.display = 'none';
+
+  const fragment = document.createDocumentFragment();
+
+  for (const profile of profiles) {
+    fragment.append(createDestinationMenuItem(profile, selectedProfileId));
+  }
+
+  destinationMenu.append(fragment);
+}
+
+/**
  * Render popup destination selector.
  *
  * @param {PopupElements} elements
  * @param {{profiles: Array<object>, selectedProfileId?: string|null}} state
  */
 export function renderDestinationSelector(elements, state) {
-  const profiles = Array.isArray(state?.profiles) ? state.profiles : [];
+  const profiles = getDestinationProfiles(state);
   const selectedProfile = getSelectedDestinationProfile(profiles, state?.selectedProfileId);
 
-  if (!elements.destinationSection || profiles.length === 0 || !selectedProfile) {
-    if (elements.destinationSection) {
-      elements.destinationSection.style.display = 'none';
-    }
+  if (!canRenderDestinationSelector(elements, profiles, selectedProfile)) {
+    hideDestinationSection(elements.destinationSection);
     return;
   }
 
   elements.destinationSection.style.display = 'block';
-
-  if (elements.destinationCurrent) {
-    elements.destinationCurrent.textContent = `${
-      UI_MESSAGES.POPUP.DESTINATION_LABEL_PREFIX
-    }${formatDestinationLabel(selectedProfile)}`;
-    elements.destinationCurrent.dataset.profileId = selectedProfile.id;
-    elements.destinationCurrent.style.borderColor = selectedProfile.color || '';
-  }
-
-  if (elements.destinationToggle) {
-    elements.destinationToggle.style.display = profiles.length > 1 ? 'inline-flex' : 'none';
-    elements.destinationToggle.disabled = profiles.length <= 1;
-    elements.destinationToggle.dataset.profileId = selectedProfile.id;
-    elements.destinationToggle.setAttribute?.('aria-expanded', 'false');
-  }
-
-  if (!elements.destinationMenu) {
-    return;
-  }
-
-  elements.destinationMenu.replaceChildren();
-  elements.destinationMenu.style.display = 'none';
-
-  const fragment = document.createDocumentFragment();
-
-  for (const profile of profiles) {
-    const item = document.createElement('button');
-    item.type = 'button';
-    item.className = 'destination-menu-item';
-    item.dataset.profileId = profile.id;
-    item.textContent = formatDestinationLabel(profile);
-    item.setAttribute('aria-pressed', profile.id === selectedProfile.id ? 'true' : 'false');
-    fragment.append(item);
-  }
-
-  elements.destinationMenu.append(fragment);
+  renderDestinationCurrent(elements.destinationCurrent, selectedProfile);
+  renderDestinationToggle(elements.destinationToggle, selectedProfile, profiles.length);
+  renderDestinationMenu(elements.destinationMenu, profiles, selectedProfile.id);
 }
 
 /**

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -131,35 +131,35 @@ describe('popupUI', () => {
       const response = { success: true, created: true, blockCount: 5, imageCount: 2 };
       const message = formatSaveSuccessMessage(response);
       expect(Array.isArray(message)).toBe(true);
-      expect(message[0]).toBe('建立成功 (5 blocks, 2 images)');
+      expect(message[0]).toBe('建立成功 (5 個區塊, 2 張圖片)');
     });
 
     test('應格式化創建成功訊息 (單數)', () => {
       const response = { success: true, created: true, blockCount: 1, imageCount: 1 };
       const message = formatSaveSuccessMessage(response);
       expect(Array.isArray(message)).toBe(true);
-      expect(message[0]).toBe('建立成功 (1 block, 1 image)');
+      expect(message[0]).toBe('建立成功 (1 個區塊, 1 張圖片)');
     });
 
     test('應格式化更新成功訊息 (混合單複數)', () => {
       const response = { success: true, updated: true, blockCount: 1, imageCount: 2 };
       const message = formatSaveSuccessMessage(response);
       expect(Array.isArray(message)).toBe(true);
-      expect(message[0]).toBe('更新成功 (1 block, 2 images)');
+      expect(message[0]).toBe('更新成功 (1 個區塊, 2 張圖片)');
     });
 
     test('應格式化標記更新訊息', () => {
       const response = { success: true, highlightsUpdated: true, highlightCount: 10 };
       const message = formatSaveSuccessMessage(response);
       expect(Array.isArray(message)).toBe(true);
-      expect(message[0]).toBe('標註已更新 (10 highlights)');
+      expect(message[0]).toBe('標註已更新 (10 條標註)');
     });
 
     test('應格式化高亮更新訊息 (單數)', () => {
       const response = { success: true, highlightsUpdated: true, highlightCount: 1 };
       const message = formatSaveSuccessMessage(response);
       expect(Array.isArray(message)).toBe(true);
-      expect(message[0]).toBe('標註已更新 (1 highlight)');
+      expect(message[0]).toBe('標註已更新 (1 條標註)');
     });
 
     test('應包含警告訊息', () => {

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -130,31 +130,36 @@ describe('popupUI', () => {
     test('應格式化創建成功訊息 (複數)', () => {
       const response = { success: true, created: true, blockCount: 5, imageCount: 2 };
       const message = formatSaveSuccessMessage(response);
-      expect(message).toBe('建立成功 (5 blocks, 2 images)');
+      expect(Array.isArray(message)).toBe(true);
+      expect(message[0]).toBe('建立成功 (5 blocks, 2 images)');
     });
 
     test('應格式化創建成功訊息 (單數)', () => {
       const response = { success: true, created: true, blockCount: 1, imageCount: 1 };
       const message = formatSaveSuccessMessage(response);
-      expect(message).toBe('建立成功 (1 block, 1 image)');
+      expect(Array.isArray(message)).toBe(true);
+      expect(message[0]).toBe('建立成功 (1 block, 1 image)');
     });
 
     test('應格式化更新成功訊息 (混合單複數)', () => {
       const response = { success: true, updated: true, blockCount: 1, imageCount: 2 };
       const message = formatSaveSuccessMessage(response);
-      expect(message).toBe('更新成功 (1 block, 2 images)');
+      expect(Array.isArray(message)).toBe(true);
+      expect(message[0]).toBe('更新成功 (1 block, 2 images)');
     });
 
     test('應格式化標記更新訊息', () => {
       const response = { success: true, highlightsUpdated: true, highlightCount: 10 };
       const message = formatSaveSuccessMessage(response);
-      expect(message).toBe('標註已更新 (10 highlights)');
+      expect(Array.isArray(message)).toBe(true);
+      expect(message[0]).toBe('標註已更新 (10 highlights)');
     });
 
     test('應格式化高亮更新訊息 (單數)', () => {
       const response = { success: true, highlightsUpdated: true, highlightCount: 1 };
       const message = formatSaveSuccessMessage(response);
-      expect(message).toBe('標註已更新 (1 highlight)');
+      expect(Array.isArray(message)).toBe(true);
+      expect(message[0]).toBe('標註已更新 (1 highlight)');
     });
 
     test('應包含警告訊息', () => {

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -124,6 +124,49 @@ describe('popupUI.js', () => {
       expect(menuItems[1].dataset.profileId).toBe('profile-2');
       createElementSpy.mockRestore();
     });
+
+    it('沒有 profiles 時應隱藏 destination section 並不渲染 menu', () => {
+      renderDestinationSelector(mockElements, { profiles: [], selectedProfileId: null });
+
+      expect(mockElements.destinationSection.style.display).toBe('none');
+      expect(mockElements.destinationMenu.replaceChildren).not.toHaveBeenCalled();
+      expect(mockElements.destinationMenu.append).not.toHaveBeenCalled();
+    });
+
+    it('selectedProfileId 不存在時應 fallback 到第一個 profile', () => {
+      const menuItems = [];
+      const createElementSpy = jest.spyOn(document, 'createElement').mockImplementation(tagName => {
+        const element = {
+          tagName,
+          textContent: '',
+          className: '',
+          type: '',
+          dataset: {},
+          style: {},
+          setAttribute: jest.fn(),
+          append: jest.fn(),
+        };
+        if (tagName === 'button') {
+          menuItems.push(element);
+        }
+        return element;
+      });
+
+      renderDestinationSelector(mockElements, {
+        profiles: [
+          { id: 'default', name: 'Default', color: '#2563eb' },
+          { id: 'profile-2', name: 'Research', color: '#16a34a' },
+        ],
+        selectedProfileId: 'missing',
+      });
+
+      expect(mockElements.destinationCurrent.textContent).toContain('Default');
+      expect(mockElements.destinationCurrent.dataset.profileId).toBe('default');
+      expect(menuItems[0].setAttribute).toHaveBeenCalledWith('aria-pressed', 'true');
+      expect(menuItems[1].setAttribute).toHaveBeenCalledWith('aria-pressed', 'false');
+
+      createElementSpy.mockRestore();
+    });
   });
 
   describe('initializePopupStaticText', () => {

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -218,6 +218,22 @@ describe('popupUI.js', () => {
       const elementsWithoutStatus = { ...mockElements, status: null };
       expect(() => setStatus(elementsWithoutStatus, 'Test')).not.toThrow();
     });
+
+    it('應安全渲染結構化文字與 SVG 狀態內容', () => {
+      setStatus(mockElements, [
+        'Saved ',
+        { type: 'svg', content: '<svg><path d="M0 0h1v1z"/></svg>' },
+        ' with warning',
+      ]);
+
+      expect(mockElements.status.replaceChildren).toHaveBeenCalled();
+      expect(mockElements.status.append).toHaveBeenCalledTimes(3);
+      expect(mockElements.status.append.mock.calls[0][0].textContent).toBe('Saved ');
+      expect(
+        mockElements.status.append.mock.calls[1][0].classList.contains('status-icon-inline')
+      ).toBe(true);
+      expect(mockElements.status.append.mock.calls[2][0].textContent).toBe(' with warning');
+    });
   });
 
   describe('setButtonState', () => {

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -234,6 +234,48 @@ describe('popupUI.js', () => {
       ).toBe(true);
       expect(mockElements.status.append.mock.calls[2][0].textContent).toBe(' with warning');
     });
+
+    it('應過濾掉 SVG 中的危險標籤（<script>）', () => {
+      setStatus(mockElements, [
+        'Status: ',
+        { type: 'svg', content: '<svg><script>alert("XSS")</script><path d="M0 0"/></svg>' },
+      ]);
+
+      expect(mockElements.status.replaceChildren).toHaveBeenCalled();
+      expect(mockElements.status.append).toHaveBeenCalledTimes(2);
+
+      const svgContainer = mockElements.status.append.mock.calls[1][0];
+      expect(svgContainer.classList.contains('status-icon-inline')).toBe(true);
+
+      // DOMPurify 應該已移除 <script> 標籤
+      const svgElement = svgContainer.querySelector('svg');
+      if (svgElement) {
+        expect(svgElement.querySelector('script')).toBeNull();
+      }
+    });
+
+    it('應過濾掉 SVG 中的危險屬性（onload）', () => {
+      setStatus(mockElements, [
+        { type: 'svg', content: '<svg onload="alert(1)"><path d="M0 0"/></svg>' },
+      ]);
+
+      expect(mockElements.status.replaceChildren).toHaveBeenCalled();
+      const svgContainer = mockElements.status.append.mock.calls[0][0];
+      const svgElement = svgContainer.querySelector('svg');
+
+      if (svgElement) {
+        expect(svgElement.hasAttribute('onload')).toBe(false);
+      }
+    });
+
+    it('當 SVG 內容無效時應返回空的 status-icon-inline span', () => {
+      setStatus(mockElements, [{ type: 'svg', content: '' }]);
+
+      expect(mockElements.status.replaceChildren).toHaveBeenCalled();
+      const svgContainer = mockElements.status.append.mock.calls[0][0];
+      expect(svgContainer.classList.contains('status-icon-inline')).toBe(true);
+      expect(svgContainer.querySelector('svg')).toBeNull();
+    });
   });
 
   describe('setButtonState', () => {

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -453,8 +453,8 @@ describe('popupUI.js', () => {
       const msg = formatSaveSuccessMessage(response);
       expect(Array.isArray(msg)).toBe(true);
       expect(msg[0]).toContain('建立成功');
-      expect(msg[0]).toContain('5 blocks');
-      expect(msg[0]).toContain('2 images');
+      expect(msg[0]).toContain('5 個區塊');
+      expect(msg[0]).toContain('2 張圖片');
     });
 
     it('應該格式化 Updated 訊息', () => {
@@ -462,8 +462,8 @@ describe('popupUI.js', () => {
       const msg = formatSaveSuccessMessage(response);
       expect(Array.isArray(msg)).toBe(true);
       expect(msg[0]).toContain('更新成功');
-      expect(msg[0]).toContain('1 block');
-      expect(msg[0]).toContain('0 images');
+      expect(msg[0]).toContain('1 個區塊');
+      expect(msg[0]).toContain('0 張圖片');
     });
 
     it('應該格式化 Highlights updated 訊息', () => {
@@ -471,7 +471,7 @@ describe('popupUI.js', () => {
       const msg = formatSaveSuccessMessage(response);
       expect(Array.isArray(msg)).toBe(true);
       expect(msg[0]).toContain('標註已更新');
-      expect(msg[0]).toContain('3 highlights');
+      expect(msg[0]).toContain('3 條標註');
     });
 
     it('應該格式化 Recreated 訊息', () => {

--- a/tests/unit/popup/popupUI.test.js
+++ b/tests/unit/popup/popupUI.test.js
@@ -409,30 +409,34 @@ describe('popupUI.js', () => {
     it('應該格式化 Created 訊息', () => {
       const response = { created: true, blockCount: 5, imageCount: 2 };
       const msg = formatSaveSuccessMessage(response);
-      expect(msg).toContain('建立成功');
-      expect(msg).toContain('5 blocks');
-      expect(msg).toContain('2 images');
+      expect(Array.isArray(msg)).toBe(true);
+      expect(msg[0]).toContain('建立成功');
+      expect(msg[0]).toContain('5 blocks');
+      expect(msg[0]).toContain('2 images');
     });
 
     it('應該格式化 Updated 訊息', () => {
       const response = { updated: true, blockCount: 1, imageCount: 0 };
       const msg = formatSaveSuccessMessage(response);
-      expect(msg).toContain('更新成功');
-      expect(msg).toContain('1 block');
-      expect(msg).toContain('0 images');
+      expect(Array.isArray(msg)).toBe(true);
+      expect(msg[0]).toContain('更新成功');
+      expect(msg[0]).toContain('1 block');
+      expect(msg[0]).toContain('0 images');
     });
 
     it('應該格式化 Highlights updated 訊息', () => {
       const response = { highlightsUpdated: true, highlightCount: 3 };
       const msg = formatSaveSuccessMessage(response);
-      expect(msg).toContain('標註已更新');
-      expect(msg).toContain('3 highlights');
+      expect(Array.isArray(msg)).toBe(true);
+      expect(msg[0]).toContain('標註已更新');
+      expect(msg[0]).toContain('3 highlights');
     });
 
     it('應該格式化 Recreated 訊息', () => {
       const response = { recreated: true, blockCount: 10, imageCount: 5 };
       const msg = formatSaveSuccessMessage(response);
-      expect(msg).toContain('重建成功 (原頁面已刪除)');
+      expect(Array.isArray(msg)).toBe(true);
+      expect(msg[0]).toContain('重建成功 (原頁面已刪除)');
     });
 
     it('應該包含警告圖標（如果存在 warning）', () => {
@@ -450,8 +454,9 @@ describe('popupUI.js', () => {
     it('預設路徑不應產生尾部空格', () => {
       const response = {};
       const msg = formatSaveSuccessMessage(response);
-      expect(msg).not.toMatch(/\s$/);
-      expect(msg).toBe('儲存成功！');
+      expect(Array.isArray(msg)).toBe(true);
+      expect(msg[0]).not.toMatch(/\s$/);
+      expect(msg[0]).toBe('儲存成功！');
     });
   });
 });


### PR DESCRIPTION
### 摘要
簡化彈出式目的地選擇器的邏輯與 UI 結構。

### 變更內容
- 減少彈出式目的地選擇器的複雜性，提升可讀性與維護性。
- 確保在沒有 profiles 時隱藏目的地區域並不渲染選單。
- 當 `selectedProfileId` 不存在時，回退至第一個 profile。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

