### PR TITLE
refactor: simplify sidepanel UI complexity

### DIFF
--- a/pages/sidepanel/sidepanel-unsynced-view.js
+++ b/pages/sidepanel/sidepanel-unsynced-view.js
@@ -177,12 +177,12 @@ export async function refreshUnsyncedBadge(
  * @param {number} count - 本次渲染數量
  */
 export function appendNextUnsyncedBatch(context, count) {
-  const renderedCount = UI.appendCards(
-    context.els,
-    context.cachedUnsyncedPages,
-    context.displayedCardCount,
+  const renderedCount = UI.appendCards({
+    elements: context.els,
+    pages: context.cachedUnsyncedPages,
+    startIndex: context.displayedCardCount,
     count,
-    {
+    callbacks: {
       onOpen: url => {
         chrome.tabs.create({ url }).catch(error => {
           Logger.warn('[SidePanel] Failed to open unsynced page tab', {
@@ -205,8 +205,8 @@ export function appendNextUnsyncedBatch(context, count) {
           });
         });
       },
-    }
-  );
+    },
+  });
 
   context.displayedCardCount += renderedCount;
 }

--- a/pages/sidepanel/sidepanelUI.js
+++ b/pages/sidepanel/sidepanelUI.js
@@ -316,50 +316,78 @@ export function renderList(elements, highlights, storageKey, onDelete) {
 // === 待同步視圖 ===
 
 /**
- * 切換視圖，只負責 DOM 顯隱與 tab active class，不觸發任何資料載入
+ * 設定 DOM 元素的顯示狀態 (如果元素存在)
+ *
+ * @param {HTMLElement|null} element
+ * @param {string} display
+ */
+function setElementDisplay(element, display) {
+  if (element) {
+    element.style.display = display;
+  }
+}
+
+/**
+ * 切換到「本頁標註」視圖的 DOM 狀態
  *
  * @param {SidePanelElements} elements
- * @param {'current'|'unsynced'} viewName
  */
-export function switchView(elements, viewName) {
+function showCurrentView(elements) {
+  setElementDisplay(elements.unsyncedView, 'none');
+  setElementDisplay(elements.syncButton, '');
+  setElementDisplay(elements.openNotionButton, '');
+  setElementDisplay(elements.loadMoreBtn, 'none');
+  setElementDisplay(elements.unsyncedToolbar, 'none');
+}
+
+/**
+ * 切換到「待同步」視圖的 DOM 狀態
+ *
+ * @param {SidePanelElements} elements
+ */
+function showUnsyncedView(elements) {
   const currentViewEls = [
     elements.loadingState,
     elements.emptyState,
     elements.highlightsList,
     elements.statusMessage,
   ];
+  currentViewEls.forEach(el => setElementDisplay(el, 'none'));
+  setElementDisplay(elements.syncButton, 'none');
+  setElementDisplay(elements.openNotionButton, 'none');
+  setElementDisplay(elements.unsyncedView, 'block');
+}
 
-  if (viewName === 'unsynced') {
-    currentViewEls.forEach(el => el && (el.style.display = 'none'));
-    if (elements.syncButton) {
-      elements.syncButton.style.display = 'none';
-    }
-    if (elements.openNotionButton) {
-      elements.openNotionButton.style.display = 'none';
-    }
-    elements.unsyncedView.style.display = 'block';
-  } else {
-    elements.unsyncedView.style.display = 'none';
-    if (elements.syncButton) {
-      elements.syncButton.style.display = '';
-    }
-    if (elements.openNotionButton) {
-      elements.openNotionButton.style.display = '';
-    }
-    if (elements.loadMoreBtn) {
-      elements.loadMoreBtn.style.display = 'none';
-    }
-    if (elements.unsyncedToolbar) {
-      elements.unsyncedToolbar.style.display = 'none';
-    }
+/**
+ * 更新 Tab 的選取與 active 樣式
+ *
+ * @param {NodeList|Array} tabs
+ * @param {string} activeViewName
+ */
+function updateViewTabs(tabs, activeViewName) {
+  if (!tabs) {
+    return;
   }
-
-  // 更新 tab 的 active 樣式
-  elements.viewTabs.forEach(tab => {
-    const isActive = tab.dataset.view === viewName;
+  tabs.forEach(tab => {
+    const isActive = tab.dataset.view === activeViewName;
     tab.classList.toggle('active', isActive);
     tab.setAttribute('aria-selected', String(isActive));
   });
+}
+
+/**
+ * 切換視圖，只負責 DOM 顯隱與 tab active class，不觸發任何資料載入
+ *
+ * @param {SidePanelElements} elements
+ * @param {'current'|'unsynced'} viewName
+ */
+export function switchView(elements, viewName) {
+  if (viewName === 'unsynced') {
+    showUnsyncedView(elements);
+  } else {
+    showCurrentView(elements);
+  }
+  updateViewTabs(elements.viewTabs, viewName);
 }
 
 /**
@@ -396,16 +424,106 @@ export function updateUnsyncedBadge(elements, pages) {
 }
 
 /**
+ * 渲染卡片的標註預覽行
+ *
+ * @param {HTMLElement} card
+ * @param {Array|null} previewHighlights
+ */
+function renderCardPreviews(card, previewHighlights) {
+  const previewContainer = card.querySelector('.page-card-previews');
+  if (!previewContainer) {
+    return;
+  }
+
+  const highlights = Array.isArray(previewHighlights) ? previewHighlights : [];
+  highlights.forEach(highlight => {
+    const row = document.createElement('p');
+    row.className = `preview-row color-${normalizeHighlightColor(highlight?.color)}`;
+    row.textContent = `"${highlight.text}${highlight.truncated ? '...' : ''}"`;
+    previewContainer.append(row);
+  });
+}
+
+/**
+ * 渲染卡片的剩餘標註數量 (+N more)
+ *
+ * @param {HTMLElement} card
+ * @param {number} remainingCount
+ */
+function renderCardRemainingCount(card, remainingCount) {
+  const remainingEl = card.querySelector('.page-card-remaining');
+  if (remainingEl && remainingCount > 0) {
+    remainingEl.textContent = UI_MESSAGES.SIDEPANEL.REMAINING_COUNT(remainingCount);
+  }
+}
+
+/**
+ * 綁定卡片的「開啟」與「刪除」按鈕事件
+ *
+ * @param {HTMLElement} card
+ * @param {object} page
+ * @param {{ onOpen: (url: string) => void, onDelete: (storageKey: string, card: HTMLElement) => void }} callbacks
+ */
+function bindCardButtons(card, page, callbacks) {
+  const openButton = card.querySelector('.page-open-button');
+  if (openButton && typeof callbacks.onOpen === 'function') {
+    openButton.addEventListener('click', () => {
+      callbacks.onOpen(page.url);
+    });
+  }
+
+  const deleteButton = card.querySelector('.page-delete-button');
+  if (deleteButton && typeof callbacks.onDelete === 'function') {
+    deleteButton.addEventListener('click', () => {
+      callbacks.onDelete(page.storageKey, card);
+    });
+  }
+}
+
+/**
+ * 為單一頁面建立 Unsynced Page Card DOM 元素
+ *
+ * @param {HTMLTemplateElement} template
+ * @param {object} page
+ * @param {{ onOpen: (url: string) => void, onDelete: (storageKey: string, card: HTMLElement) => void }} callbacks
+ * @returns {HTMLElement|null}
+ */
+function createUnsyncedPageCard(template, page, callbacks) {
+  const cardNode = template.content.cloneNode(true);
+  const card = cardNode.querySelector('.page-card');
+  if (!card) {
+    return null;
+  }
+
+  const titleEl = card.querySelector('.page-title');
+  if (titleEl) {
+    titleEl.textContent = page.title;
+  }
+
+  const metaEl = card.querySelector('.page-meta');
+  if (metaEl) {
+    metaEl.textContent = `${extractDomain(page.url)} • ${UI_MESSAGES.SIDEPANEL.HIGHLIGHT_COUNT(page.highlightCount)}`;
+  }
+
+  renderCardPreviews(card, page.previewHighlights);
+  renderCardRemainingCount(card, page.remainingCount);
+  bindCardButtons(card, page, callbacks);
+
+  return card;
+}
+
+/**
  * 從 pages 取出指定範圍的卡片並插入 unsyncedView 容器
  *
- * @param {SidePanelElements} elements
- * @param {Array} pages - 完整的未同步頁面陣列
- * @param {number} startIndex - 起始索引
- * @param {number} count - 本次渲染數量
- * @param {{ onOpen: (url: string) => void, onDelete: (storageKey: string, card: HTMLElement) => void }} callbacks
+ * @param {object} request
+ * @param {SidePanelElements} request.elements
+ * @param {Array} request.pages - 完整的未同步頁面陣列
+ * @param {number} request.startIndex - 起始索引
+ * @param {number} request.count - 本次渲染數量
+ * @param {{ onOpen: (url: string) => void, onDelete: (storageKey: string, card: HTMLElement) => void }} request.callbacks
  * @returns {number} 本次渲染的卡片數量
  */
-export function appendCards(elements, pages, startIndex, count, callbacks) {
+export function appendCards({ elements, pages, startIndex, count, callbacks }) {
   const container = elements.unsyncedView;
   const template = elements.pageCardTemplate;
   if (!container || !template?.content) {
@@ -415,57 +533,10 @@ export function appendCards(elements, pages, startIndex, count, callbacks) {
   const fragment = document.createDocumentFragment();
 
   batch.forEach(page => {
-    const cardNode = template.content.cloneNode(true);
-    const card = cardNode.querySelector('.page-card');
-    if (!card) {
-      return;
+    const card = createUnsyncedPageCard(template, page, callbacks);
+    if (card) {
+      fragment.append(card);
     }
-
-    const titleEl = card.querySelector('.page-title');
-    if (titleEl) {
-      titleEl.textContent = page.title;
-    }
-
-    const metaEl = card.querySelector('.page-meta');
-    if (metaEl) {
-      metaEl.textContent = `${extractDomain(page.url)} • ${UI_MESSAGES.SIDEPANEL.HIGHLIGHT_COUNT(page.highlightCount)}`;
-    }
-
-    // 標註預覽
-    const previewContainer = card.querySelector('.page-card-previews');
-    if (previewContainer) {
-      const previewHighlights = Array.isArray(page.previewHighlights) ? page.previewHighlights : [];
-      previewHighlights.forEach(highlight => {
-        const row = document.createElement('p');
-        row.className = `preview-row color-${normalizeHighlightColor(highlight?.color)}`;
-        row.textContent = `"${highlight.text}${highlight.truncated ? '...' : ''}"`;
-        previewContainer.append(row);
-      });
-    }
-
-    // +N more
-    const remainingEl = card.querySelector('.page-card-remaining');
-    if (remainingEl && page.remainingCount > 0) {
-      remainingEl.textContent = UI_MESSAGES.SIDEPANEL.REMAINING_COUNT(page.remainingCount);
-    }
-
-    // 開啟頁面
-    const openButton = card.querySelector('.page-open-button');
-    if (openButton && typeof callbacks.onOpen === 'function') {
-      openButton.addEventListener('click', () => {
-        callbacks.onOpen(page.url);
-      });
-    }
-
-    // 刪除單頁標注
-    const deleteButton = card.querySelector('.page-delete-button');
-    if (deleteButton && typeof callbacks.onDelete === 'function') {
-      deleteButton.addEventListener('click', () => {
-        callbacks.onDelete(page.storageKey, card);
-      });
-    }
-
-    fragment.append(card);
   });
 
   container.append(fragment);

--- a/tests/unit/sidepanel/sidepanelUI.test.js
+++ b/tests/unit/sidepanel/sidepanelUI.test.js
@@ -375,6 +375,37 @@ describe('sidepanelUI', () => {
       expect(currentTab.getAttribute('aria-selected')).toBe('true');
     });
 
+    it('切換到 current 時應重設按鈕顯示狀態', () => {
+      const elements = getElements();
+      if (elements.syncButton) {
+        elements.syncButton.style.display = 'none';
+      }
+      if (elements.openNotionButton) {
+        elements.openNotionButton.style.display = 'none';
+      }
+      if (elements.loadMoreBtn) {
+        elements.loadMoreBtn.style.display = 'block';
+      }
+      if (elements.unsyncedToolbar) {
+        elements.unsyncedToolbar.style.display = 'block';
+      }
+
+      switchView(elements, 'current');
+
+      if (elements.syncButton) {
+        expect(elements.syncButton.style.display).toBe('');
+      }
+      if (elements.openNotionButton) {
+        expect(elements.openNotionButton.style.display).toBe('');
+      }
+      if (elements.loadMoreBtn) {
+        expect(elements.loadMoreBtn.style.display).toBe('none');
+      }
+      if (elements.unsyncedToolbar) {
+        expect(elements.unsyncedToolbar.style.display).toBe('none');
+      }
+    });
+
     it('switchView 不應觸發 loadCurrentTab 或 renderUnsyncedView', () => {
       // 此測試確保 switchView 是純 DOM 操作
       // 若它不呼叫任何外部函數，就不會拋出 ReferenceError
@@ -385,13 +416,40 @@ describe('sidepanelUI', () => {
   });
 
   describe('appendCards', () => {
+    it('當缺少 pageCardTemplate 時應回傳 0', () => {
+      const elements = getElements();
+      const originalTemplate = elements.pageCardTemplate;
+      elements.pageCardTemplate = null;
+
+      const pages = [makePage(1)];
+      const result = appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 1,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete: jest.fn(),
+        },
+      });
+
+      expect(result).toBe(0);
+      elements.pageCardTemplate = originalTemplate;
+    });
+
     it('應渲染指定範圍的卡片並回傳 renderedCount', () => {
       const elements = getElements();
       const pages = [makePage(1), makePage(2), makePage(3)];
 
-      const result = appendCards(elements, pages, 0, 2, {
-        onOpen: jest.fn(),
-        onDelete: jest.fn(),
+      const result = appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 2,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete: jest.fn(),
+        },
       });
 
       expect(result).toBe(2);
@@ -402,9 +460,15 @@ describe('sidepanelUI', () => {
       const elements = getElements();
       const pages = [makePage(1), makePage(2), makePage(3)];
 
-      appendCards(elements, pages, 0, 2, {
-        onOpen: jest.fn(),
-        onDelete: jest.fn(),
+      appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 2,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete: jest.fn(),
+        },
       });
 
       expect(elements.loadMoreBtn.style.display).toBe('block');
@@ -414,9 +478,15 @@ describe('sidepanelUI', () => {
       const elements = getElements();
       const pages = [makePage(1), makePage(2)];
 
-      appendCards(elements, pages, 0, 10, {
-        onOpen: jest.fn(),
-        onDelete: jest.fn(),
+      appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 10,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete: jest.fn(),
+        },
       });
 
       expect(elements.loadMoreBtn.style.display).toBe('none');
@@ -427,7 +497,16 @@ describe('sidepanelUI', () => {
       const onOpen = jest.fn();
       const pages = [makePage(1)];
 
-      appendCards(elements, pages, 0, 1, { onOpen, onDelete: jest.fn() });
+      appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 1,
+        callbacks: {
+          onOpen,
+          onDelete: jest.fn(),
+        },
+      });
 
       const openBtn = elements.unsyncedView.querySelector('.page-open-button');
       openBtn.click();
@@ -440,7 +519,16 @@ describe('sidepanelUI', () => {
       const onDelete = jest.fn();
       const pages = [makePage(1)];
 
-      appendCards(elements, pages, 0, 1, { onOpen: jest.fn(), onDelete });
+      appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 1,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete,
+        },
+      });
 
       const card = elements.unsyncedView.querySelector('.page-card');
       const delBtn = card.querySelector('.page-delete-button');
@@ -458,7 +546,16 @@ describe('sidepanelUI', () => {
         },
       ];
 
-      appendCards(elements, pages, 0, 1, { onOpen: jest.fn(), onDelete: jest.fn() });
+      appendCards({
+        elements,
+        pages,
+        startIndex: 0,
+        count: 1,
+        callbacks: {
+          onOpen: jest.fn(),
+          onDelete: jest.fn(),
+        },
+      });
 
       const previewRow = elements.unsyncedView.querySelector('.preview-row');
       expect(previewRow.className).toContain('color-yellow');
@@ -474,9 +571,15 @@ describe('sidepanelUI', () => {
       const pages = [makePage(1)];
 
       expect(() =>
-        appendCards(elements, pages, 0, 1, {
-          onOpen: jest.fn(),
-          onDelete: jest.fn(),
+        appendCards({
+          elements,
+          pages,
+          startIndex: 0,
+          count: 1,
+          callbacks: {
+            onOpen: jest.fn(),
+            onDelete: jest.fn(),
+          },
         })
       ).not.toThrow();
       expect(elements.unsyncedView.querySelectorAll('.page-card')).toHaveLength(1);

--- a/tests/unit/sidepanel/sidepanelUI.test.js
+++ b/tests/unit/sidepanel/sidepanelUI.test.js
@@ -87,6 +87,30 @@ function makePage(i) {
   };
 }
 
+function appendPageCardsForTest({
+  pages = [makePage(1)],
+  startIndex = 0,
+  count = pages.length,
+  callbacks = {},
+} = {}) {
+  const elements = getElements();
+  const resolvedCallbacks = {
+    onOpen: jest.fn(),
+    onDelete: jest.fn(),
+    ...callbacks,
+  };
+
+  const renderedCount = appendCards({
+    elements,
+    pages,
+    startIndex,
+    count,
+    callbacks: resolvedCallbacks,
+  });
+
+  return { elements, renderedCount };
+}
+
 // ---- 測試 ----
 
 describe('sidepanelUI', () => {
@@ -377,33 +401,17 @@ describe('sidepanelUI', () => {
 
     it('切換到 current 時應重設按鈕顯示狀態', () => {
       const elements = getElements();
-      if (elements.syncButton) {
-        elements.syncButton.style.display = 'none';
-      }
-      if (elements.openNotionButton) {
-        elements.openNotionButton.style.display = 'none';
-      }
-      if (elements.loadMoreBtn) {
-        elements.loadMoreBtn.style.display = 'block';
-      }
-      if (elements.unsyncedToolbar) {
-        elements.unsyncedToolbar.style.display = 'block';
-      }
+      elements.syncButton.style.display = 'none';
+      elements.openNotionButton.style.display = 'none';
+      elements.loadMoreBtn.style.display = 'block';
+      elements.unsyncedToolbar.style.display = 'block';
 
       switchView(elements, 'current');
 
-      if (elements.syncButton) {
-        expect(elements.syncButton.style.display).toBe('');
-      }
-      if (elements.openNotionButton) {
-        expect(elements.openNotionButton.style.display).toBe('');
-      }
-      if (elements.loadMoreBtn) {
-        expect(elements.loadMoreBtn.style.display).toBe('none');
-      }
-      if (elements.unsyncedToolbar) {
-        expect(elements.unsyncedToolbar.style.display).toBe('none');
-      }
+      expect(elements.syncButton.style.display).toBe('');
+      expect(elements.openNotionButton.style.display).toBe('');
+      expect(elements.loadMoreBtn.style.display).toBe('none');
+      expect(elements.unsyncedToolbar.style.display).toBe('none');
     });
 
     it('switchView 不應觸發 loadCurrentTab 或 renderUnsyncedView', () => {
@@ -438,73 +446,44 @@ describe('sidepanelUI', () => {
     });
 
     it('應渲染指定範圍的卡片並回傳 renderedCount', () => {
-      const elements = getElements();
       const pages = [makePage(1), makePage(2), makePage(3)];
-
-      const result = appendCards({
-        elements,
+      const { elements, renderedCount } = appendPageCardsForTest({
         pages,
-        startIndex: 0,
         count: 2,
-        callbacks: {
-          onOpen: jest.fn(),
-          onDelete: jest.fn(),
-        },
       });
 
-      expect(result).toBe(2);
+      expect(renderedCount).toBe(2);
       expect(elements.unsyncedView.querySelectorAll('.page-card')).toHaveLength(2);
     });
 
     it('當還有更多卡片時應顯示 loadMoreBtn', () => {
-      const elements = getElements();
       const pages = [makePage(1), makePage(2), makePage(3)];
 
-      appendCards({
-        elements,
+      const { elements } = appendPageCardsForTest({
         pages,
-        startIndex: 0,
         count: 2,
-        callbacks: {
-          onOpen: jest.fn(),
-          onDelete: jest.fn(),
-        },
       });
 
       expect(elements.loadMoreBtn.style.display).toBe('block');
     });
 
     it('當已渲染全部卡片時應隱藏 loadMoreBtn', () => {
-      const elements = getElements();
       const pages = [makePage(1), makePage(2)];
 
-      appendCards({
-        elements,
+      const { elements } = appendPageCardsForTest({
         pages,
-        startIndex: 0,
         count: 10,
-        callbacks: {
-          onOpen: jest.fn(),
-          onDelete: jest.fn(),
-        },
       });
 
       expect(elements.loadMoreBtn.style.display).toBe('none');
     });
 
     it('點擊開啟按鈕應呼叫 onOpen 回調', () => {
-      const elements = getElements();
       const onOpen = jest.fn();
-      const pages = [makePage(1)];
 
-      appendCards({
-        elements,
-        pages,
-        startIndex: 0,
-        count: 1,
+      const { elements } = appendPageCardsForTest({
         callbacks: {
           onOpen,
-          onDelete: jest.fn(),
         },
       });
 
@@ -515,17 +494,10 @@ describe('sidepanelUI', () => {
     });
 
     it('點擊刪除按鈕應呼叫 onDelete 回調並傳入正確參數', () => {
-      const elements = getElements();
       const onDelete = jest.fn();
-      const pages = [makePage(1)];
 
-      appendCards({
-        elements,
-        pages,
-        startIndex: 0,
-        count: 1,
+      const { elements } = appendPageCardsForTest({
         callbacks: {
-          onOpen: jest.fn(),
           onDelete,
         },
       });
@@ -538,7 +510,6 @@ describe('sidepanelUI', () => {
     });
 
     it('應將非法 preview 顏色回退為 yellow class', () => {
-      const elements = getElements();
       const pages = [
         {
           ...makePage(1),
@@ -546,15 +517,8 @@ describe('sidepanelUI', () => {
         },
       ];
 
-      appendCards({
-        elements,
+      const { elements } = appendPageCardsForTest({
         pages,
-        startIndex: 0,
-        count: 1,
-        callbacks: {
-          onOpen: jest.fn(),
-          onDelete: jest.fn(),
-        },
       });
 
       const previewRow = elements.unsyncedView.querySelector('.preview-row');


### PR DESCRIPTION
### 摘要
重構 sidepanel UI 以解決 ESLint 複雜度警告，並簡化測試邏輯。

### 變更內容
- 將 `appendCards` 函數改為使用物件簽名以提高可讀性。
- 減少 sidepanel UI 測試的複雜度，簡化測試邏輯。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

