### PR TITLE
refactor: simplify onboarding logic and error handling

### DIFF
--- a/pages/onboarding/onboarding.js
+++ b/pages/onboarding/onboarding.js
@@ -34,6 +34,56 @@ const ARIA_CHECKED = 'aria-checked';
 
 let selectedDatabaseId = null;
 
+/**
+ * 格式化錯誤訊息，若 error 無 message 則轉為字串
+ * 若指定了 defaultText 且無 error.message，則傳回 defaultText
+ *
+ * @param {any} error 錯誤物件
+ * @param {string} [defaultText] 預設訊息
+ * @returns {string} 格式化後的字串
+ */
+function formatError(error, defaultText = null) {
+  if (defaultText) {
+    return error?.message ?? defaultText;
+  }
+  return error?.message ?? String(error);
+}
+
+/**
+ * 檢查 storage 變更是否代表已完成 account 登入
+ *
+ * @param {object} changes Storage 變更
+ * @param {string} areaName 儲存區域名稱
+ * @returns {boolean}
+ */
+function hasCompletedAccountLogin(changes, areaName) {
+  return areaName === 'local' && Boolean(changes.accountEmail?.newValue);
+}
+
+/**
+ * 還原步驟 4 的登入按鈕狀態與隱藏等待中文字
+ *
+ * @param {HTMLButtonElement} button 登入按鈕
+ * @param {string} originalText 按鈕原本的文字
+ */
+function restoreStep4LoginButton(button, originalText) {
+  button.disabled = false;
+  button.textContent = originalText;
+  setStep4WaitingVisible(false);
+}
+
+/**
+ * 驗證 account 登入結果，若失敗則拋出錯誤
+ *
+ * @param {object} result 登入結果
+ * @throws {Error}
+ */
+function assertAccountLoginStarted(result) {
+  if (!result?.success) {
+    throw new Error(result?.error || 'login_failed');
+  }
+}
+
 function setError(scope, message) {
   const errorEl = root.querySelector(`[data-error="${scope}"]`);
   if (!errorEl) {
@@ -129,11 +179,11 @@ async function loadDatabasesForStep3() {
   } catch (error) {
     Logger.warn('[Onboarding] 拉取 database 列表失敗', {
       action: 'fetchNotionDatabases',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
     setError(
       ERROR_SCOPE_FETCH_DATABASES,
-      `載入失敗：${error?.message ?? '未知錯誤'}，請重試或稍後再說`
+      `載入失敗：${formatError(error, '未知錯誤')}，請重試或稍後再說`
     );
     setStep3State('error');
   }
@@ -149,7 +199,7 @@ async function handleStep2Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 Notion 授權狀態失敗', {
       action: 'isNotionConnected',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
   }
 }
@@ -161,7 +211,7 @@ async function handleStep3Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 Notion 授權狀態失敗', {
       action: 'isNotionConnected',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
   }
   if (!connected) {
@@ -187,7 +237,7 @@ async function handleStep4Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 account 登入狀態失敗', {
       action: 'isAccountLoggedIn',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
   }
 }
@@ -198,7 +248,7 @@ async function handleStepCompleted() {
   } catch (error) {
     Logger.warn('[Onboarding] 寫入完成旗標失敗', {
       action: 'markCompleted',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
   }
 }
@@ -237,11 +287,11 @@ async function handleConnectNotion(button) {
   } catch (error) {
     Logger.warn('[Onboarding] Notion OAuth 連接失敗', {
       action: 'runNotionOAuthFlow',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
     setError(
       ERROR_SCOPE_CONNECT_NOTION,
-      `連接失敗：${error?.message ?? '未知錯誤'}，請重試或稍後再說`
+      `連接失敗：${formatError(error, '未知錯誤')}，請重試或稍後再說`
     );
     button.disabled = false;
     button.textContent = originalText;
@@ -264,9 +314,9 @@ async function handleConfirmDatabase(button) {
   } catch (error) {
     Logger.warn('[Onboarding] 寫入 notionDataSourceId 失敗', {
       action: 'selectDataSource',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
-    setError(ERROR_SCOPE_FETCH_DATABASES, `儲存失敗：${error?.message ?? '未知錯誤'}，請重試`);
+    setError(ERROR_SCOPE_FETCH_DATABASES, `儲存失敗：${formatError(error, '未知錯誤')}，請重試`);
     setStep3State('error');
     button.disabled = originalDisabled;
   }
@@ -285,14 +335,9 @@ async function handleLoginAccount(button) {
   button.textContent = '登入中...';
   setError(ERROR_SCOPE_LOGIN_ACCOUNT, '');
 
-  // 設置 storage listener 偵測登入完成（accountEmail 寫入）
-  const restoreButton = () => {
-    button.disabled = false;
-    button.textContent = originalText;
-    setStep4WaitingVisible(false);
-  };
+  const restoreButton = () => restoreStep4LoginButton(button, originalText);
   const onChanged = async (changes, areaName) => {
-    if (areaName !== 'local' || !changes.accountEmail?.newValue) {
+    if (!hasCompletedAccountLogin(changes, areaName)) {
       return;
     }
     chrome.storage.onChanged.removeListener(onChanged);
@@ -304,72 +349,75 @@ async function handleLoginAccount(button) {
 
   try {
     const result = await startAccountLogin();
-    if (!result?.success) {
-      throw new Error(result?.error || 'login_failed');
-    }
+    assertAccountLoginStarted(result);
     setStep4WaitingVisible(true);
   } catch (error) {
     chrome.storage.onChanged.removeListener(onChanged);
     Logger.warn('[Onboarding] account 登入觸發失敗', {
       action: 'startAccountLogin',
-      error: error?.message ?? String(error),
+      error: formatError(error),
     });
     setError(
       ERROR_SCOPE_LOGIN_ACCOUNT,
-      `登入失敗：${error?.message ?? '未知錯誤'}，請重試或稍後再說`
+      `登入失敗：${formatError(error, '未知錯誤')}，請重試或稍後再說`
     );
     restoreButton();
   }
 }
 
+/**
+ * Onboarding click action 對應表
+ */
+const ACTION_HANDLERS = {
+  next: async () => {
+    const step = nextStep(root);
+    await handleStepEntered(step);
+  },
+  skip: async () => {
+    const step = skipToEnd(root);
+    await handleStepEntered(step);
+  },
+  'connect-notion': async trigger => {
+    await handleConnectNotion(trigger);
+  },
+  'login-account': async trigger => {
+    await handleLoginAccount(trigger);
+  },
+  'confirm-database': async trigger => {
+    await handleConfirmDatabase(trigger);
+  },
+  'retry-databases': async () => {
+    await loadDatabasesForStep3();
+  },
+  finish: () => {
+    window.close();
+  },
+};
+
+/**
+ * 處理 onboarding 按鈕點擊的分發
+ *
+ * @param {MouseEvent} event 點擊事件
+ */
+async function handleOnboardingClick(event) {
+  const databaseItem = event.target.closest('.database-item[data-database-id]');
+  if (databaseItem) {
+    selectDatabaseItem(databaseItem);
+    return;
+  }
+  const trigger = event.target.closest('[data-action]');
+  if (!trigger) {
+    return;
+  }
+  const action = trigger.dataset.action;
+  const handler = ACTION_HANDLERS[action];
+  if (handler) {
+    await handler(trigger);
+  }
+}
+
 function bindActions() {
-  root.addEventListener('click', async event => {
-    const databaseItem = event.target.closest('.database-item[data-database-id]');
-    if (databaseItem) {
-      selectDatabaseItem(databaseItem);
-      return;
-    }
-    const trigger = event.target.closest('[data-action]');
-    if (!trigger) {
-      return;
-    }
-    const action = trigger.dataset.action;
-    switch (action) {
-      case 'next': {
-        const step = nextStep(root);
-        await handleStepEntered(step);
-        break;
-      }
-      case 'skip': {
-        const step = skipToEnd(root);
-        await handleStepEntered(step);
-        break;
-      }
-      case 'connect-notion': {
-        await handleConnectNotion(trigger);
-        break;
-      }
-      case 'login-account': {
-        await handleLoginAccount(trigger);
-        break;
-      }
-      case 'confirm-database': {
-        await handleConfirmDatabase(trigger);
-        break;
-      }
-      case 'retry-databases': {
-        await loadDatabasesForStep3();
-        break;
-      }
-      case 'finish': {
-        window.close();
-        break;
-      }
-      default: {
-        break;
-      }
-    }
-  });
+  root.addEventListener('click', handleOnboardingClick);
 }
 
 showStep(root, 1);

--- a/pages/onboarding/onboarding.js
+++ b/pages/onboarding/onboarding.js
@@ -191,6 +191,7 @@ async function loadDatabasesForStep3() {
   } catch (error) {
     Logger.warn('[Onboarding] 拉取 database 列表失敗', {
       action: 'fetchNotionDatabases',
+      result: 'failed',
       error: formatError(error),
     });
     setError(
@@ -211,6 +212,7 @@ async function handleStep2Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 Notion 授權狀態失敗', {
       action: 'isNotionConnected',
+      result: 'failed',
       error: formatError(error),
     });
   }
@@ -223,6 +225,7 @@ async function handleStep3Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 Notion 授權狀態失敗', {
       action: 'isNotionConnected',
+      result: 'failed',
       error: formatError(error),
     });
   }
@@ -249,6 +252,7 @@ async function handleStep4Entered() {
   } catch (error) {
     Logger.warn('[Onboarding] 偵測 account 登入狀態失敗', {
       action: 'isAccountLoggedIn',
+      result: 'failed',
       error: formatError(error),
     });
   }
@@ -260,6 +264,7 @@ async function handleStepCompleted() {
   } catch (error) {
     Logger.warn('[Onboarding] 寫入完成旗標失敗', {
       action: 'markCompleted',
+      result: 'failed',
       error: formatError(error),
     });
   }
@@ -299,6 +304,7 @@ async function handleConnectNotion(button) {
   } catch (error) {
     Logger.warn('[Onboarding] Notion OAuth 連接失敗', {
       action: 'runNotionOAuthFlow',
+      result: 'failed',
       error: formatError(error),
     });
     setError(
@@ -326,6 +332,7 @@ async function handleConfirmDatabase(button) {
   } catch (error) {
     Logger.warn('[Onboarding] 寫入 notionDataSourceId 失敗', {
       action: 'selectDataSource',
+      result: 'failed',
       error: formatError(error),
     });
     setError(ERROR_SCOPE_FETCH_DATABASES, `儲存失敗：${formatError(error, '未知錯誤')}，請重試`);
@@ -367,6 +374,7 @@ async function handleLoginAccount(button) {
     chrome.storage.onChanged.removeListener(onChanged);
     Logger.warn('[Onboarding] account 登入觸發失敗', {
       action: 'startAccountLogin',
+      result: 'failed',
       error: formatError(error),
     });
     setError(
@@ -412,12 +420,17 @@ const ACTION_HANDLERS = {
  * @param {MouseEvent} event 點擊事件
  */
 async function handleOnboardingClick(event) {
-  const databaseItem = event.target.closest('.database-item[data-database-id]');
+  const { target } = event;
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const databaseItem = target.closest('.database-item[data-database-id]');
   if (databaseItem) {
     selectDatabaseItem(databaseItem);
     return;
   }
-  const trigger = event.target.closest('[data-action]');
+  const trigger = target.closest('[data-action]');
   if (!trigger) {
     return;
   }
@@ -434,4 +447,4 @@ function bindActions() {
 
 showStep(root, 1);
 bindActions();
-Logger.ready('[Onboarding] entry loaded', { action: 'onboarding_init' });
+Logger.ready('[Onboarding] entry loaded', { action: 'onboarding_init', result: 'success' });

--- a/pages/onboarding/onboarding.js
+++ b/pages/onboarding/onboarding.js
@@ -35,18 +35,30 @@ const ARIA_CHECKED = 'aria-checked';
 let selectedDatabaseId = null;
 
 /**
- * 格式化錯誤訊息，若 error 無 message 則轉為字串
- * 若指定了 defaultText 且無 error.message，則傳回 defaultText
+ * 格式化錯誤訊息，優先使用錯誤內容本身，次之使用 defaultText
  *
- * @param {any} error 錯誤物件
+ * @param {any} error 錯誤物件、字串或其他值
  * @param {string} [defaultText] 預設訊息
  * @returns {string} 格式化後的字串
  */
 function formatError(error, defaultText = null) {
-  if (defaultText) {
-    return error?.message ?? defaultText;
+  // 若 error 本身就是非空字串，直接回傳
+  if (typeof error === 'string' && error) {
+    return error;
   }
-  return error?.message ?? String(error);
+
+  // 若 error 是 Error object 且有 message，回傳 message
+  if (error?.message) {
+    return error.message;
+  }
+
+  // 若 error 是 null/undefined，回傳 defaultText 或通用訊息
+  if (error == null) {
+    return defaultText || '未知錯誤';
+  }
+
+  // 其他情況：回傳 defaultText 或嘗試轉字串
+  return defaultText || String(error);
 }
 
 /**

--- a/tests/unit/onboarding/onboarding-entry.test.js
+++ b/tests/unit/onboarding/onboarding-entry.test.js
@@ -1,0 +1,327 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* global jest, describe, it, expect, beforeEach, afterEach */
+
+// Mock controller
+jest.mock('../../../pages/onboarding/onboardingController.js', () => ({
+  TOTAL_STEPS: 6,
+  showStep: jest.fn(),
+  getCurrentStep: jest.fn(),
+  nextStep: jest.fn(),
+  skipToEnd: jest.fn(),
+  markCompleted: jest.fn(),
+  isNotionConnected: jest.fn(),
+  runNotionOAuthFlow: jest.fn(),
+  fetchNotionDatabases: jest.fn(),
+  selectDataSource: jest.fn(),
+  isAccountFeatureEnabled: jest.fn(),
+  isAccountLoggedIn: jest.fn(),
+}));
+
+// Mock login initiator
+jest.mock('../../../scripts/auth/accountLoginInitiator.js', () => ({
+  startAccountLogin: jest.fn(),
+}));
+
+import {
+  showStep,
+  nextStep,
+  skipToEnd,
+  isNotionConnected,
+  runNotionOAuthFlow,
+  fetchNotionDatabases,
+  selectDataSource,
+  isAccountFeatureEnabled,
+  isAccountLoggedIn,
+} from '../../../pages/onboarding/onboardingController.js';
+import { startAccountLogin } from '../../../scripts/auth/accountLoginInitiator.js';
+
+describe('onboarding entry script (onboarding.js)', () => {
+  let root;
+  let originalWindowClose;
+
+  beforeEach(() => {
+    // 設置 JSDOM 環境的 HTML
+    document.body.innerHTML = `
+      <div id="onboarding-root">
+        <div class="onboarding-progress">
+          <span class="progress-dot" data-dot="1"></span>
+          <span class="progress-dot" data-dot="2"></span>
+          <span class="progress-dot" data-dot="3"></span>
+          <span class="progress-dot" data-dot="4"></span>
+          <span class="progress-dot" data-dot="5"></span>
+          <span class="progress-dot" data-dot="6"></span>
+        </div>
+        <section data-step="1" class="step-section"></section>
+        <section data-step="2" class="step-section">
+          <button data-action="connect-notion">Connect Notion</button>
+          <div data-error="connect-notion" hidden></div>
+        </section>
+        <section data-step="3" class="step-section">
+          <div data-step3-state="loading" hidden>Loading...</div>
+          <div data-step3-state="empty" hidden>No databases</div>
+          <div data-step3-state="list" hidden>
+            <ul data-database-list></ul>
+          </div>
+          <div data-step3-state="error" hidden>Error loading</div>
+          <button data-step3-confirm disabled data-action="confirm-database">Confirm Database</button>
+          <button data-action="retry-databases">Retry</button>
+          <div data-error="fetch-databases" hidden></div>
+        </section>
+        <section data-step="4" class="step-section">
+          <button data-action="login-account">Login Account</button>
+          <div data-step4-state="waiting" hidden>Waiting for login...</div>
+          <div data-error="login-account" hidden></div>
+        </section>
+        <section data-step="5" class="step-section">
+          <button data-action="next">Next</button>
+          <button data-action="skip">Skip</button>
+        </section>
+        <section data-step="6" class="step-section">
+          <button data-action="finish">Finish</button>
+        </section>
+      </div>
+    `;
+    root = document.querySelector('#onboarding-root');
+
+    // Mock chrome storage
+    globalThis.chrome.storage = {
+      local: {},
+      onChanged: {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      },
+    };
+
+    // Mock chrome runtime
+    globalThis.chrome.runtime = {
+      sendMessage: jest.fn(),
+    };
+
+    originalWindowClose = window.close;
+    window.close = jest.fn();
+
+    // 預設重置 Mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.close = originalWindowClose;
+  });
+
+  const loadEntryScript = () => {
+    jest.isolateModules(() => {
+      require('../../../pages/onboarding/onboarding.js');
+    });
+  };
+
+  it('載入時應初始化步驟 1 並綁定 actions', () => {
+    loadEntryScript();
+    expect(showStep).toHaveBeenCalledWith(root, 1);
+  });
+
+  it('點擊 next 應調用 nextStep', () => {
+    loadEntryScript();
+    nextStep.mockReturnValue(5);
+
+    const nextBtn = root.querySelector('[data-action="next"]');
+    nextBtn.click();
+
+    expect(nextStep).toHaveBeenCalledWith(root);
+  });
+
+  it('點擊 skip 應調用 skipToEnd', () => {
+    loadEntryScript();
+    skipToEnd.mockReturnValue(6);
+
+    const skipBtn = root.querySelector('[data-action="skip"]');
+    skipBtn.click();
+
+    expect(skipToEnd).toHaveBeenCalledWith(root);
+  });
+
+  it('點擊 finish 應關閉視窗', () => {
+    loadEntryScript();
+
+    const finishBtn = root.querySelector('[data-action="finish"]');
+    finishBtn.click();
+
+    expect(window.close).toHaveBeenCalled();
+  });
+
+  describe('Step 2: Connect Notion', () => {
+    it('若 Notion 已連接，進入 Step 2 時應自動跳到下一步', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      nextStep.mockReturnValue(3);
+
+      loadEntryScript();
+
+      runNotionOAuthFlow.mockResolvedValue(undefined);
+      nextStep.mockReturnValue(3);
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      await connectBtn.click();
+
+      expect(runNotionOAuthFlow).toHaveBeenCalled();
+      expect(nextStep).toHaveBeenCalledWith(root);
+    });
+
+    it('Notion OAuth 連接失敗時，應顯示錯誤訊息並還原按鈕', async () => {
+      isNotionConnected.mockResolvedValue(false);
+      runNotionOAuthFlow.mockRejectedValue(new Error('oauth_error'));
+
+      loadEntryScript();
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      const originalText = connectBtn.textContent;
+
+      connectBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      expect(errorEl.hidden).toBe(false);
+      expect(errorEl.textContent).toContain('oauth_error');
+      expect(connectBtn.disabled).toBe(false);
+      expect(connectBtn.textContent).toBe(originalText);
+    });
+  });
+
+  describe('Step 3: Database Selection', () => {
+    it('加載資料庫為空時應顯示空狀態', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const emptyState = root.querySelector('[data-step3-state="empty"]');
+      expect(emptyState.hidden).toBe(false);
+    });
+
+    it('載入資料庫成功時，應渲染列表並支援選取與確認', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([
+        { id: 'db-1', title: 'DB One' },
+        { id: 'db-2', title: 'DB Two' },
+      ]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const listState = root.querySelector('[data-step3-state="list"]');
+      expect(listState.hidden).toBe(false);
+
+      const listEl = root.querySelector('[data-database-list]');
+      expect(listEl.children).toHaveLength(2);
+
+      const firstItem = listEl.children[0];
+      firstItem.click();
+
+      expect(firstItem.classList.contains('selected')).toBe(true);
+      expect(firstItem.getAttribute('aria-checked')).toBe('true');
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      expect(confirmBtn.disabled).toBe(false);
+
+      selectDataSource.mockResolvedValue(undefined);
+      nextStep.mockReturnValue(4);
+      confirmBtn.click();
+
+      await new Promise(process.nextTick);
+      expect(selectDataSource).toHaveBeenCalledWith({
+        storage: globalThis.chrome.storage.local,
+        dataSourceId: 'db-1',
+      });
+    });
+
+    it('資料庫加載失敗時應顯示錯誤狀態與訊息', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockRejectedValue(new Error('network_error'));
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorState = root.querySelector('[data-step3-state="error"]');
+      expect(errorState.hidden).toBe(false);
+
+      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      expect(errorEl.hidden).toBe(false);
+      expect(errorEl.textContent).toContain('network_error');
+    });
+  });
+
+  describe('Step 4: Account Login', () => {
+    it('點擊登入應啟動登入流，設置 listener，並在儲存 accountEmail 後進入下一步', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(false);
+      startAccountLogin.mockResolvedValue({ success: true });
+
+      let addedListener = null;
+      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
+        addedListener = listener;
+      });
+
+      loadEntryScript();
+
+      const loginBtn = root.querySelector('[data-action="login-account"]');
+      loginBtn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(startAccountLogin).toHaveBeenCalled();
+      expect(globalThis.chrome.storage.onChanged.addListener).toHaveBeenCalled();
+      expect(addedListener).not.toBeNull();
+
+      const waitingEl = root.querySelector('[data-step4-state="waiting"]');
+      expect(waitingEl.hidden).toBe(false);
+
+      nextStep.mockReturnValue(5);
+
+      await addedListener({ accountEmail: { newValue: 'user@example.com' } }, 'local');
+
+      expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalledWith(
+        addedListener
+      );
+      expect(waitingEl.hidden).toBe(true);
+      expect(nextStep).toHaveBeenCalledWith(root);
+    });
+
+    it('啟動登入失敗時應移除 listener 並恢復按鈕', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(false);
+      startAccountLogin.mockRejectedValue(new Error('auth_api_down'));
+
+      // 此測試中不需監聽 storage 變更
+
+      loadEntryScript();
+
+      const loginBtn = root.querySelector('[data-action="login-account"]');
+      const originalText = loginBtn.textContent;
+      loginBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="login-account"]');
+      expect(errorEl.hidden).toBe(false);
+      expect(errorEl.textContent).toContain('auth_api_down');
+      expect(loginBtn.disabled).toBe(false);
+      expect(loginBtn.textContent).toBe(originalText);
+      expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/onboarding/onboarding-entry.test.js
+++ b/tests/unit/onboarding/onboarding-entry.test.js
@@ -323,5 +323,471 @@ describe('onboarding entry script (onboarding.js)', () => {
       expect(loginBtn.textContent).toBe(originalText);
       expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalled();
     });
+
+    it('startAccountLogin 回傳 success:false 應視為失敗並顯示錯誤', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(false);
+      startAccountLogin.mockResolvedValue({ success: false, error: 'login_failed' });
+
+      loadEntryScript();
+
+      const loginBtn = root.querySelector('[data-action="login-account"]');
+      loginBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="login-account"]');
+      expect(errorEl.hidden).toBe(false);
+      expect(errorEl.textContent).toContain('login_failed');
+      expect(loginBtn.disabled).toBe(false);
+      expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalled();
+    });
+
+    it('storage listener 收到非 accountEmail 變更應忽略', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(false);
+      startAccountLogin.mockResolvedValue({ success: true });
+
+      let addedListener = null;
+      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
+        addedListener = listener;
+      });
+
+      loadEntryScript();
+
+      const loginBtn = root.querySelector('[data-action="login-account"]');
+      loginBtn.click();
+
+      await new Promise(process.nextTick);
+
+      nextStep.mockClear();
+
+      // 傳送不相關的 storage 變更
+      await addedListener({ otherKey: { newValue: 'value' } }, 'local');
+
+      expect(nextStep).not.toHaveBeenCalled();
+      expect(globalThis.chrome.storage.onChanged.removeListener).not.toHaveBeenCalled();
+    });
+
+    it('storage listener 收到 sync 區域變更應忽略', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(false);
+      startAccountLogin.mockResolvedValue({ success: true });
+
+      let addedListener = null;
+      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
+        addedListener = listener;
+      });
+
+      loadEntryScript();
+
+      const loginBtn = root.querySelector('[data-action="login-account"]');
+      loginBtn.click();
+
+      await new Promise(process.nextTick);
+
+      nextStep.mockClear();
+
+      // 傳送 sync 區域變更
+      await addedListener({ accountEmail: { newValue: 'user@example.com' } }, 'sync');
+
+      expect(nextStep).not.toHaveBeenCalled();
+      expect(globalThis.chrome.storage.onChanged.removeListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('formatError 函數行為', () => {
+    it('formatError 應處理字串類型錯誤', async () => {
+      runNotionOAuthFlow.mockRejectedValue('string_error');
+
+      loadEntryScript();
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      connectBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      expect(errorEl.textContent).toContain('string_error');
+    });
+
+    it('formatError 應處理 null/undefined 錯誤', async () => {
+      runNotionOAuthFlow.mockRejectedValue(null);
+
+      loadEntryScript();
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      connectBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      expect(errorEl.textContent).toContain('未知錯誤');
+    });
+
+    it('formatError 應處理非 Error 物件', async () => {
+      runNotionOAuthFlow.mockRejectedValue(12_345);
+
+      loadEntryScript();
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      connectBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      expect(errorEl.textContent).toContain('未知錯誤');
+    });
+  });
+
+  describe('防禦性檢查', () => {
+    it('setError 找不到 error 元素時應不拋錯', async () => {
+      // 移除 error 元素
+      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      errorEl.remove();
+
+      runNotionOAuthFlow.mockRejectedValue(new Error('test_error'));
+
+      loadEntryScript();
+
+      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+
+      // 應該不拋錯
+      await expect(async () => {
+        connectBtn.click();
+        await new Promise(process.nextTick);
+      }).not.toThrow();
+    });
+
+    it('renderDatabaseList 找不到 list 元素時應不拋錯', async () => {
+      // 移除 list 元素
+      const listEl = root.querySelector('[data-database-list]');
+      listEl.remove();
+
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+
+      // 應該不拋錯
+      await expect(async () => {
+        retryBtn.click();
+        await new Promise(process.nextTick);
+      }).not.toThrow();
+    });
+
+    it('handleConfirmDatabase 未選資料庫時應直接返回', async () => {
+      loadEntryScript();
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      confirmBtn.disabled = false;
+      confirmBtn.click();
+
+      await new Promise(process.nextTick);
+
+      // selectDataSource 不應被調用
+      expect(selectDataSource).not.toHaveBeenCalled();
+    });
+
+    it('點擊非 action 元素應不觸發任何 handler', () => {
+      loadEntryScript();
+
+      const section = root.querySelector('[data-step="1"]');
+      section.click();
+
+      // 所有 handler 都不應被調用
+      expect(nextStep).not.toHaveBeenCalled();
+      expect(skipToEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('步驟自動跳轉與錯誤處理', () => {
+    it('進入 Step 2 時若已連接 Notion 應自動跳到 Step 3', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      nextStep.mockReturnValue(3);
+      fetchNotionDatabases.mockResolvedValue([]);
+
+      loadEntryScript();
+
+      const nextBtn = root.querySelector('[data-action="next"]');
+      nextBtn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(isNotionConnected).toHaveBeenCalled();
+      expect(nextStep).toHaveBeenCalledWith(root);
+    });
+
+    it('進入 Step 2 時檢測 Notion 連接失敗應記錄但不阻斷', async () => {
+      isNotionConnected.mockRejectedValue(new Error('detection_failed'));
+
+      loadEntryScript();
+
+      const nextBtn = root.querySelector('[data-action="next"]');
+
+      // 應該不拋錯
+      await expect(async () => {
+        nextBtn.click();
+        await new Promise(process.nextTick);
+      }).not.toThrow();
+    });
+
+    it('進入 Step 3 時若未連接 Notion 應顯示 needs-auth 狀態', async () => {
+      isNotionConnected.mockResolvedValue(false);
+      nextStep.mockReturnValue(3);
+
+      loadEntryScript();
+
+      const nextBtn = root.querySelector('[data-action="next"]');
+      nextStep.mockReturnValue(3);
+      nextBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      expect(confirmBtn.hidden).toBe(true);
+    });
+
+    it('進入 Step 3 時檢測 Notion 連接失敗應顯示 needs-auth', async () => {
+      isNotionConnected.mockRejectedValue(new Error('detection_failed'));
+      nextStep.mockReturnValue(3);
+
+      loadEntryScript();
+
+      const nextBtn = root.querySelector('[data-action="next"]');
+      nextStep.mockReturnValue(3);
+      nextBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      expect(confirmBtn.hidden).toBe(true);
+    });
+
+    it('進入 Step 4 時若功能關閉應自動跳到 Step 5', async () => {
+      isAccountFeatureEnabled.mockReturnValue(false);
+
+      // 模擬從 Step 3 進入 Step 4
+      nextStep.mockReturnValueOnce(4).mockReturnValueOnce(5);
+
+      loadEntryScript();
+
+      // 模擬完成 Step 3 (選擇資料庫)
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
+      selectDataSource.mockResolvedValue(undefined);
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const listEl = root.querySelector('[data-database-list]');
+      const firstItem = listEl.children[0];
+      firstItem.click();
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      confirmBtn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(isAccountFeatureEnabled).toHaveBeenCalled();
+      expect(nextStep).toHaveBeenCalledTimes(2); // Step 3->4, Step 4->5
+    });
+
+    it('進入 Step 4 時若已登入應自動跳到 Step 5', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockResolvedValue(true);
+
+      // 模擬從 Step 3 進入 Step 4
+      nextStep.mockReturnValueOnce(4).mockReturnValueOnce(5);
+
+      loadEntryScript();
+
+      // 模擬完成 Step 3 (選擇資料庫)
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
+      selectDataSource.mockResolvedValue(undefined);
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const listEl = root.querySelector('[data-database-list]');
+      const firstItem = listEl.children[0];
+      firstItem.click();
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      confirmBtn.click();
+
+      await new Promise(process.nextTick);
+
+      expect(isAccountLoggedIn).toHaveBeenCalled();
+      expect(nextStep).toHaveBeenCalledTimes(2); // Step 3->4, Step 4->5
+    });
+
+    it('進入 Step 4 時檢測登入狀態失敗應記錄但不阻斷', async () => {
+      isAccountFeatureEnabled.mockReturnValue(true);
+      isAccountLoggedIn.mockRejectedValue(new Error('detection_failed'));
+      nextStep.mockReturnValue(4);
+
+      loadEntryScript();
+
+      const nextBtn = root.querySelector('[data-action="next"]');
+
+      // 應該不拋錯
+      await expect(async () => {
+        nextBtn.click();
+        await new Promise(process.nextTick);
+      }).not.toThrow();
+    });
+
+    it('進入 Step 6 (完成) 時 markCompleted 失敗應記錄但不阻斷', async () => {
+      const { markCompleted } = require('../../../pages/onboarding/onboardingController.js');
+      markCompleted.mockRejectedValue(new Error('write_failed'));
+      skipToEnd.mockReturnValue(6);
+
+      loadEntryScript();
+
+      const skipBtn = root.querySelector('[data-action="skip"]');
+
+      // 應該不拋錯
+      await expect(async () => {
+        skipBtn.click();
+        await new Promise(process.nextTick);
+      }).not.toThrow();
+
+      expect(markCompleted).toHaveBeenCalled();
+    });
+  });
+
+  describe('資料庫選取與切換', () => {
+    it('選取第二個資料庫時應移除第一個的 selected 狀態', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([
+        { id: 'db-1', title: 'DB One' },
+        { id: 'db-2', title: 'DB Two' },
+      ]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const listEl = root.querySelector('[data-database-list]');
+      const firstItem = listEl.children[0];
+      const secondItem = listEl.children[1];
+
+      // 選取第一個
+      firstItem.click();
+      expect(firstItem.classList.contains('selected')).toBe(true);
+      expect(firstItem.getAttribute('aria-checked')).toBe('true');
+
+      // 選取第二個
+      secondItem.click();
+      expect(firstItem.classList.contains('selected')).toBe(false);
+      expect(firstItem.getAttribute('aria-checked')).toBe('false');
+      expect(secondItem.classList.contains('selected')).toBe(true);
+      expect(secondItem.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('selectDataSource 失敗時應顯示錯誤並保留按鈕狀態', async () => {
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const listEl = root.querySelector('[data-database-list]');
+      const firstItem = listEl.children[0];
+      firstItem.click();
+
+      selectDataSource.mockRejectedValue(new Error('storage_error'));
+
+      const confirmBtn = root.querySelector('[data-step3-confirm]');
+      confirmBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      expect(errorEl.hidden).toBe(false);
+      expect(errorEl.textContent).toContain('storage_error');
+
+      const errorState = root.querySelector('[data-step3-state="error"]');
+      expect(errorState.hidden).toBe(false);
+    });
+  });
+
+  describe('chrome.runtime.sendMessage 錯誤處理', () => {
+    it('sendMessage 成功應正常返回 response', async () => {
+      globalThis.chrome.runtime.sendMessage.mockImplementation((msg, callback) => {
+        callback({ success: true, data: [] });
+      });
+
+      isNotionConnected.mockResolvedValue(true);
+      fetchNotionDatabases.mockResolvedValue([]);
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      // 成功載入（空列表）
+      const emptyState = root.querySelector('[data-step3-state="empty"]');
+      expect(emptyState.hidden).toBe(false);
+    });
+
+    it('sendMessage 觸發 chrome.runtime.lastError 應拋出錯誤', async () => {
+      globalThis.chrome.runtime.sendMessage.mockImplementation((msg, callback) => {
+        globalThis.chrome.runtime.lastError = { message: 'runtime_error' };
+        callback();
+        delete globalThis.chrome.runtime.lastError;
+      });
+
+      fetchNotionDatabases.mockImplementation(async ({ sendMessage }) => {
+        await sendMessage({ action: 'test' });
+      });
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      expect(errorEl.hidden).toBe(false);
+    });
+
+    it('sendMessage 同步拋出錯誤應被捕獲', async () => {
+      globalThis.chrome.runtime.sendMessage.mockImplementation(() => {
+        throw new Error('sync_error');
+      });
+
+      fetchNotionDatabases.mockImplementation(async ({ sendMessage }) => {
+        await sendMessage({ action: 'test' });
+      });
+
+      loadEntryScript();
+
+      const retryBtn = root.querySelector('[data-action="retry-databases"]');
+      retryBtn.click();
+
+      await new Promise(process.nextTick);
+
+      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      expect(errorEl.hidden).toBe(false);
+    });
   });
 });

--- a/tests/unit/onboarding/onboarding-entry.test.js
+++ b/tests/unit/onboarding/onboarding-entry.test.js
@@ -25,6 +25,11 @@ jest.mock('../../../scripts/auth/accountLoginInitiator.js', () => ({
   startAccountLogin: jest.fn(),
 }));
 
+jest.mock('../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: require('../../helpers/loggerMock.js').createLoggerMock(),
+}));
+
 import {
   showStep,
   nextStep,
@@ -37,6 +42,7 @@ import {
   isAccountLoggedIn,
 } from '../../../pages/onboarding/onboardingController.js';
 import { startAccountLogin } from '../../../scripts/auth/accountLoginInitiator.js';
+import Logger from '../../../scripts/utils/Logger.js';
 
 describe('onboarding entry script (onboarding.js)', () => {
   let root;
@@ -86,6 +92,8 @@ describe('onboarding entry script (onboarding.js)', () => {
     `;
     root = document.querySelector('#onboarding-root');
 
+    globalThis.chrome = {};
+
     // Mock chrome storage
     globalThis.chrome.storage = {
       local: {},
@@ -120,6 +128,11 @@ describe('onboarding entry script (onboarding.js)', () => {
   const flushPendingPromises = () => new Promise(process.nextTick);
 
   const getActionButton = action => root.querySelector(`[data-action="${action}"]`);
+
+  const expectLoggerWarnResult = action => {
+    const call = Logger.warn.mock.calls.find(([, context]) => context?.action === action);
+    expect(call?.[1]).toEqual(expect.objectContaining({ action, result: 'failed' }));
+  };
 
   const clickAction = action => {
     const button = getActionButton(action);
@@ -205,6 +218,10 @@ describe('onboarding entry script (onboarding.js)', () => {
   it('載入時應初始化步驟 1 並綁定 actions', () => {
     loadEntryScript();
     expect(showStep).toHaveBeenCalledWith(root, 1);
+    expect(Logger.ready).toHaveBeenCalledWith('[Onboarding] entry loaded', {
+      action: 'onboarding_init',
+      result: 'success',
+    });
   });
 
   it('點擊 next 應調用 nextStep', () => {
@@ -265,6 +282,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       expect(errorEl.textContent).toContain('oauth_error');
       expect(connectBtn.disabled).toBe(false);
       expect(connectBtn.textContent).toBe(originalText);
+      expectLoggerWarnResult('runNotionOAuthFlow');
     });
   });
 
@@ -316,6 +334,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       const errorEl = getErrorElement('fetch-databases');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('network_error');
+      expectLoggerWarnResult('fetchNotionDatabases');
     });
   });
 
@@ -359,6 +378,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       expect(loginBtn.disabled).toBe(false);
       expect(loginBtn.textContent).toBe(originalText);
       expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalled();
+      expectLoggerWarnResult('startAccountLogin');
     });
 
     it('startAccountLogin 回傳 success:false 應視為失敗並顯示錯誤', async () => {
@@ -414,9 +434,11 @@ describe('onboarding entry script (onboarding.js)', () => {
       loadEntryScript();
 
       // 應該不拋錯
-      await expect(async () => {
-        await clickActionAndFlush('connect-notion');
-      }).not.toThrow();
+      await expect(
+        (async () => {
+          await clickActionAndFlush('connect-notion');
+        })()
+      ).resolves.toBeUndefined();
     });
 
     it('renderDatabaseList 找不到 list 元素時應不拋錯', async () => {
@@ -430,9 +452,11 @@ describe('onboarding entry script (onboarding.js)', () => {
       loadEntryScript();
 
       // 應該不拋錯
-      await expect(async () => {
-        await clickActionAndFlush('retry-databases');
-      }).not.toThrow();
+      await expect(
+        (async () => {
+          await clickActionAndFlush('retry-databases');
+        })()
+      ).resolves.toBeUndefined();
     });
 
     it('handleConfirmDatabase 未選資料庫時應直接返回', async () => {
@@ -458,6 +482,19 @@ describe('onboarding entry script (onboarding.js)', () => {
       expect(nextStep).not.toHaveBeenCalled();
       expect(skipToEnd).not.toHaveBeenCalled();
     });
+
+    it('event.target 不是 Element 時應忽略 click', async () => {
+      loadEntryScript();
+
+      const textNode = document.createTextNode('plain text');
+      root.append(textNode);
+      textNode.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      await flushPendingPromises();
+
+      expect(nextStep).not.toHaveBeenCalled();
+      expect(skipToEnd).not.toHaveBeenCalled();
+    });
   });
 
   describe('步驟自動跳轉與錯誤處理', () => {
@@ -480,9 +517,12 @@ describe('onboarding entry script (onboarding.js)', () => {
       loadEntryScript();
 
       // 應該不拋錯
-      await expect(async () => {
-        await clickActionAndFlush('next');
-      }).not.toThrow();
+      await expect(
+        (async () => {
+          await clickActionAndFlush('next');
+        })()
+      ).resolves.toBeUndefined();
+      expectLoggerWarnResult('isNotionConnected');
     });
 
     it('進入 Step 3 時若未連接 Notion 應顯示 needs-auth 狀態', async () => {
@@ -511,6 +551,7 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       const confirmBtn = root.querySelector('[data-step3-confirm]');
       expect(confirmBtn.hidden).toBe(true);
+      expectLoggerWarnResult('isNotionConnected');
     });
 
     it('進入 Step 4 時若功能關閉應自動跳到 Step 5', async () => {
@@ -546,9 +587,12 @@ describe('onboarding entry script (onboarding.js)', () => {
       loadEntryScript();
 
       // 應該不拋錯
-      await expect(async () => {
-        await clickActionAndFlush('next');
-      }).not.toThrow();
+      await expect(
+        (async () => {
+          await clickActionAndFlush('next');
+        })()
+      ).resolves.toBeUndefined();
+      expectLoggerWarnResult('isAccountLoggedIn');
     });
 
     it('進入 Step 6 (完成) 時 markCompleted 失敗應記錄但不阻斷', async () => {
@@ -559,11 +603,14 @@ describe('onboarding entry script (onboarding.js)', () => {
       loadEntryScript();
 
       // 應該不拋錯
-      await expect(async () => {
-        await clickActionAndFlush('skip');
-      }).not.toThrow();
+      await expect(
+        (async () => {
+          await clickActionAndFlush('skip');
+        })()
+      ).resolves.toBeUndefined();
 
       expect(markCompleted).toHaveBeenCalled();
+      expectLoggerWarnResult('markCompleted');
     });
   });
 
@@ -599,6 +646,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       const errorEl = getErrorElement('fetch-databases');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('storage_error');
+      expectLoggerWarnResult('selectDataSource');
 
       const errorState = getStep3State('error');
       expect(errorState.hidden).toBe(false);

--- a/tests/unit/onboarding/onboarding-entry.test.js
+++ b/tests/unit/onboarding/onboarding-entry.test.js
@@ -117,6 +117,91 @@ describe('onboarding entry script (onboarding.js)', () => {
     });
   };
 
+  const flushPendingPromises = () => new Promise(process.nextTick);
+
+  const getActionButton = action => root.querySelector(`[data-action="${action}"]`);
+
+  const clickAction = action => {
+    const button = getActionButton(action);
+    button.click();
+    return button;
+  };
+
+  const clickActionAndFlush = async action => {
+    const button = clickAction(action);
+    await flushPendingPromises();
+    return button;
+  };
+
+  const getErrorElement = errorKey => root.querySelector(`[data-error="${errorKey}"]`);
+
+  const getStep3State = state => root.querySelector(`[data-step3-state="${state}"]`);
+
+  const loadDatabasesByRetry = async databases => {
+    isNotionConnected.mockResolvedValue(true);
+    fetchNotionDatabases.mockResolvedValue(databases);
+
+    loadEntryScript();
+    await clickActionAndFlush('retry-databases');
+
+    return root.querySelector('[data-database-list]');
+  };
+
+  const loadDatabasesAndSelectFirst = async databases => {
+    const listEl = await loadDatabasesByRetry(databases);
+    const firstItem = listEl.children[0];
+    firstItem.click();
+
+    return {
+      listEl,
+      firstItem,
+      confirmBtn: root.querySelector('[data-step3-confirm]'),
+    };
+  };
+
+  const completeFirstDatabaseSelection = async () => {
+    const { confirmBtn } = await loadDatabasesAndSelectFirst([{ id: 'db-1', title: 'DB One' }]);
+
+    selectDataSource.mockResolvedValue(undefined);
+    confirmBtn.click();
+    await flushPendingPromises();
+  };
+
+  const startAccountLoginAndCaptureListener = async () => {
+    let addedListener = null;
+    globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
+      addedListener = listener;
+    });
+
+    isAccountFeatureEnabled.mockReturnValue(true);
+    isAccountLoggedIn.mockResolvedValue(false);
+    startAccountLogin.mockResolvedValue({ success: true });
+
+    loadEntryScript();
+    const loginBtn = await clickActionAndFlush('login-account');
+
+    return {
+      addedListener,
+      loginBtn,
+      waitingEl: root.querySelector('[data-step4-state="waiting"]'),
+    };
+  };
+
+  const showConnectNotionError = async error => {
+    runNotionOAuthFlow.mockRejectedValue(error);
+
+    loadEntryScript();
+    await clickActionAndFlush('connect-notion');
+
+    return getErrorElement('connect-notion');
+  };
+
+  const mockFetchThroughRuntimeSendMessage = () => {
+    fetchNotionDatabases.mockImplementation(async ({ sendMessage }) => {
+      await sendMessage({ action: 'test' });
+    });
+  };
+
   it('載入時應初始化步驟 1 並綁定 actions', () => {
     loadEntryScript();
     expect(showStep).toHaveBeenCalledWith(root, 1);
@@ -126,8 +211,7 @@ describe('onboarding entry script (onboarding.js)', () => {
     loadEntryScript();
     nextStep.mockReturnValue(5);
 
-    const nextBtn = root.querySelector('[data-action="next"]');
-    nextBtn.click();
+    clickAction('next');
 
     expect(nextStep).toHaveBeenCalledWith(root);
   });
@@ -136,8 +220,7 @@ describe('onboarding entry script (onboarding.js)', () => {
     loadEntryScript();
     skipToEnd.mockReturnValue(6);
 
-    const skipBtn = root.querySelector('[data-action="skip"]');
-    skipBtn.click();
+    clickAction('skip');
 
     expect(skipToEnd).toHaveBeenCalledWith(root);
   });
@@ -145,8 +228,7 @@ describe('onboarding entry script (onboarding.js)', () => {
   it('點擊 finish 應關閉視窗', () => {
     loadEntryScript();
 
-    const finishBtn = root.querySelector('[data-action="finish"]');
-    finishBtn.click();
+    clickAction('finish');
 
     expect(window.close).toHaveBeenCalled();
   });
@@ -161,8 +243,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       runNotionOAuthFlow.mockResolvedValue(undefined);
       nextStep.mockReturnValue(3);
 
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
-      await connectBtn.click();
+      await clickActionAndFlush('connect-notion');
 
       expect(runNotionOAuthFlow).toHaveBeenCalled();
       expect(nextStep).toHaveBeenCalledWith(root);
@@ -174,14 +255,12 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
+      const connectBtn = getActionButton('connect-notion');
       const originalText = connectBtn.textContent;
 
-      connectBtn.click();
+      await clickActionAndFlush('connect-notion');
 
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      const errorEl = getErrorElement('connect-notion');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('oauth_error');
       expect(connectBtn.disabled).toBe(false);
@@ -191,54 +270,33 @@ describe('onboarding entry script (onboarding.js)', () => {
 
   describe('Step 3: Database Selection', () => {
     it('加載資料庫為空時應顯示空狀態', async () => {
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([]);
+      await loadDatabasesByRetry([]);
 
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const emptyState = root.querySelector('[data-step3-state="empty"]');
+      const emptyState = getStep3State('empty');
       expect(emptyState.hidden).toBe(false);
     });
 
     it('載入資料庫成功時，應渲染列表並支援選取與確認', async () => {
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([
+      const { listEl, firstItem, confirmBtn } = await loadDatabasesAndSelectFirst([
         { id: 'db-1', title: 'DB One' },
         { id: 'db-2', title: 'DB Two' },
       ]);
 
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const listState = root.querySelector('[data-step3-state="list"]');
+      const listState = getStep3State('list');
       expect(listState.hidden).toBe(false);
 
-      const listEl = root.querySelector('[data-database-list]');
       expect(listEl.children).toHaveLength(2);
-
-      const firstItem = listEl.children[0];
-      firstItem.click();
 
       expect(firstItem.classList.contains('selected')).toBe(true);
       expect(firstItem.getAttribute('aria-checked')).toBe('true');
 
-      const confirmBtn = root.querySelector('[data-step3-confirm]');
       expect(confirmBtn.disabled).toBe(false);
 
       selectDataSource.mockResolvedValue(undefined);
       nextStep.mockReturnValue(4);
       confirmBtn.click();
 
-      await new Promise(process.nextTick);
+      await flushPendingPromises();
       expect(selectDataSource).toHaveBeenCalledWith({
         storage: globalThis.chrome.storage.local,
         dataSourceId: 'db-1',
@@ -250,16 +308,12 @@ describe('onboarding entry script (onboarding.js)', () => {
       fetchNotionDatabases.mockRejectedValue(new Error('network_error'));
 
       loadEntryScript();
+      await clickActionAndFlush('retry-databases');
 
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorState = root.querySelector('[data-step3-state="error"]');
+      const errorState = getStep3State('error');
       expect(errorState.hidden).toBe(false);
 
-      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      const errorEl = getErrorElement('fetch-databases');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('network_error');
     });
@@ -267,27 +321,12 @@ describe('onboarding entry script (onboarding.js)', () => {
 
   describe('Step 4: Account Login', () => {
     it('點擊登入應啟動登入流，設置 listener，並在儲存 accountEmail 後進入下一步', async () => {
-      isAccountFeatureEnabled.mockReturnValue(true);
-      isAccountLoggedIn.mockResolvedValue(false);
-      startAccountLogin.mockResolvedValue({ success: true });
-
-      let addedListener = null;
-      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
-        addedListener = listener;
-      });
-
-      loadEntryScript();
-
-      const loginBtn = root.querySelector('[data-action="login-account"]');
-      loginBtn.click();
-
-      await new Promise(process.nextTick);
+      const { addedListener, waitingEl } = await startAccountLoginAndCaptureListener();
 
       expect(startAccountLogin).toHaveBeenCalled();
       expect(globalThis.chrome.storage.onChanged.addListener).toHaveBeenCalled();
       expect(addedListener).not.toBeNull();
 
-      const waitingEl = root.querySelector('[data-step4-state="waiting"]');
       expect(waitingEl.hidden).toBe(false);
 
       nextStep.mockReturnValue(5);
@@ -310,13 +349,11 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const loginBtn = root.querySelector('[data-action="login-account"]');
+      const loginBtn = getActionButton('login-account');
       const originalText = loginBtn.textContent;
-      loginBtn.click();
+      await clickActionAndFlush('login-account');
 
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="login-account"]');
+      const errorEl = getErrorElement('login-account');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('auth_api_down');
       expect(loginBtn.disabled).toBe(false);
@@ -331,65 +368,23 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const loginBtn = root.querySelector('[data-action="login-account"]');
-      loginBtn.click();
+      const loginBtn = await clickActionAndFlush('login-account');
 
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="login-account"]');
+      const errorEl = getErrorElement('login-account');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('login_failed');
       expect(loginBtn.disabled).toBe(false);
       expect(globalThis.chrome.storage.onChanged.removeListener).toHaveBeenCalled();
     });
 
-    it('storage listener 收到非 accountEmail 變更應忽略', async () => {
-      isAccountFeatureEnabled.mockReturnValue(true);
-      isAccountLoggedIn.mockResolvedValue(false);
-      startAccountLogin.mockResolvedValue({ success: true });
-
-      let addedListener = null;
-      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
-        addedListener = listener;
-      });
-
-      loadEntryScript();
-
-      const loginBtn = root.querySelector('[data-action="login-account"]');
-      loginBtn.click();
-
-      await new Promise(process.nextTick);
-
+    it.each([
+      ['非 accountEmail 變更', { otherKey: { newValue: 'value' } }, 'local'],
+      ['sync 區域變更', { accountEmail: { newValue: 'user@example.com' } }, 'sync'],
+    ])('storage listener 收到%s應忽略', async (_label, changes, areaName) => {
+      const { addedListener } = await startAccountLoginAndCaptureListener();
       nextStep.mockClear();
 
-      // 傳送不相關的 storage 變更
-      await addedListener({ otherKey: { newValue: 'value' } }, 'local');
-
-      expect(nextStep).not.toHaveBeenCalled();
-      expect(globalThis.chrome.storage.onChanged.removeListener).not.toHaveBeenCalled();
-    });
-
-    it('storage listener 收到 sync 區域變更應忽略', async () => {
-      isAccountFeatureEnabled.mockReturnValue(true);
-      isAccountLoggedIn.mockResolvedValue(false);
-      startAccountLogin.mockResolvedValue({ success: true });
-
-      let addedListener = null;
-      globalThis.chrome.storage.onChanged.addListener.mockImplementation(listener => {
-        addedListener = listener;
-      });
-
-      loadEntryScript();
-
-      const loginBtn = root.querySelector('[data-action="login-account"]');
-      loginBtn.click();
-
-      await new Promise(process.nextTick);
-
-      nextStep.mockClear();
-
-      // 傳送 sync 區域變更
-      await addedListener({ accountEmail: { newValue: 'user@example.com' } }, 'sync');
+      await addedListener(changes, areaName);
 
       expect(nextStep).not.toHaveBeenCalled();
       expect(globalThis.chrome.storage.onChanged.removeListener).not.toHaveBeenCalled();
@@ -397,65 +392,30 @@ describe('onboarding entry script (onboarding.js)', () => {
   });
 
   describe('formatError 函數行為', () => {
-    it('formatError 應處理字串類型錯誤', async () => {
-      runNotionOAuthFlow.mockRejectedValue('string_error');
+    it.each([
+      ['字串類型錯誤', 'string_error', 'string_error'],
+      ['null/undefined 錯誤', null, '未知錯誤'],
+      ['非 Error 物件', 12_345, '未知錯誤'],
+    ])('formatError 應處理%s', async (_label, thrownError, expectedMessage) => {
+      const errorEl = await showConnectNotionError(thrownError);
 
-      loadEntryScript();
-
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
-      connectBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="connect-notion"]');
-      expect(errorEl.textContent).toContain('string_error');
-    });
-
-    it('formatError 應處理 null/undefined 錯誤', async () => {
-      runNotionOAuthFlow.mockRejectedValue(null);
-
-      loadEntryScript();
-
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
-      connectBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="connect-notion"]');
-      expect(errorEl.textContent).toContain('未知錯誤');
-    });
-
-    it('formatError 應處理非 Error 物件', async () => {
-      runNotionOAuthFlow.mockRejectedValue(12_345);
-
-      loadEntryScript();
-
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
-      connectBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="connect-notion"]');
-      expect(errorEl.textContent).toContain('未知錯誤');
+      expect(errorEl.textContent).toContain(expectedMessage);
     });
   });
 
   describe('防禦性檢查', () => {
     it('setError 找不到 error 元素時應不拋錯', async () => {
       // 移除 error 元素
-      const errorEl = root.querySelector('[data-error="connect-notion"]');
+      const errorEl = getErrorElement('connect-notion');
       errorEl.remove();
 
       runNotionOAuthFlow.mockRejectedValue(new Error('test_error'));
 
       loadEntryScript();
 
-      const connectBtn = root.querySelector('[data-action="connect-notion"]');
-
       // 應該不拋錯
       await expect(async () => {
-        connectBtn.click();
-        await new Promise(process.nextTick);
+        await clickActionAndFlush('connect-notion');
       }).not.toThrow();
     });
 
@@ -469,12 +429,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-
       // 應該不拋錯
       await expect(async () => {
-        retryBtn.click();
-        await new Promise(process.nextTick);
+        await clickActionAndFlush('retry-databases');
       }).not.toThrow();
     });
 
@@ -485,7 +442,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       confirmBtn.disabled = false;
       confirmBtn.click();
 
-      await new Promise(process.nextTick);
+      await flushPendingPromises();
 
       // selectDataSource 不應被調用
       expect(selectDataSource).not.toHaveBeenCalled();
@@ -511,10 +468,7 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const nextBtn = root.querySelector('[data-action="next"]');
-      nextBtn.click();
-
-      await new Promise(process.nextTick);
+      await clickActionAndFlush('next');
 
       expect(isNotionConnected).toHaveBeenCalled();
       expect(nextStep).toHaveBeenCalledWith(root);
@@ -525,12 +479,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const nextBtn = root.querySelector('[data-action="next"]');
-
       // 應該不拋錯
       await expect(async () => {
-        nextBtn.click();
-        await new Promise(process.nextTick);
+        await clickActionAndFlush('next');
       }).not.toThrow();
     });
 
@@ -540,11 +491,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const nextBtn = root.querySelector('[data-action="next"]');
       nextStep.mockReturnValue(3);
-      nextBtn.click();
 
-      await new Promise(process.nextTick);
+      await clickActionAndFlush('next');
 
       const confirmBtn = root.querySelector('[data-step3-confirm]');
       expect(confirmBtn.hidden).toBe(true);
@@ -556,11 +505,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const nextBtn = root.querySelector('[data-action="next"]');
       nextStep.mockReturnValue(3);
-      nextBtn.click();
 
-      await new Promise(process.nextTick);
+      await clickActionAndFlush('next');
 
       const confirmBtn = root.querySelector('[data-step3-confirm]');
       expect(confirmBtn.hidden).toBe(true);
@@ -572,26 +519,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       // 模擬從 Step 3 進入 Step 4
       nextStep.mockReturnValueOnce(4).mockReturnValueOnce(5);
 
-      loadEntryScript();
-
-      // 模擬完成 Step 3 (選擇資料庫)
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
-      selectDataSource.mockResolvedValue(undefined);
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const listEl = root.querySelector('[data-database-list]');
-      const firstItem = listEl.children[0];
-      firstItem.click();
-
-      const confirmBtn = root.querySelector('[data-step3-confirm]');
-      confirmBtn.click();
-
-      await new Promise(process.nextTick);
+      await completeFirstDatabaseSelection();
 
       expect(isAccountFeatureEnabled).toHaveBeenCalled();
       expect(nextStep).toHaveBeenCalledTimes(2); // Step 3->4, Step 4->5
@@ -604,26 +532,7 @@ describe('onboarding entry script (onboarding.js)', () => {
       // 模擬從 Step 3 進入 Step 4
       nextStep.mockReturnValueOnce(4).mockReturnValueOnce(5);
 
-      loadEntryScript();
-
-      // 模擬完成 Step 3 (選擇資料庫)
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
-      selectDataSource.mockResolvedValue(undefined);
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const listEl = root.querySelector('[data-database-list]');
-      const firstItem = listEl.children[0];
-      firstItem.click();
-
-      const confirmBtn = root.querySelector('[data-step3-confirm]');
-      confirmBtn.click();
-
-      await new Promise(process.nextTick);
+      await completeFirstDatabaseSelection();
 
       expect(isAccountLoggedIn).toHaveBeenCalled();
       expect(nextStep).toHaveBeenCalledTimes(2); // Step 3->4, Step 4->5
@@ -636,12 +545,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const nextBtn = root.querySelector('[data-action="next"]');
-
       // 應該不拋錯
       await expect(async () => {
-        nextBtn.click();
-        await new Promise(process.nextTick);
+        await clickActionAndFlush('next');
       }).not.toThrow();
     });
 
@@ -652,12 +558,9 @@ describe('onboarding entry script (onboarding.js)', () => {
 
       loadEntryScript();
 
-      const skipBtn = root.querySelector('[data-action="skip"]');
-
       // 應該不拋錯
       await expect(async () => {
-        skipBtn.click();
-        await new Promise(process.nextTick);
+        await clickActionAndFlush('skip');
       }).not.toThrow();
 
       expect(markCompleted).toHaveBeenCalled();
@@ -666,25 +569,13 @@ describe('onboarding entry script (onboarding.js)', () => {
 
   describe('資料庫選取與切換', () => {
     it('選取第二個資料庫時應移除第一個的 selected 狀態', async () => {
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([
+      const { listEl, firstItem } = await loadDatabasesAndSelectFirst([
         { id: 'db-1', title: 'DB One' },
         { id: 'db-2', title: 'DB Two' },
       ]);
 
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const listEl = root.querySelector('[data-database-list]');
-      const firstItem = listEl.children[0];
       const secondItem = listEl.children[1];
 
-      // 選取第一個
-      firstItem.click();
       expect(firstItem.classList.contains('selected')).toBe(true);
       expect(firstItem.getAttribute('aria-checked')).toBe('true');
 
@@ -697,32 +588,19 @@ describe('onboarding entry script (onboarding.js)', () => {
     });
 
     it('selectDataSource 失敗時應顯示錯誤並保留按鈕狀態', async () => {
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([{ id: 'db-1', title: 'DB One' }]);
-
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const listEl = root.querySelector('[data-database-list]');
-      const firstItem = listEl.children[0];
-      firstItem.click();
+      const { confirmBtn } = await loadDatabasesAndSelectFirst([{ id: 'db-1', title: 'DB One' }]);
 
       selectDataSource.mockRejectedValue(new Error('storage_error'));
 
-      const confirmBtn = root.querySelector('[data-step3-confirm]');
       confirmBtn.click();
 
-      await new Promise(process.nextTick);
+      await flushPendingPromises();
 
-      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      const errorEl = getErrorElement('fetch-databases');
       expect(errorEl.hidden).toBe(false);
       expect(errorEl.textContent).toContain('storage_error');
 
-      const errorState = root.querySelector('[data-step3-state="error"]');
+      const errorState = getStep3State('error');
       expect(errorState.hidden).toBe(false);
     });
   });
@@ -733,60 +611,36 @@ describe('onboarding entry script (onboarding.js)', () => {
         callback({ success: true, data: [] });
       });
 
-      isNotionConnected.mockResolvedValue(true);
-      fetchNotionDatabases.mockResolvedValue([]);
-
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
+      await loadDatabasesByRetry([]);
 
       // 成功載入（空列表）
-      const emptyState = root.querySelector('[data-step3-state="empty"]');
+      const emptyState = getStep3State('empty');
       expect(emptyState.hidden).toBe(false);
     });
 
-    it('sendMessage 觸發 chrome.runtime.lastError 應拋出錯誤', async () => {
-      globalThis.chrome.runtime.sendMessage.mockImplementation((msg, callback) => {
-        globalThis.chrome.runtime.lastError = { message: 'runtime_error' };
-        callback();
-        delete globalThis.chrome.runtime.lastError;
-      });
-
-      fetchNotionDatabases.mockImplementation(async ({ sendMessage }) => {
-        await sendMessage({ action: 'test' });
-      });
-
-      loadEntryScript();
-
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="fetch-databases"]');
-      expect(errorEl.hidden).toBe(false);
-    });
-
-    it('sendMessage 同步拋出錯誤應被捕獲', async () => {
-      globalThis.chrome.runtime.sendMessage.mockImplementation(() => {
-        throw new Error('sync_error');
-      });
-
-      fetchNotionDatabases.mockImplementation(async ({ sendMessage }) => {
-        await sendMessage({ action: 'test' });
-      });
+    it.each([
+      [
+        '觸發 chrome.runtime.lastError 應拋出錯誤',
+        (_msg, callback) => {
+          globalThis.chrome.runtime.lastError = { message: 'runtime_error' };
+          callback();
+          delete globalThis.chrome.runtime.lastError;
+        },
+      ],
+      [
+        '同步拋出錯誤應被捕獲',
+        () => {
+          throw new Error('sync_error');
+        },
+      ],
+    ])('sendMessage %s', async (_label, sendMessageImplementation) => {
+      globalThis.chrome.runtime.sendMessage.mockImplementation(sendMessageImplementation);
+      mockFetchThroughRuntimeSendMessage();
 
       loadEntryScript();
+      await clickActionAndFlush('retry-databases');
 
-      const retryBtn = root.querySelector('[data-action="retry-databases"]');
-      retryBtn.click();
-
-      await new Promise(process.nextTick);
-
-      const errorEl = root.querySelector('[data-error="fetch-databases"]');
+      const errorEl = getErrorElement('fetch-databases');
       expect(errorEl.hidden).toBe(false);
     });
   });


### PR DESCRIPTION
### 摘要
重構 onboarding 邏輯，提升可讀性與錯誤處理的一致性。

### 變更內容
- 新增多個輔助函數以簡化錯誤訊息格式化及登入狀態檢查邏輯。
- 將登入按鈕的狀態恢復邏輯提取至單獨函數。
- 在多處使用 `formatError` 函數來統一錯誤訊息的處理。
- 重構事件綁定邏輯為 `handleOnboardingClick` 函數，簡化事件處理流程。
- 新增單元測試以確保 onboarding 邏輯的正確性與穩定性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

