### PR TITLE
refactor: simplify MigrationTool logic and reduce duplication

### DIFF
--- a/pages/options/MigrationScanner.js
+++ b/pages/options/MigrationScanner.js
@@ -237,6 +237,11 @@ export class MigrationScanner {
    * @returns {string}
    */
   static truncateUrl(url, maxLength = 50) {
+    // 防禦性空值處理
+    if (!url || typeof url !== 'string') {
+      return '';
+    }
+
     if (url.length <= maxLength) {
       return url;
     }

--- a/pages/options/MigrationTool.js
+++ b/pages/options/MigrationTool.js
@@ -647,6 +647,7 @@ export class MigrationTool {
     const link = document.createElement('a');
     link.href = url;
     link.target = '_blank';
+    link.rel = 'noopener noreferrer';
     link.className = 'open-page-link';
     link.textContent = '打開頁面';
     return link;

--- a/pages/options/MigrationTool.js
+++ b/pages/options/MigrationTool.js
@@ -12,6 +12,26 @@ import { createSafeIcon } from '../../scripts/utils/securityUtils.js';
 import { sanitizeApiError } from '../../scripts/utils/ApiErrorSanitizer.js';
 import { MigrationScanner } from './MigrationScanner.js';
 
+const BATCH_OPERATION_TYPES = Object.freeze({
+  MIGRATION: 'migration',
+  DELETION: 'deletion',
+});
+
+const BATCH_OPERATION_CONFIGS = Object.freeze({
+  migration: Object.freeze({
+    type: BATCH_OPERATION_TYPES.MIGRATION,
+    action: RUNTIME_ACTIONS.MIGRATION_BATCH,
+    progressText: '處理中...',
+    errorContext: 'batch_migration',
+  }),
+  deletion: Object.freeze({
+    type: BATCH_OPERATION_TYPES.DELETION,
+    action: RUNTIME_ACTIONS.MIGRATION_BATCH_DELETE,
+    progressText: '刪除中...',
+    errorContext: 'batch_deletion',
+  }),
+});
+
 /**
  * 遷移工具類別
  * 負責協調舊版數據的掃描與遷移過程，並管理相關 UI
@@ -389,70 +409,93 @@ export class MigrationTool {
 
   /**
    * 執行選中項目的遷移（使用批量 API）
+   *
+   * @returns {Promise<void>}
    */
-  async performSelectedMigration() {
+  performSelectedMigration() {
+    return this.runSelectedBatchOperation(BATCH_OPERATION_CONFIGS.migration);
+  }
+
+  /**
+   * 執行選中項目的刪除（使用批量 API）
+   *
+   * @returns {Promise<void>}
+   */
+  performSelectedDeletion() {
+    if (!this.confirmSelectedDeletion()) {
+      return Promise.resolve();
+    }
+    return this.runSelectedBatchOperation(BATCH_OPERATION_CONFIGS.deletion);
+  }
+
+  /**
+   * 確認使用者是否要刪除目前選中的舊版標註資料
+   *
+   * @returns {boolean}
+   */
+  confirmSelectedDeletion() {
+    if (this.selectedUrls.size === 0) {
+      return false;
+    }
+    return globalThis.confirm(
+      `確定要刪除 ${this.selectedUrls.size} 個頁面的舊版標註數據嗎？\n此操作無法還原！`
+    );
+  }
+
+  /**
+   * 執行批量 migration/delete 共用流程
+   *
+   * @param {{type: string, action: string, progressText: string, errorContext: string}} operation
+   * @returns {Promise<void>}
+   */
+  async runSelectedBatchOperation(operation) {
     if (this.selectedUrls.size === 0) {
       return;
     }
 
     const urls = this.getSelectedUrls();
-
-    this.showBatchProgress('處理中...');
+    this.showBatchProgress(operation.progressText);
 
     try {
       const response = await chrome.runtime.sendMessage({
-        action: RUNTIME_ACTIONS.MIGRATION_BATCH,
+        action: operation.action,
         urls,
       });
 
-      this.completeBatchProgress('100%');
-      this.handleBatchMigrationResponse(response);
+      this.completeBatchProgress();
+      this.handleBatchOperationResponse(operation.type, response, urls);
     } catch (error) {
-      const safeMessage = sanitizeApiError(error, 'batch_migration');
-      const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
-      this.showErrorResult(errorMsg);
+      this.showBatchOperationError(error, operation.errorContext);
     } finally {
       this.finishBatchOperation();
     }
   }
 
   /**
-   * 執行選中項目的刪除（使用批量 API）
+   * 依批量操作類型分派 API 回應處理
+   *
+   * @param {string} operationType 批量操作類型
+   * @param {object} response API 回應對象
+   * @param {string[]} urls 操作 URL 陣列
    */
-  async performSelectedDeletion() {
-    if (this.selectedUrls.size === 0) {
+  handleBatchOperationResponse(operationType, response, urls) {
+    if (operationType === BATCH_OPERATION_TYPES.MIGRATION) {
+      this.handleBatchMigrationResponse(response);
       return;
     }
+    this.handleBatchDeletionResponse(response, urls);
+  }
 
-    // 確認刪除（使用原生對話框確保用戶明確確認）
-
-    const confirmed = globalThis.confirm(
-      `確定要刪除 ${this.selectedUrls.size} 個頁面的舊版標註數據嗎？\n此操作無法還原！`
-    );
-
-    if (!confirmed) {
-      return;
-    }
-
-    const urls = this.getSelectedUrls();
-
-    this.showBatchProgress('刪除中...');
-
-    try {
-      const response = await chrome.runtime.sendMessage({
-        action: RUNTIME_ACTIONS.MIGRATION_BATCH_DELETE,
-        urls,
-      });
-
-      this.completeBatchProgress('100%');
-      this.handleBatchDeletionResponse(response, urls);
-    } catch (error) {
-      const safeMessage = sanitizeApiError(error, 'batch_deletion');
-      const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
-      this.showErrorResult(errorMsg);
-    } finally {
-      this.finishBatchOperation();
-    }
+  /**
+   * 顯示批量操作錯誤
+   *
+   * @param {unknown} error 原始錯誤
+   * @param {string} errorContext 錯誤清理情境
+   */
+  showBatchOperationError(error, errorContext) {
+    const safeMessage = sanitizeApiError(error, errorContext);
+    const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
+    this.showErrorResult(errorMsg);
   }
 
   /**

--- a/pages/options/MigrationTool.js
+++ b/pages/options/MigrationTool.js
@@ -395,22 +395,9 @@ export class MigrationTool {
       return;
     }
 
-    const urls = Array.from(this.selectedUrls);
-    const { progressContainer, progressBar, progressText } = this.elements;
+    const urls = this.getSelectedUrls();
 
-    // 禁用按鈕
-    this.setButtonsDisabled(true);
-
-    // 顯示進度（批量操作很快，顯示不確定進度）
-    if (progressContainer) {
-      progressContainer.style.display = 'block';
-    }
-    if (progressBar) {
-      progressBar.style.width = '50%';
-    }
-    if (progressText) {
-      progressText.textContent = '處理中...';
-    }
+    this.showBatchProgress('處理中...');
 
     try {
       const response = await chrome.runtime.sendMessage({
@@ -418,37 +405,14 @@ export class MigrationTool {
         urls,
       });
 
-      // 完成進度
-      if (progressBar) {
-        progressBar.style.width = '100%';
-      }
-      if (progressText) {
-        progressText.textContent = '100%';
-      }
-
-      if (response?.success) {
-        this.showBatchMigrationResult(response.results);
-        this.selectedUrls.clear();
-        // 不自動重新掃描，讓用戶能看到結果連結
-        // 用戶可點擊連結打開頁面完成 rangeInfo 生成
-        // 或手動點擊掃描按鈕重新掃描
-      } else {
-        this.showErrorResult(response?.error || '批量遷移失敗');
-      }
+      this.completeBatchProgress('100%');
+      this.handleBatchMigrationResponse(response);
     } catch (error) {
       const safeMessage = sanitizeApiError(error, 'batch_migration');
       const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
       this.showErrorResult(errorMsg);
     } finally {
-      // 隱藏進度條
-      if (progressContainer) {
-        progressContainer.style.display = 'none';
-      }
-      // 根據實際選擇狀態更新按鈕（而非無條件啟用）
-      this.updateActionButtons();
-
-      // 觸發刷新儲存使用量
-      document.dispatchEvent(new CustomEvent('storageUsageUpdate'));
+      this.finishBatchOperation();
     }
   }
 
@@ -470,22 +434,9 @@ export class MigrationTool {
       return;
     }
 
-    const urls = Array.from(this.selectedUrls);
-    const { progressContainer, progressBar, progressText } = this.elements;
+    const urls = this.getSelectedUrls();
 
-    // 禁用按鈕
-    this.setButtonsDisabled(true);
-
-    // 顯示進度
-    if (progressContainer) {
-      progressContainer.style.display = 'block';
-    }
-    if (progressBar) {
-      progressBar.style.width = '50%';
-    }
-    if (progressText) {
-      progressText.textContent = '刪除中...';
-    }
+    this.showBatchProgress('刪除中...');
 
     try {
       const response = await chrome.runtime.sendMessage({
@@ -493,46 +444,237 @@ export class MigrationTool {
         urls,
       });
 
-      // 完成進度
-      if (progressBar) {
-        progressBar.style.width = '100%';
-      }
-      if (progressText) {
-        progressText.textContent = '100%';
-      }
-
-      const results = response?.results;
-      if (response?.success && results) {
-        if ((results.failed ?? 0) > 0) {
-          this.showPartialDeleteResult(
-            results.success ?? 0,
-            results.failed,
-            results.total ?? urls.length
-          );
-        } else {
-          this.showDeleteResult(results.success ?? 0);
-        }
-        this.selectedUrls.clear();
-        // 延遲後重新掃描
-        setTimeout(() => this.scanForLegacyHighlights(), 1500);
-      } else {
-        this.showErrorResult(response?.error || '批量刪除失敗');
-      }
+      this.completeBatchProgress('100%');
+      this.handleBatchDeletionResponse(response, urls);
     } catch (error) {
       const safeMessage = sanitizeApiError(error, 'batch_deletion');
       const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
       this.showErrorResult(errorMsg);
     } finally {
-      // 隱藏進度條
-      if (progressContainer) {
-        progressContainer.style.display = 'none';
-      }
-      // 根據實際選擇狀態更新按鈕（而非無條件啟用）
-      this.updateActionButtons();
-
-      // 觸發刷新儲存使用量
-      document.dispatchEvent(new CustomEvent('storageUsageUpdate'));
+      this.finishBatchOperation();
     }
+  }
+
+  /**
+   * 顯示批量操作進度，並禁用相關按鈕
+   *
+   * @param {string} text 進度顯示文字
+   */
+  showBatchProgress(text) {
+    const { progressContainer, progressBar, progressText } = this.elements;
+    this.setButtonsDisabled(true);
+    if (progressContainer) {
+      progressContainer.style.display = 'block';
+    }
+    if (progressBar) {
+      progressBar.style.width = '50%';
+    }
+    if (progressText) {
+      progressText.textContent = text;
+    }
+  }
+
+  /**
+   * 將進度更新為 100%
+   *
+   * @param {string} percentText 顯示的百分比文字
+   */
+  completeBatchProgress(percentText = '100%') {
+    const { progressBar, progressText } = this.elements;
+    if (progressBar) {
+      progressBar.style.width = '100%';
+    }
+    if (progressText) {
+      progressText.textContent = percentText;
+    }
+  }
+
+  /**
+   * 結束批量操作，隱藏進度條、更新按鈕狀態並觸發儲存更新事件
+   */
+  finishBatchOperation() {
+    const { progressContainer } = this.elements;
+    if (progressContainer) {
+      progressContainer.style.display = 'none';
+    }
+    this.updateActionButtons();
+    document.dispatchEvent(new CustomEvent('storageUsageUpdate'));
+  }
+
+  /**
+   * 取得已選取的 URL 陣列
+   *
+   * @returns {string[]}
+   */
+  getSelectedUrls() {
+    return Array.from(this.selectedUrls);
+  }
+
+  /**
+   * 處理批量遷移的 API 回應
+   *
+   * @param {object} response API 回應對象
+   */
+  handleBatchMigrationResponse(response) {
+    if (response?.success) {
+      this.showBatchMigrationResult(response.results);
+      this.selectedUrls.clear();
+    } else {
+      this.showErrorResult(response?.error || '批量遷移失敗');
+    }
+  }
+
+  /**
+   * 處理批量刪除的 API 回應
+   *
+   * @param {object} response API 回應對象
+   * @param {string[]} urls 被刪除的 URL 陣列
+   */
+  handleBatchDeletionResponse(response, urls) {
+    const results = response?.results;
+    if (response?.success && results) {
+      this.showDeletionResponseResult(results, urls.length);
+      this.selectedUrls.clear();
+      this.scheduleLegacyHighlightsRescan();
+    } else {
+      this.showErrorResult(response?.error || '批量刪除失敗');
+    }
+  }
+
+  /**
+   * 顯示批量刪除的詳細結果
+   *
+   * @param {object} results 刪除結果統計對象
+   * @param {number} fallbackTotal 總數 fallback 值
+   */
+  showDeletionResponseResult(results, fallbackTotal) {
+    if ((results.failed ?? 0) > 0) {
+      this.showPartialDeleteResult(
+        results.success ?? 0,
+        results.failed,
+        results.total ?? fallbackTotal
+      );
+    } else {
+      this.showDeleteResult(results.success ?? 0);
+    }
+  }
+
+  /**
+   * 安排在延遲後重新掃描舊版標註
+   */
+  scheduleLegacyHighlightsRescan() {
+    setTimeout(() => this.scanForLegacyHighlights(), 1500);
+  }
+
+  /**
+   * 建立帶有圖示和計數 Badge 的 URL Label 元素
+   *
+   * @param {string} url URL 網址
+   * @param {string} icon 圖示 HTML
+   * @param {string} badgeText Badge 顯示文字
+   * @param {string} extraBadgeClass 額外的 Badge CSS class
+   * @returns {HTMLSpanElement}
+   */
+  createResultUrlLabel(url, icon, badgeText, extraBadgeClass = '') {
+    const spanUrl = document.createElement('span');
+    spanUrl.className = COMMON_CSS_CLASSES.RESULT_URL;
+    spanUrl.title = url;
+
+    const iconSpan = createSafeIcon(icon);
+    spanUrl.append(iconSpan);
+    spanUrl.append(document.createTextNode(` ${MigrationScanner.truncateUrl(url, 60)}`));
+
+    const badge = document.createElement('span');
+    badge.className = extraBadgeClass
+      ? `${COMMON_CSS_CLASSES.COUNT_BADGE} ${extraBadgeClass}`
+      : COMMON_CSS_CLASSES.COUNT_BADGE;
+    badge.textContent = badgeText;
+    spanUrl.append(badge);
+
+    return spanUrl;
+  }
+
+  /**
+   * 建立在新分頁打開網頁的連結元素
+   *
+   * @param {string} url URL 網址
+   * @returns {HTMLAnchorElement}
+   */
+  createOpenPageLink(url) {
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.className = 'open-page-link';
+    link.textContent = '打開頁面';
+    return link;
+  }
+
+  /**
+   * 建立批量遷移結果的單個列表項目元素
+   *
+   * @param {object} detail 遷移結果詳意
+   * @returns {HTMLDivElement}
+   */
+  createBatchMigrationResultItem(detail) {
+    const itemDiv = document.createElement('div');
+    itemDiv.className = COMMON_CSS_CLASSES.RESULT_ITEM;
+
+    const url = detail.url || '';
+    const pendingCount = detail.pending ?? 0;
+    const pendingText = pendingCount > 0 ? `，${pendingCount} 待完成` : '';
+    const badgeText = `${detail.count ?? 0} 個標註${pendingText}`;
+
+    const spanUrl = this.createResultUrlLabel(url, UI_ICONS.CHECK, badgeText);
+    itemDiv.append(spanUrl);
+
+    const link = this.createOpenPageLink(url);
+    itemDiv.append(link);
+
+    return itemDiv;
+  }
+
+  /**
+   * 建立待完成遷移的單個列表項目元素
+   *
+   * @param {object} item 待完成項目資料
+   * @returns {HTMLDivElement}
+   */
+  createPendingMigrationItem(item) {
+    const itemDiv = document.createElement('div');
+    itemDiv.className = COMMON_CSS_CLASSES.RESULT_ITEM;
+
+    const badgeText = `${item.pendingCount} / ${item.totalCount} 待完成`;
+    const spanUrl = this.createResultUrlLabel(item.url, UI_ICONS.STAR, badgeText);
+    itemDiv.append(spanUrl);
+
+    const link = this.createOpenPageLink(item.url);
+    itemDiv.append(link);
+
+    return itemDiv;
+  }
+
+  /**
+   * 建立失敗遷移的單個列表項目元素
+   *
+   * @param {object} item 失敗項目資料
+   * @returns {HTMLDivElement}
+   */
+  createFailedMigrationItem(item) {
+    const itemDiv = document.createElement('div');
+    itemDiv.className = `${COMMON_CSS_CLASSES.RESULT_ITEM} failed-item`;
+
+    const badgeText = `${item.failedCount} 個無法恢復`;
+    const spanUrl = this.createResultUrlLabel(item.url, UI_ICONS.WARNING, badgeText, 'failed');
+    itemDiv.append(spanUrl);
+
+    const button = document.createElement('button');
+    button.className = 'btn-danger btn-small delete-failed-btn';
+    button.dataset.url = item.url;
+    button.textContent = '刪除';
+    button.addEventListener('click', () => this.deleteFailedHighlights(item.url));
+    itemDiv.append(button);
+
+    return itemDiv;
   }
 
   /**
@@ -694,34 +836,7 @@ export class MigrationTool {
       listDiv.className = 'result-list';
 
       successItems.forEach(detail => {
-        const itemDiv = document.createElement('div');
-        itemDiv.className = COMMON_CSS_CLASSES.RESULT_ITEM;
-
-        const spanUrl = document.createElement('span');
-        spanUrl.className = COMMON_CSS_CLASSES.RESULT_URL;
-        const urlTitle = detail.url || '';
-        spanUrl.title = urlTitle;
-
-        const checkIcon = createSafeIcon(UI_ICONS.CHECK);
-        spanUrl.append(checkIcon);
-        spanUrl.append(document.createTextNode(` ${MigrationScanner.truncateUrl(urlTitle, 60)}`));
-
-        const badge = document.createElement('span');
-        badge.className = COMMON_CSS_CLASSES.COUNT_BADGE;
-        const pendingCount = detail.pending ?? 0;
-        const pendingText = pendingCount > 0 ? `，${pendingCount} 待完成` : '';
-        badge.textContent = `${detail.count ?? 0} 個標註${pendingText}`;
-        spanUrl.append(badge);
-
-        itemDiv.append(spanUrl);
-
-        const link = document.createElement('a');
-        link.href = urlTitle;
-        link.target = '_blank';
-        link.className = 'open-page-link';
-        link.textContent = '打開頁面';
-        itemDiv.append(link);
-
+        const itemDiv = this.createBatchMigrationResultItem(detail);
         listDiv.append(itemDiv);
       });
       box.append(listDiv);
@@ -883,31 +998,7 @@ export class MigrationTool {
     const fragment = document.createDocumentFragment();
 
     items.forEach(item => {
-      const itemDiv = document.createElement('div');
-      itemDiv.className = COMMON_CSS_CLASSES.RESULT_ITEM;
-
-      const spanUrl = document.createElement('span');
-      spanUrl.className = COMMON_CSS_CLASSES.RESULT_URL;
-      spanUrl.title = item.url;
-
-      const iconSpan = createSafeIcon(UI_ICONS.STAR);
-      spanUrl.append(iconSpan);
-      spanUrl.append(document.createTextNode(` ${MigrationScanner.truncateUrl(item.url, 60)}`));
-
-      const badge = document.createElement('span');
-      badge.className = COMMON_CSS_CLASSES.COUNT_BADGE;
-      badge.textContent = `${item.pendingCount} / ${item.totalCount} 待完成`;
-      spanUrl.append(badge);
-
-      itemDiv.append(spanUrl);
-
-      const link = document.createElement('a');
-      link.href = item.url;
-      link.target = '_blank';
-      link.className = 'open-page-link';
-      link.textContent = '打開頁面';
-      itemDiv.append(link);
-
+      const itemDiv = this.createPendingMigrationItem(item);
       fragment.append(itemDiv);
     });
 
@@ -939,33 +1030,7 @@ export class MigrationTool {
     const fragment = document.createDocumentFragment();
 
     items.forEach(item => {
-      const itemDiv = document.createElement('div');
-      itemDiv.className = `${COMMON_CSS_CLASSES.RESULT_ITEM} failed-item`;
-
-      const spanUrl = document.createElement('span');
-      spanUrl.className = COMMON_CSS_CLASSES.RESULT_URL;
-      spanUrl.title = item.url;
-
-      const iconSpan = createSafeIcon(UI_ICONS.WARNING);
-      spanUrl.append(iconSpan);
-      spanUrl.append(document.createTextNode(` ${MigrationScanner.truncateUrl(item.url, 60)}`));
-
-      const badge = document.createElement('span');
-      badge.className = `${COMMON_CSS_CLASSES.COUNT_BADGE} failed`;
-      badge.textContent = `${item.failedCount} 個無法恢復`;
-      spanUrl.append(badge);
-
-      itemDiv.append(spanUrl);
-
-      const button = document.createElement('button');
-      button.className = 'btn-danger btn-small delete-failed-btn';
-      button.dataset.url = item.url;
-      button.textContent = '刪除';
-      // 直接綁定事件
-      button.addEventListener('click', () => this.deleteFailedHighlights(item.url));
-
-      itemDiv.append(button);
-
+      const itemDiv = this.createFailedMigrationItem(item);
       fragment.append(itemDiv);
     });
 

--- a/tests/unit/options/MigrationScanner.test.js
+++ b/tests/unit/options/MigrationScanner.test.js
@@ -237,5 +237,20 @@ describe('MigrationScanner', () => {
       const result = MigrationScanner.truncateUrl(shortUrl, 50);
       expect(result).toBe(shortUrl);
     });
+
+    it('should handle null URL', () => {
+      const result = MigrationScanner.truncateUrl(null, 30);
+      expect(result).toBe('');
+    });
+
+    it('should handle undefined URL', () => {
+      const result = MigrationScanner.truncateUrl(undefined, 30);
+      expect(result).toBe('');
+    });
+
+    it('should handle non-string URL', () => {
+      const result = MigrationScanner.truncateUrl(12_345, 30);
+      expect(result).toBe('');
+    });
   });
 });

--- a/tests/unit/options/MigrationTool.test.js
+++ b/tests/unit/options/MigrationTool.test.js
@@ -436,7 +436,11 @@ describe('MigrationTool Extended', () => {
       });
       expect(migrationTool.selectedUrls.size).toBe(0);
       expect(dispatchSpy).toHaveBeenCalledWith(expect.any(CustomEvent));
-      expect(dispatchSpy.mock.calls[0][0].type).toBe('storageUsageUpdate');
+      // 驗證任一 dispatch 包含正確的 event type，而非假設順序
+      const storageUpdateCalls = dispatchSpy.mock.calls.filter(
+        call => call[0]?.type === 'storageUsageUpdate'
+      );
+      expect(storageUpdateCalls.length).toBeGreaterThan(0);
 
       dispatchSpy.mockRestore();
     });
@@ -464,7 +468,10 @@ describe('MigrationTool Extended', () => {
       await migrationTool.performSelectedMigration();
 
       const migrationResult = document.querySelector('#migration-result');
-      expect(migrationResult.textContent).toBeTruthy();
+      // 驗證顯示完整的使用者友善錯誤訊息（經 sanitizeApiError + ErrorHandler.formatUserMessage 處理）
+      // 'Network error' → sanitizeApiError → 'NETWORK_ERROR' → formatUserMessage → 實際中文訊息
+      // showErrorResult 會在前面加上 " 操作失敗"（含前導空格來自 icon）
+      expect(migrationResult.textContent).toBe(' 操作失敗網路連線異常，請檢查網路後重試');
       expect(migrationTool.elements.progressContainer.style.display).toBe('none');
     });
   });

--- a/tests/unit/options/MigrationTool.test.js
+++ b/tests/unit/options/MigrationTool.test.js
@@ -395,6 +395,80 @@ describe('MigrationTool Extended', () => {
     });
   });
 
+  describe('performSelectedMigration', () => {
+    beforeEach(() => {
+      chrome.runtime.sendMessage.mockClear();
+    });
+
+    test('no selection 應不呼叫 chrome.runtime.sendMessage', async () => {
+      migrationTool.selectedUrls = new Set();
+      await migrationTool.performSelectedMigration();
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    });
+
+    test('success response 應送出正確 action 且顯示 success result，清空 selectedUrls，dispatch storageUsageUpdate', async () => {
+      jest.spyOn(migrationTool, 'showBatchMigrationResult').mockImplementation(() => {});
+      const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        results: {
+          success: 2,
+          failed: 0,
+          total: 2,
+          details: [],
+        },
+      });
+
+      migrationTool.selectedUrls = new Set(['https://example.com/one', 'https://example.com/two']);
+
+      await migrationTool.performSelectedMigration();
+
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+        action: RUNTIME_ACTIONS.MIGRATION_BATCH,
+        urls: ['https://example.com/one', 'https://example.com/two'],
+      });
+      expect(migrationTool.showBatchMigrationResult).toHaveBeenCalledWith({
+        success: 2,
+        failed: 0,
+        total: 2,
+        details: [],
+      });
+      expect(migrationTool.selectedUrls.size).toBe(0);
+      expect(dispatchSpy).toHaveBeenCalledWith(expect.any(CustomEvent));
+      expect(dispatchSpy.mock.calls[0][0].type).toBe('storageUsageUpdate');
+
+      dispatchSpy.mockRestore();
+    });
+
+    test('unsuccessful response 應顯示錯誤，且保留 selected state 以便重試', async () => {
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: false,
+        error: '測試遷移失敗',
+      });
+
+      migrationTool.selectedUrls = new Set(['https://example.com/one', 'https://example.com/two']);
+
+      await migrationTool.performSelectedMigration();
+
+      const migrationResult = document.querySelector('#migration-result');
+      expect(migrationResult.textContent).toContain('測試遷移失敗');
+      expect(migrationTool.selectedUrls.size).toBe(2);
+    });
+
+    test('thrown error 應經 sanitize/format 後顯示，並執行 cleanup', async () => {
+      chrome.runtime.sendMessage.mockRejectedValue(new Error('Network error'));
+
+      migrationTool.selectedUrls = new Set(['https://example.com/one']);
+
+      await migrationTool.performSelectedMigration();
+
+      const migrationResult = document.querySelector('#migration-result');
+      expect(migrationResult.textContent).toBeTruthy();
+      expect(migrationTool.elements.progressContainer.style.display).toBe('none');
+    });
+  });
+
   describe('truncateUrl extended (委託 MigrationScanner)', () => {
     test('應處理空 URL', () => {
       const result = MigrationScanner.truncateUrl('', 60);


### PR DESCRIPTION
### 摘要
重構 MigrationTool，簡化邏輯並減少重複代碼。

### 變更內容
- 減少 MigrationTool 中的複雜性和重複性。
- 中央化批次處理流程，提升可讀性和維護性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

