### PR TITLE
chore: clean up logger mock imports

### DIFF
--- a/tests/unit/background/handlers/logHandlers.test.js
+++ b/tests/unit/background/handlers/logHandlers.test.js
@@ -2,10 +2,12 @@
  * @jest-environment jsdom
  */
 
+import { createLoggerMock as mockCreateLoggerMock } from '../../../helpers/loggerMock.js';
+
 // Mock Logger（保留 parseArgsToContext 的真實實作，因為它是純函數）
 jest.mock('../../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
-  default: require('../../../helpers/loggerMock.js').createLoggerMock(),
+  default: mockCreateLoggerMock(),
   parseArgsToContext: args => {
     if (!Array.isArray(args) || args.length === 0) {
       return {};

--- a/tests/unit/content/extractors/NextJsDataResolver.rsc.test.js
+++ b/tests/unit/content/extractors/NextJsDataResolver.rsc.test.js
@@ -2,13 +2,14 @@
  * @jest-environment jsdom
  */
 
+import { createLoggerMock as mockCreateLoggerMock } from '../../../helpers/loggerMock.js';
 import * as NextJsDataResolver from '../../../../scripts/content/extractors/NextJsDataResolver.js';
 import { NEXTJS_CONFIG } from '../../../../scripts/config/shared/content.js';
 import Logger from '../../../../scripts/utils/Logger.js';
 
 jest.mock('../../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
-  default: require('../../../helpers/loggerMock.js').createLoggerMock(),
+  default: mockCreateLoggerMock(),
 }));
 
 describe('NextJsDataResolver getPagesRouterData logging', () => {

--- a/tests/unit/highlighter/autoInit/initializationInputs.test.js
+++ b/tests/unit/highlighter/autoInit/initializationInputs.test.js
@@ -1,14 +1,15 @@
-jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  default: require('../../../helpers/loggerMock.js').createLoggerMock(),
-  __esModule: true,
-}));
-
-const Logger = require('../../../../scripts/utils/Logger.js').default;
-const {
+import { createLoggerMock as mockCreateLoggerMock } from '../../../helpers/loggerMock.js';
+import Logger from '../../../../scripts/utils/Logger.js';
+import {
   fetchHighlighterSettings,
   fetchPageStatus,
   resolveStyleMode,
-} = require('../../../../scripts/highlighter/autoInit/initializationInputs.js');
+} from '../../../../scripts/highlighter/autoInit/initializationInputs.js';
+
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  default: mockCreateLoggerMock(),
+  __esModule: true,
+}));
 
 describe('autoInit/initializationInputs', () => {
   beforeEach(() => {

--- a/tests/unit/highlighter/autoInit/lateStableUrlRestore.test.js
+++ b/tests/unit/highlighter/autoInit/lateStableUrlRestore.test.js
@@ -1,12 +1,13 @@
+import { createLoggerMock as mockCreateLoggerMock } from '../../../helpers/loggerMock.js';
+import Logger from '../../../../scripts/utils/Logger.js';
+import {
+  createLateStableUrlRestoreController,
+} from '../../../../scripts/highlighter/autoInit/lateStableUrlRestore.js';
+
 jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  default: require('../../../helpers/loggerMock.js').createLoggerMock(),
+  default: mockCreateLoggerMock(),
   __esModule: true,
 }));
-
-const Logger = require('../../../../scripts/utils/Logger.js').default;
-const {
-  createLateStableUrlRestoreController,
-} = require('../../../../scripts/highlighter/autoInit/lateStableUrlRestore.js');
 
 const flushPromises = async () => {
   await Promise.resolve();


### PR DESCRIPTION
### 摘要
清理測試中的 logger 模擬導入，提升代碼可讀性。

### 變更內容
- 將 logger 模擬的導入方式統一為使用 `createLoggerMock` 函數。
- 移除重複的導入語句，簡化測試代碼結構。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

