### PR TITLE
chore: reduce release-please PR noise

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   validate-pr-title:
     name: Validate PR Title
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -2,8 +2,7 @@
 response_language = "zh-TW"
 ignore_pr_title = [
   "^chore: release",
-  "^chore\\([^)]*\\): release",
-  "^chore\\(main\\): release"
+  "^chore\\([^)]*\\): release"
 ]
 ignore_pr_source_branches = ["^release-please--"]
 add_repo_metadata = true

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,11 @@
 [config]
 response_language = "zh-TW"
-ignore_pr_title = ["^chore: release", "^chore\\(main\\): release"]
+ignore_pr_title = [
+  "^chore: release",
+  "^chore\\([^)]*\\): release",
+  "^chore\\(main\\): release"
+]
+ignore_pr_source_branches = ["^release-please--"]
 add_repo_metadata = true
 model="gpt-5"
 


### PR DESCRIPTION
### 摘要
此 PR 旨在減少由 `release-please` 產生的 PR 噪音。

### 變更內容
- 更新 CI 配置以跳過 `release-please` 相關的 PR 標題驗證。
- 擴展 `ignore_pr_title` 規則以涵蓋更多情況，避免不必要的 PR 噪音。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

