### PR TITLE
refactor: improve NotionService test structure and reduce duplication

### DIFF
--- a/tests/helpers/notionServiceTestHarness.js
+++ b/tests/helpers/notionServiceTestHarness.js
@@ -1,0 +1,71 @@
+/**
+ * NotionService 測試專用輔助模組 (Test Support Boundary)
+ */
+
+/**
+ * 建立 401 錯誤
+ */
+export const buildUnauthorizedError = (overrides = {}) => {
+  const err = new Error(overrides.message || 'Unauthorized');
+  err.status = 401;
+  Object.assign(err, overrides);
+  return err;
+};
+
+/**
+ * Mock 獲取 Active Token
+ */
+export const mockActiveToken = (getActiveNotionTokenMock, { token, mode }) => {
+  getActiveNotionTokenMock.mockResolvedValueOnce({ token, mode });
+};
+
+/**
+ * Mock Token 刷新
+ */
+export const mockRefreshToken = (refreshOAuthTokenMock, valueOrError) => {
+  if (valueOrError instanceof Error) {
+    refreshOAuthTokenMock.mockRejectedValueOnce(valueOrError);
+  } else {
+    refreshOAuthTokenMock.mockResolvedValueOnce(valueOrError);
+  }
+};
+
+/**
+ * 建立段落區塊
+ */
+export const paragraphBlock = id => ({ id, type: 'paragraph' });
+
+/**
+ * 建立標題區塊
+ */
+export const headingBlock = (id, level = 3, content = '') => {
+  const type = `heading_${level}`;
+  return {
+    id,
+    type,
+    [type]: { rich_text: content ? [{ text: { content } }] : [] },
+  };
+};
+
+/**
+ * 建立基礎 Page Data 參數 fixture
+ */
+export const buildPageDataOptions = (overrides = {}) => {
+  return {
+    title: 'Test Title',
+    pageUrl: 'https://example.com/test',
+    dataSourceId: 'ds-123',
+    blocks: [],
+    ...overrides,
+  };
+};
+
+/**
+ * 斷言 Logger 的 Warn 方法被呼叫且包含特定訊息
+ */
+export const expectWarnContaining = (mockLogger, messageFragment, context = null) => {
+  expect(mockLogger.warn).toHaveBeenCalledWith(
+    expect.stringContaining(messageFragment),
+    context ? expect.objectContaining(context) : expect.any(Object)
+  );
+};

--- a/tests/unit/background/services/NotionService.auth-retry.test.js
+++ b/tests/unit/background/services/NotionService.auth-retry.test.js
@@ -1,22 +1,15 @@
 // NotionService.auth-retry.test.js
 // 1. Mocks MUST be at the very top
-jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-    debug: jest.fn(),
+jest.mock('../../../../scripts/utils/Logger.js', () => {
+  const loggerMock = require('../../../helpers/loggerMock.js').createLoggerMock({
     debugEnabled: true,
-  },
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  success: jest.fn(),
-  debug: jest.fn(),
-  debugEnabled: true,
-}));
+  });
+  return {
+    __esModule: true,
+    default: loggerMock,
+    ...loggerMock,
+  };
+});
 
 jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
   getActiveNotionToken: jest.fn(),
@@ -80,12 +73,9 @@ describe('NotionService - OAuth 401 retry flow', () => {
     jest.clearAllMocks();
     getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
     refreshOAuthToken.mockResolvedValue(null);
-    mockLogger = {
-      log: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      success: jest.fn(),
-    };
+    mockLogger = require('../../../helpers/loggerMock.js').createLoggerMock({
+      debugEnabled: true,
+    });
     globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
 
     service = new NotionService({

--- a/tests/unit/background/services/NotionService.auth-retry.test.js
+++ b/tests/unit/background/services/NotionService.auth-retry.test.js
@@ -43,6 +43,32 @@ const createMockResponse = (data, ok = true, status = 200) => ({
 });
 
 const mockFetchResponse = createMockResponse({});
+const TEST_OPERATION_LABEL = 'TestOperation';
+const OAUTH_OLD_TOKEN = 'oauth_old_token';
+const OAUTH_NEW_TOKEN = 'oauth_new_token';
+
+const callTestOperation = (service, options = {}) =>
+  service._callNotionApiWithRetry(jest.fn(), {
+    label: TEST_OPERATION_LABEL,
+    ...options,
+  });
+
+const mockUnauthorizedExecution = service => {
+  const unauthorizedError = buildUnauthorizedError();
+  const executeWithRetrySpy = jest
+    .spyOn(service, '_executeWithRetry')
+    .mockRejectedValueOnce(unauthorizedError);
+
+  return { unauthorizedError, executeWithRetrySpy };
+};
+
+const mockOAuthActiveToken = (token = OAUTH_OLD_TOKEN) => {
+  mockActiveToken(getActiveNotionToken, { token, mode: 'oauth' });
+};
+
+const mockManualActiveToken = token => {
+  mockActiveToken(getActiveNotionToken, { token, mode: 'manual' });
+};
 
 describe('NotionService - OAuth 401 retry flow', () => {
   let service = null;
@@ -74,20 +100,15 @@ describe('NotionService - OAuth 401 retry flow', () => {
   });
 
   it('401 + OAuth + refresh 成功時應重試一次', async () => {
-    const unauthorizedError = buildUnauthorizedError();
     const staleClient = { id: 'stale-client' };
+    const { executeWithRetrySpy } = mockUnauthorizedExecution(service);
+    executeWithRetrySpy.mockResolvedValueOnce({ ok: true });
 
-    const executeWithRetrySpy = jest
-      .spyOn(service, '_executeWithRetry')
-      .mockRejectedValueOnce(unauthorizedError)
-      .mockResolvedValueOnce({ ok: true });
+    mockOAuthActiveToken();
+    mockRefreshToken(refreshOAuthToken, OAUTH_NEW_TOKEN);
 
-    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
-    mockRefreshToken(refreshOAuthToken, 'oauth_new_token');
-
-    const result = await service._callNotionApiWithRetry(jest.fn(), {
-      apiKey: 'oauth_old_token',
-      label: 'TestOperation',
+    const result = await callTestOperation(service, {
+      apiKey: OAUTH_OLD_TOKEN,
       client: staleClient,
     });
 
@@ -98,107 +119,79 @@ describe('NotionService - OAuth 401 retry flow', () => {
       2,
       expect.any(Function),
       expect.objectContaining({
-        apiKey: 'oauth_new_token',
+        apiKey: OAUTH_NEW_TOKEN,
       })
     );
     expect(executeWithRetrySpy.mock.calls[1][1].client).toBeUndefined();
   });
 
   it('401 + OAuth + refresh 失敗時應拋出原錯誤', async () => {
-    const unauthorizedError = buildUnauthorizedError();
-
-    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    const { unauthorizedError } = mockUnauthorizedExecution(service);
+    mockOAuthActiveToken();
     mockRefreshToken(refreshOAuthToken, null);
 
-    await expect(
-      service._callNotionApiWithRetry(jest.fn(), {
-        apiKey: 'oauth_old_token',
-        label: 'TestOperation',
-      })
-    ).rejects.toBe(unauthorizedError);
+    await expect(callTestOperation(service, { apiKey: OAUTH_OLD_TOKEN })).rejects.toBe(
+      unauthorizedError
+    );
     expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
   });
 
   it('401 + OAuth + refresh reject 時應保留原始 401 錯誤', async () => {
-    const unauthorizedError = buildUnauthorizedError();
     const refreshError = new Error('Refresh failed');
+    const { unauthorizedError } = mockUnauthorizedExecution(service);
 
-    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    mockOAuthActiveToken();
     mockRefreshToken(refreshOAuthToken, refreshError);
 
-    await expect(
-      service._callNotionApiWithRetry(jest.fn(), {
-        apiKey: 'oauth_old_token',
-        label: 'TestOperation',
-      })
-    ).rejects.toBe(unauthorizedError);
+    await expect(callTestOperation(service, { apiKey: OAUTH_OLD_TOKEN })).rejects.toBe(
+      unauthorizedError
+    );
     expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
   });
 
   it('401 + 非 OAuth 模式時不應刷新 token', async () => {
-    const unauthorizedError = buildUnauthorizedError();
+    const manualKey = 'manual_key';
+    const { unauthorizedError } = mockUnauthorizedExecution(service);
 
-    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-    mockActiveToken(getActiveNotionToken, { token: 'manual_key', mode: 'manual' });
+    mockManualActiveToken(manualKey);
 
-    await expect(
-      service._callNotionApiWithRetry(jest.fn(), {
-        apiKey: 'manual_key',
-        label: 'TestOperation',
-      })
-    ).rejects.toBe(unauthorizedError);
+    await expect(callTestOperation(service, { apiKey: manualKey })).rejects.toBe(unauthorizedError);
     expect(refreshOAuthToken).not.toHaveBeenCalled();
   });
 
   it('使用全域 token 的 OAuth 請求在 refresh 成功後會更新全域 apiKey', async () => {
-    const unauthorizedError = buildUnauthorizedError();
+    const { executeWithRetrySpy } = mockUnauthorizedExecution(service);
+    executeWithRetrySpy.mockResolvedValueOnce({ ok: true });
 
-    jest
-      .spyOn(service, '_executeWithRetry')
-      .mockRejectedValueOnce(unauthorizedError)
-      .mockResolvedValueOnce({ ok: true });
+    service.apiKey = OAUTH_OLD_TOKEN;
+    mockOAuthActiveToken();
+    mockRefreshToken(refreshOAuthToken, OAUTH_NEW_TOKEN);
 
-    service.apiKey = 'oauth_old_token';
-    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
-    mockRefreshToken(refreshOAuthToken, 'oauth_new_token');
+    await callTestOperation(service);
 
-    await service._callNotionApiWithRetry(jest.fn(), {
-      label: 'TestOperation',
-    });
-
-    expect(service.apiKey).toBe('oauth_new_token');
+    expect(service.apiKey).toBe(OAUTH_NEW_TOKEN);
   });
 
   it('使用 scoped apiKey 的 OAuth 請求在 refresh 成功後不覆寫既有全域 apiKey', async () => {
-    const unauthorizedError = buildUnauthorizedError();
+    const scopedOldToken = 'oauth_old_scoped_token';
+    const scopedNewToken = 'oauth_new_scoped_token';
+    const globalManualToken = 'global_manual_token';
+    const { executeWithRetrySpy } = mockUnauthorizedExecution(service);
+    executeWithRetrySpy.mockResolvedValueOnce({ ok: true });
 
-    jest
-      .spyOn(service, '_executeWithRetry')
-      .mockRejectedValueOnce(unauthorizedError)
-      .mockResolvedValueOnce({ ok: true });
+    service.apiKey = globalManualToken;
+    mockOAuthActiveToken(scopedOldToken);
+    mockRefreshToken(refreshOAuthToken, scopedNewToken);
 
-    service.apiKey = 'global_manual_token';
-    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_scoped_token', mode: 'oauth' });
-    mockRefreshToken(refreshOAuthToken, 'oauth_new_scoped_token');
+    await callTestOperation(service, { apiKey: scopedOldToken });
 
-    await service._callNotionApiWithRetry(jest.fn(), {
-      apiKey: 'oauth_old_scoped_token',
-      label: 'TestOperation',
-    });
-
-    expect(service.apiKey).toBe('global_manual_token');
+    expect(service.apiKey).toBe(globalManualToken);
   });
 
   it('client-only scoped request 401 時不應用全域 token 自動 refresh', async () => {
-    const unauthorizedError = buildUnauthorizedError();
+    const { unauthorizedError, executeWithRetrySpy } = mockUnauthorizedExecution(service);
 
-    const executeWithRetrySpy = jest
-      .spyOn(service, '_executeWithRetry')
-      .mockRejectedValueOnce(unauthorizedError);
-
-    mockActiveToken(getActiveNotionToken, { token: 'test-api-key', mode: 'oauth' });
+    mockOAuthActiveToken('test-api-key');
 
     await expect(
       service._callNotionApiWithRetry(jest.fn(), {

--- a/tests/unit/background/services/NotionService.auth-retry.test.js
+++ b/tests/unit/background/services/NotionService.auth-retry.test.js
@@ -125,23 +125,14 @@ describe('NotionService - OAuth 401 retry flow', () => {
     expect(executeWithRetrySpy.mock.calls[1][1].client).toBeUndefined();
   });
 
-  it('401 + OAuth + refresh 失敗時應拋出原錯誤', async () => {
-    const { unauthorizedError } = mockUnauthorizedExecution(service);
-    mockOAuthActiveToken();
-    mockRefreshToken(refreshOAuthToken, null);
-
-    await expect(callTestOperation(service, { apiKey: OAUTH_OLD_TOKEN })).rejects.toBe(
-      unauthorizedError
-    );
-    expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
-  });
-
-  it('401 + OAuth + refresh reject 時應保留原始 401 錯誤', async () => {
-    const refreshError = new Error('Refresh failed');
+  it.each([
+    ['refresh 失敗時應拋出原錯誤', null],
+    ['refresh reject 時應保留原始 401 錯誤', new Error('Refresh failed')],
+  ])('401 + OAuth + %s', async (_description, refreshResult) => {
     const { unauthorizedError } = mockUnauthorizedExecution(service);
 
     mockOAuthActiveToken();
-    mockRefreshToken(refreshOAuthToken, refreshError);
+    mockRefreshToken(refreshOAuthToken, refreshResult);
 
     await expect(callTestOperation(service, { apiKey: OAUTH_OLD_TOKEN })).rejects.toBe(
       unauthorizedError

--- a/tests/unit/background/services/NotionService.auth-retry.test.js
+++ b/tests/unit/background/services/NotionService.auth-retry.test.js
@@ -1,0 +1,213 @@
+// NotionService.auth-retry.test.js
+// 1. Mocks MUST be at the very top
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    debug: jest.fn(),
+    debugEnabled: true,
+  },
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn(),
+  debugEnabled: true,
+}));
+
+jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
+  getActiveNotionToken: jest.fn(),
+  refreshOAuthToken: jest.fn(),
+}));
+
+import { NotionService } from '../../../../scripts/background/services/NotionService.js';
+import { getActiveNotionToken, refreshOAuthToken } from '../../../../scripts/utils/notionAuth.js';
+import {
+  buildUnauthorizedError,
+  mockActiveToken,
+  mockRefreshToken,
+} from '../../../helpers/notionServiceTestHarness.js';
+
+const createMockResponse = (data, ok = true, status = 200) => ({
+  ok,
+  status,
+  headers: new Headers([['content-type', 'application/json']]),
+  clone() {
+    return this;
+  },
+  json: () => Promise.resolve(data),
+  text: () => Promise.resolve(JSON.stringify(data)),
+});
+
+const mockFetchResponse = createMockResponse({});
+
+describe('NotionService - OAuth 401 retry flow', () => {
+  let service = null;
+  let mockLogger = null;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
+    refreshOAuthToken.mockResolvedValue(null);
+    mockLogger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      success: jest.fn(),
+    };
+    globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
+
+    service = new NotionService({
+      apiKey: 'test-api-key',
+      logger: mockLogger,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('401 + OAuth + refresh 成功時應重試一次', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+    const staleClient = { id: 'stale-client' };
+
+    const executeWithRetrySpy = jest
+      .spyOn(service, '_executeWithRetry')
+      .mockRejectedValueOnce(unauthorizedError)
+      .mockResolvedValueOnce({ ok: true });
+
+    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    mockRefreshToken(refreshOAuthToken, 'oauth_new_token');
+
+    const result = await service._callNotionApiWithRetry(jest.fn(), {
+      apiKey: 'oauth_old_token',
+      label: 'TestOperation',
+      client: staleClient,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
+    expect(executeWithRetrySpy).toHaveBeenCalledTimes(2);
+    expect(executeWithRetrySpy).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      expect.objectContaining({
+        apiKey: 'oauth_new_token',
+      })
+    );
+    expect(executeWithRetrySpy.mock.calls[1][1].client).toBeUndefined();
+  });
+
+  it('401 + OAuth + refresh 失敗時應拋出原錯誤', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+
+    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
+    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    mockRefreshToken(refreshOAuthToken, null);
+
+    await expect(
+      service._callNotionApiWithRetry(jest.fn(), {
+        apiKey: 'oauth_old_token',
+        label: 'TestOperation',
+      })
+    ).rejects.toBe(unauthorizedError);
+    expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('401 + OAuth + refresh reject 時應保留原始 401 錯誤', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+    const refreshError = new Error('Refresh failed');
+
+    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
+    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    mockRefreshToken(refreshOAuthToken, refreshError);
+
+    await expect(
+      service._callNotionApiWithRetry(jest.fn(), {
+        apiKey: 'oauth_old_token',
+        label: 'TestOperation',
+      })
+    ).rejects.toBe(unauthorizedError);
+    expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('401 + 非 OAuth 模式時不應刷新 token', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+
+    jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
+    mockActiveToken(getActiveNotionToken, { token: 'manual_key', mode: 'manual' });
+
+    await expect(
+      service._callNotionApiWithRetry(jest.fn(), {
+        apiKey: 'manual_key',
+        label: 'TestOperation',
+      })
+    ).rejects.toBe(unauthorizedError);
+    expect(refreshOAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('使用全域 token 的 OAuth 請求在 refresh 成功後會更新全域 apiKey', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+
+    jest
+      .spyOn(service, '_executeWithRetry')
+      .mockRejectedValueOnce(unauthorizedError)
+      .mockResolvedValueOnce({ ok: true });
+
+    service.apiKey = 'oauth_old_token';
+    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_token', mode: 'oauth' });
+    mockRefreshToken(refreshOAuthToken, 'oauth_new_token');
+
+    await service._callNotionApiWithRetry(jest.fn(), {
+      label: 'TestOperation',
+    });
+
+    expect(service.apiKey).toBe('oauth_new_token');
+  });
+
+  it('使用 scoped apiKey 的 OAuth 請求在 refresh 成功後不覆寫既有全域 apiKey', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+
+    jest
+      .spyOn(service, '_executeWithRetry')
+      .mockRejectedValueOnce(unauthorizedError)
+      .mockResolvedValueOnce({ ok: true });
+
+    service.apiKey = 'global_manual_token';
+    mockActiveToken(getActiveNotionToken, { token: 'oauth_old_scoped_token', mode: 'oauth' });
+    mockRefreshToken(refreshOAuthToken, 'oauth_new_scoped_token');
+
+    await service._callNotionApiWithRetry(jest.fn(), {
+      apiKey: 'oauth_old_scoped_token',
+      label: 'TestOperation',
+    });
+
+    expect(service.apiKey).toBe('global_manual_token');
+  });
+
+  it('client-only scoped request 401 時不應用全域 token 自動 refresh', async () => {
+    const unauthorizedError = buildUnauthorizedError();
+
+    const executeWithRetrySpy = jest
+      .spyOn(service, '_executeWithRetry')
+      .mockRejectedValueOnce(unauthorizedError);
+
+    mockActiveToken(getActiveNotionToken, { token: 'test-api-key', mode: 'oauth' });
+
+    await expect(
+      service._callNotionApiWithRetry(jest.fn(), {
+        client: { request: jest.fn() },
+        label: 'ClientOnlyOperation',
+      })
+    ).rejects.toBe(unauthorizedError);
+
+    expect(refreshOAuthToken).not.toHaveBeenCalled();
+    expect(executeWithRetrySpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/background/services/NotionService.block-operations.test.js
+++ b/tests/unit/background/services/NotionService.block-operations.test.js
@@ -1,0 +1,445 @@
+// NotionService.block-operations.test.js
+// 1. Mocks MUST be at the very top
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    debug: jest.fn(),
+    debugEnabled: true,
+  },
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn(),
+  debugEnabled: true,
+}));
+
+jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
+  getActiveNotionToken: jest.fn(),
+  refreshOAuthToken: jest.fn(),
+}));
+
+import { NotionService } from '../../../../scripts/background/services/NotionService.js';
+import { NOTION_API } from '../../../../scripts/config/extension/notionApi.js';
+import Logger from '../../../../scripts/utils/Logger.js';
+import { getActiveNotionToken, refreshOAuthToken } from '../../../../scripts/utils/notionAuth.js';
+import notionBlockFixtures from '../../../fixtures/json/notion-api-blocks.json';
+
+const createMockResponse = (data, ok = true, status = 200) => ({
+  ok,
+  status,
+  headers: new Headers([['content-type', 'application/json']]),
+  clone() {
+    return this;
+  },
+  json: () => Promise.resolve(data),
+  text: () => Promise.resolve(JSON.stringify(data)),
+});
+
+const mockFetchResponse = createMockResponse({});
+
+const createMockNotionBlock = (id, fixtureType = 'paragraph') => ({
+  id,
+  ...structuredClone(notionBlockFixtures[fixtureType]),
+});
+
+describe('NotionService - Block Operations', () => {
+  let service = null;
+  let mockLogger = null;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
+    refreshOAuthToken.mockResolvedValue(null);
+    mockLogger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      success: jest.fn(),
+    };
+    globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
+
+    service = new NotionService({
+      apiKey: 'test-api-key',
+      logger: mockLogger,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  describe('appendBlocksInBatches', () => {
+    const TOTAL_BLOCKS = 150;
+    const BATCH_SIZE = 50;
+    const EXPECTED_ADDED = TOTAL_BLOCKS - BATCH_SIZE;
+    const TIMER_ADVANCE_MS = 10_000;
+
+    it('應該成功分批添加區塊', async () => {
+      globalThis.fetch.mockResolvedValue({
+        ...mockFetchResponse,
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
+
+      const promise = service.appendBlocksInBatches('page-123', blocks);
+
+      // 快進時間以處理批次間的延遲
+      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
+
+      const result = await promise;
+      const expectedCalls = Math.ceil(blocks.length / NOTION_API.BLOCKS_PER_BATCH);
+
+      expect(result.success).toBe(true);
+      expect(result.addedCount).toBe(TOTAL_BLOCKS);
+      expect(result.totalCount).toBe(TOTAL_BLOCKS);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(expectedCalls);
+    });
+
+    it('應該處理空區塊數組', async () => {
+      const result = await service.appendBlocksInBatches('page-123', []);
+      expect(result.success).toBe(true);
+      expect(result.addedCount).toBe(0);
+    });
+
+    it('應該處理批次失敗', async () => {
+      globalThis.fetch
+        .mockResolvedValueOnce(createMockResponse({ results: [] }))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            {
+              object: 'error',
+              status: 400,
+              code: 'validation_error',
+              message: 'Bad request',
+            },
+            false,
+            400
+          )
+        );
+
+      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
+
+      const promise = service.appendBlocksInBatches('page-123', blocks);
+      await jest.advanceTimersByTimeAsync(10_000);
+      const result = await promise;
+
+      expect(result.success).toBe(false);
+      expect(result.addedCount).toBe(100);
+      expect(result.error).toBe('VALIDATION_ERROR');
+    });
+
+    it('應該從指定索引開始處理', async () => {
+      globalThis.fetch.mockResolvedValue({
+        ...mockFetchResponse,
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
+
+      const promise = service.appendBlocksInBatches('page-123', blocks, BATCH_SIZE);
+
+      // 快進時間以處理批次間的延遲
+      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
+
+      const result = await promise;
+      const expectedCalls = Math.ceil(EXPECTED_ADDED / NOTION_API.BLOCKS_PER_BATCH);
+
+      expect(result.success).toBe(true);
+      expect(result.addedCount).toBe(EXPECTED_ADDED);
+      expect(result.totalCount).toBe(EXPECTED_ADDED);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(expectedCalls);
+
+      // 驗證已略過前 BATCH_SIZE 個項目
+      const fetchArg = globalThis.fetch.mock.calls[0][1];
+      const reqBody = JSON.parse(fetchArg.body);
+      expect(reqBody.children[0].id).toBe(BATCH_SIZE);
+    });
+
+    it.each([
+      { desc: '等於 blocks.length', getStartIndex: blocks => blocks.length },
+      { desc: '大於 blocks.length', getStartIndex: blocks => blocks.length + 1 },
+    ])('startIndex $desc 時應回傳空結果且不發送請求', async ({ getStartIndex }) => {
+      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
+
+      const promise = service.appendBlocksInBatches('page-123', blocks, getStartIndex(blocks));
+      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.addedCount).toBe(0);
+      expect(result.totalCount).toBe(0);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteAllBlocks', () => {
+    it('應該成功刪除所有區塊', async () => {
+      globalThis.fetch
+        .mockResolvedValueOnce(
+          createMockResponse({
+            results: [createMockNotionBlock('block-1'), createMockNotionBlock('block-2')],
+          })
+        )
+        .mockResolvedValue(createMockResponse({ object: 'block', id: 'deleted-block' }));
+
+      const promise = service.deleteAllBlocks('page-123');
+      await jest.advanceTimersByTimeAsync(2000);
+      const result = await promise;
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(2);
+    });
+
+    it('部分刪除失敗時應保留 best-effort 結果並回傳失敗詳情', async () => {
+      globalThis.fetch
+        .mockResolvedValueOnce(
+          createMockResponse({
+            results: [createMockNotionBlock('block-1'), createMockNotionBlock('block-2')],
+          })
+        )
+        .mockResolvedValueOnce(createMockResponse({ object: 'block', id: 'block-1' }))
+        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400));
+
+      const promise = service.deleteAllBlocks('page-123');
+      await jest.advanceTimersByTimeAsync(10_000);
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(1);
+      expect(result.failureCount).toBe(1);
+      expect(result.errors).toEqual([
+        expect.objectContaining({
+          id: 'block-2',
+          error: expect.any(String),
+        }),
+      ]);
+      expect(Logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('部分區塊刪除失敗'),
+        expect.objectContaining({
+          action: 'deleteAllBlocks',
+          failureCount: 1,
+          totalBlocks: 2,
+        })
+      );
+      const [, warnContext] = Logger.warn.mock.calls.find(([message]) =>
+        message.includes('部分區塊刪除失敗')
+      );
+      expect(warnContext).toEqual(
+        expect.objectContaining({
+          result: 'partial_failure',
+          failedBlockIds: ['block-2'],
+          sanitizedError: expect.any(Array),
+        })
+      );
+      expect(warnContext).not.toHaveProperty('errors');
+    });
+
+    it('應該處理沒有區塊的情況', async () => {
+      globalThis.fetch.mockResolvedValue({
+        ...mockFetchResponse,
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      const result = await service.deleteAllBlocks('page-123');
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(0);
+    });
+
+    it('應該處理分頁情況', async () => {
+      globalThis.fetch
+        // First page
+        .mockResolvedValueOnce(
+          createMockResponse({
+            results: [{ id: 'block-1' }],
+            has_more: true,
+            next_cursor: 'cursor-1',
+          })
+        )
+        // Second page
+        .mockResolvedValueOnce(
+          createMockResponse({
+            results: [{ id: 'block-2' }],
+            has_more: false,
+            next_cursor: null,
+          })
+        )
+        // Delete calls
+        .mockResolvedValue(createMockResponse({ object: 'block', id: 'deleted-block' }));
+
+      const promise = service.deleteAllBlocks('page-123');
+
+      // 無論是否有延遲，快進時間總是安全的
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      const result = await promise;
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(2);
+      // Calls: 1. List page 1, 2. List page 2, 3. Delete block 1, 4. Delete block 2
+      expect(globalThis.fetch.mock.calls.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe('內部方法與邊界情況', () => {
+    describe('_fetchPageBlocks Error Handling', () => {
+      it('應該處理獲取區塊失敗', async () => {
+        globalThis.fetch.mockResolvedValue(createMockResponse({ message: 'fail' }, false, 400));
+        const result = await service._fetchPageBlocks('id');
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('_deleteBlocksByIds Error Handling and Delay', () => {
+      it('應該處理 deleteBlock 異常並記錄警告', async () => {
+        service._executeWithRetry = jest.fn().mockRejectedValue(new Error('crash'));
+        await service._deleteBlocksByIds(['b1']);
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('刪除區塊異常'),
+          expect.objectContaining({
+            action: 'deleteBlocksByIds',
+            phase: 'deleteBlock',
+            blockId: 'b1',
+            error: expect.any(Error),
+          })
+        );
+      });
+
+      it('應該彙整單一 worker unexpected reject 而不中斷整批刪除', async () => {
+        service.config.DELETE_CONCURRENCY = 3;
+        service._deleteBlockById = jest.fn(blockId => {
+          if (blockId === 'b2') {
+            return Promise.reject(new Error('worker crashed'));
+          }
+          return Promise.resolve({ success: true, id: blockId });
+        });
+
+        const result = await service._deleteBlocksByIds(['b1', 'b2', 'b3']);
+
+        expect(service._deleteBlockById).toHaveBeenCalledTimes(3);
+        expect(result).toEqual({
+          successCount: 2,
+          failureCount: 1,
+          errors: [{ id: 'b2', error: 'worker crashed' }],
+        });
+      });
+
+      it('應該保留非 Error rejection 的原始訊息（字串、plain object）', async () => {
+        service.config.DELETE_CONCURRENCY = 3;
+        service._deleteBlockById = jest.fn(blockId => {
+          if (blockId === 'b1') {
+            return Promise.reject('string reason token');
+          }
+          if (blockId === 'b2') {
+            return Promise.reject({ message: 'plain object reason' });
+          }
+          return Promise.reject(null);
+        });
+
+        const result = await service._deleteBlocksByIds(['b1', 'b2', 'b3']);
+
+        expect(result).toEqual({
+          successCount: 0,
+          failureCount: 3,
+          errors: [
+            { id: 'b1', error: 'string reason token' },
+            { id: 'b2', error: 'plain object reason' },
+            { id: 'b3', error: 'Unknown error' },
+          ],
+        });
+      });
+
+      it('應該在批次間執行延遲', async () => {
+        jest.useRealTimers();
+        service.config.DELETE_CONCURRENCY = 1;
+        service.config.DELETE_BATCH_DELAY_MS = 1;
+        service._executeWithRetry = jest.fn().mockResolvedValue({ success: true });
+
+        await service._deleteBlocksByIds(['b1', 'b2']);
+
+        expect(service._executeWithRetry).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('建立頁面自動批次處理', () => {
+      it('應該在分批添加失敗時記錄警告', async () => {
+        globalThis.fetch
+          .mockResolvedValueOnce(createMockResponse({ id: 'id' }))
+          .mockResolvedValueOnce(createMockResponse({ message: 'fail' }, false, 400));
+        const manyBlocks = Array.from({ length: 110 }, () => ({ type: 'paragraph' }));
+        await service.createPage(
+          { parent: { data_source_id: 'db' } },
+          { autoBatch: true, allBlocks: manyBlocks }
+        );
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('部分區塊添加失敗'),
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('更新頁面標題錯誤處理', () => {
+      it('應該處理更新失敗並記錄錯誤', async () => {
+        globalThis.fetch.mockResolvedValue(createMockResponse({ message: 'fail' }, false, 400));
+        await service.updatePageTitle('id', 'Title');
+        expect(Logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('更新標題失敗'),
+          expect.objectContaining({ error: expect.any(Object) })
+        );
+      });
+    });
+
+    describe('刪除所有區塊警告處理', () => {
+      it('應該在部分失敗時記錄警告', async () => {
+        service._fetchPageBlocks = jest
+          .fn()
+          .mockResolvedValue({ success: true, blocks: [{ id: 'b1' }] });
+        service._deleteBlocksByIds = jest
+          .fn()
+          .mockResolvedValue({ successCount: 0, failureCount: 1, errors: [{ id: 'b1' }] });
+        await service.deleteAllBlocks('id');
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('部分區塊刪除失敗'),
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('更新頁面內容警告處理', () => {
+      it('應該在標題更新失敗時記錄警告', async () => {
+        service.updatePageTitle = jest.fn().mockResolvedValue({ success: false });
+        service.deleteAllBlocks = jest.fn().mockResolvedValue({ success: true });
+        service.appendBlocksInBatches = jest.fn().mockResolvedValue({ success: true });
+        await service.refreshPageContent('id', [], { updateTitle: true, title: 'T' });
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('標題更新失敗'),
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('更新標記區塊警告處理', () => {
+      it('應該在刪除標記失敗時記錄警告', async () => {
+        service._fetchPageBlocks = jest.fn().mockResolvedValue({ success: true, blocks: [] });
+        service._deleteBlocksByIds = jest
+          .fn()
+          .mockResolvedValue({ successCount: 0, failureCount: 1, errors: [{ id: 'b1' }] });
+        const result = await service.updateHighlightsSection('id', []);
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('部分標記區塊刪除失敗'),
+          expect.any(Object)
+        );
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+});

--- a/tests/unit/background/services/NotionService.block-operations.test.js
+++ b/tests/unit/background/services/NotionService.block-operations.test.js
@@ -1,22 +1,15 @@
 // NotionService.block-operations.test.js
 // 1. Mocks MUST be at the very top
-jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-    debug: jest.fn(),
+jest.mock('../../../../scripts/utils/Logger.js', () => {
+  const loggerMock = require('../../../helpers/loggerMock.js').createLoggerMock({
     debugEnabled: true,
-  },
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  success: jest.fn(),
-  debug: jest.fn(),
-  debugEnabled: true,
-}));
+  });
+  return {
+    __esModule: true,
+    default: loggerMock,
+    ...loggerMock,
+  };
+});
 
 jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
   getActiveNotionToken: jest.fn(),
@@ -57,12 +50,9 @@ describe('NotionService - Block Operations', () => {
     jest.clearAllMocks();
     getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
     refreshOAuthToken.mockResolvedValue(null);
-    mockLogger = {
-      log: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      success: jest.fn(),
-    };
+    mockLogger = require('../../../helpers/loggerMock.js').createLoggerMock({
+      debugEnabled: true,
+    });
     globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
 
     service = new NotionService({
@@ -382,7 +372,12 @@ describe('NotionService - Block Operations', () => {
         );
         expect(Logger.warn).toHaveBeenCalledWith(
           expect.stringContaining('部分區塊添加失敗'),
-          expect.any(Object)
+          expect.objectContaining({
+            action: 'createPage',
+            phase: 'autoBatch',
+            addedCount: expect.any(Number),
+            totalCount: expect.any(Number),
+          })
         );
       });
     });
@@ -409,7 +404,11 @@ describe('NotionService - Block Operations', () => {
         await service.deleteAllBlocks('id');
         expect(Logger.warn).toHaveBeenCalledWith(
           expect.stringContaining('部分區塊刪除失敗'),
-          expect.any(Object)
+          expect.objectContaining({
+            action: 'deleteAllBlocks',
+            result: 'partial_failure',
+            failureCount: 1,
+          })
         );
       });
     });
@@ -422,7 +421,10 @@ describe('NotionService - Block Operations', () => {
         await service.refreshPageContent('id', [], { updateTitle: true, title: 'T' });
         expect(Logger.warn).toHaveBeenCalledWith(
           expect.stringContaining('標題更新失敗'),
-          expect.any(Object)
+          expect.objectContaining({
+            action: 'refreshPageContent',
+            phase: 'updateTitle',
+          })
         );
       });
     });
@@ -436,7 +438,11 @@ describe('NotionService - Block Operations', () => {
         const result = await service.updateHighlightsSection('id', []);
         expect(Logger.warn).toHaveBeenCalledWith(
           expect.stringContaining('部分標記區塊刪除失敗'),
-          expect.any(Object)
+          expect.objectContaining({
+            action: 'updateHighlightsSection',
+            result: 'partial_failure',
+            phase: 'delete',
+          })
         );
         expect(result.success).toBe(false);
       });

--- a/tests/unit/background/services/NotionService.highlight-section.test.js
+++ b/tests/unit/background/services/NotionService.highlight-section.test.js
@@ -1,0 +1,93 @@
+// NotionService.highlight-section.test.js
+import { NotionService } from '../../../../scripts/background/services/NotionService.js';
+import { paragraphBlock, headingBlock } from '../../../helpers/notionServiceTestHarness.js';
+
+describe('NotionService - _findHighlightSectionBlocks (靜態方法)', () => {
+  const HEADER = '📝 頁面標記';
+
+  it.each([
+    {
+      desc: '應該處理只有標題沒有內容的情況',
+      blocks: [paragraphBlock('1'), headingBlock('2', 3, HEADER)],
+      expected: ['2'],
+    },
+    {
+      desc: '應該正確識別標記區塊',
+      blocks: [
+        paragraphBlock('1'),
+        headingBlock('2', 3, HEADER),
+        paragraphBlock('3'),
+        paragraphBlock('4'),
+      ],
+      expected: ['2', '3', '4'],
+    },
+    {
+      desc: '應該在遇到下一個標題時停止收集',
+      blocks: [
+        headingBlock('1', 3, HEADER),
+        paragraphBlock('2'),
+        headingBlock('3', 2),
+        paragraphBlock('4'),
+      ],
+      expected: ['1', '2'],
+    },
+    {
+      desc: '應該正確處理沒有標記區域的情況',
+      blocks: [paragraphBlock('1'), headingBlock('2', 2)],
+      expected: [],
+    },
+    {
+      desc: '應該處理空區塊數組',
+      blocks: [],
+      expected: [],
+    },
+    {
+      desc: '應收集所有非標題類型的區塊',
+      blocks: [
+        headingBlock('1', 3, HEADER),
+        paragraphBlock('2'),
+        { id: '3', type: 'image', image: {} },
+        paragraphBlock('4'),
+      ],
+      expected: ['1', '2', '3', '4'],
+    },
+    {
+      desc: '應該忽略沒有 ID 的區塊',
+      blocks: [headingBlock('1', 3, HEADER), { type: 'paragraph' }, paragraphBlock('3')],
+      expected: ['1', '3'],
+    },
+    {
+      desc: '應該只處理第一個匹配的標記區域',
+      blocks: [
+        headingBlock('1', 3, HEADER),
+        paragraphBlock('2'),
+        headingBlock('3', 3, HEADER),
+        paragraphBlock('4'),
+      ],
+      expected: ['1', '2'],
+    },
+    {
+      desc: '應該跳過內容不同的 heading_3',
+      blocks: [headingBlock('1', 3, '其他標題'), headingBlock('2', 3, HEADER), paragraphBlock('3')],
+      expected: ['2', '3'],
+    },
+    {
+      desc: '應該將 nullish 區塊視為標記區域邊界以避免擴大刪除範圍',
+      blocks: [headingBlock('1', 3, HEADER), paragraphBlock('2'), null, paragraphBlock('3')],
+      expected: ['1', '2'],
+    },
+    {
+      desc: '應該處理標記區域在頁面末尾的情況',
+      blocks: [
+        paragraphBlock('1'),
+        paragraphBlock('2'),
+        headingBlock('3', 3, HEADER),
+        paragraphBlock('4'),
+      ],
+      expected: ['3', '4'],
+    },
+  ])('$desc', ({ blocks, expected }) => {
+    const result = NotionService._findHighlightSectionBlocks(blocks);
+    expect(result).toEqual(expected);
+  });
+});

--- a/tests/unit/background/services/NotionService.page-data.test.js
+++ b/tests/unit/background/services/NotionService.page-data.test.js
@@ -71,6 +71,38 @@ describe('NotionService - Page Data and Request Body', () => {
     jest.useRealTimers();
   });
 
+  const buildPageData = (overrides = {}) => service.buildPageData(buildPageDataOptions(overrides));
+
+  const expectExternalFile = (value, url) => {
+    expect(value).toEqual({
+      type: 'external',
+      external: { url },
+    });
+  };
+
+  const expectFetchRequest = expectedOptions => {
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/test'),
+      expectedOptions
+    );
+  };
+
+  const expectFetchWithoutBody = () => {
+    expectFetchRequest(
+      expect.not.objectContaining({
+        body: expect.anything(),
+      })
+    );
+  };
+
+  const expectFetchBody = body => {
+    expectFetchRequest(
+      expect.objectContaining({
+        body: JSON.stringify(body),
+      })
+    );
+  };
+
   describe('buildPageData', () => {
     it.each([
       {
@@ -95,13 +127,11 @@ describe('NotionService - Page Data and Request Body', () => {
         expectedId: 'page-456',
       },
     ])('$desc', ({ options, expectedType, expectedIdKey, expectedId }) => {
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          title: 'Test Title',
-          pageUrl: 'https://example.com',
-          ...options,
-        })
-      );
+      const result = buildPageData({
+        title: 'Test Title',
+        pageUrl: 'https://example.com',
+        ...options,
+      });
 
       expect(result.pageData.parent.type).toBe(expectedType);
       expect(result.pageData.parent[expectedIdKey]).toBe(expectedId);
@@ -112,13 +142,11 @@ describe('NotionService - Page Data and Request Body', () => {
     });
 
     it('page parent 應使用 Notion page title property，不應送出 data source schema properties', () => {
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          title: 'Child Page',
-          dataSourceId: 'page-456',
-          dataSourceType: 'page',
-        })
-      );
+      const result = buildPageData({
+        title: 'Child Page',
+        dataSourceId: 'page-456',
+        dataSourceType: 'page',
+      });
 
       expect(result.pageData.properties).toEqual({
         title: {
@@ -130,37 +158,29 @@ describe('NotionService - Page Data and Request Body', () => {
     });
 
     it('當提供時應該加入網站圖示', () => {
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          siteIcon: 'https://example.com/icon.png',
-        })
-      );
+      expect.hasAssertions();
 
-      expect(result.pageData.icon).toEqual({
-        type: 'external',
-        external: { url: 'https://example.com/icon.png' },
-      });
+      const url = 'https://example.com/icon.png';
+
+      const result = buildPageData({ siteIcon: url });
+
+      expectExternalFile(result.pageData.icon, url);
     });
 
     it('應該為一般 https URL 設定 page cover', () => {
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          coverImage: 'https://example.com/cover.jpg',
-        })
-      );
+      expect.hasAssertions();
 
-      expect(result.pageData.cover).toEqual({
-        type: 'external',
-        external: { url: 'https://example.com/cover.jpg' },
-      });
+      const url = 'https://example.com/cover.jpg';
+
+      const result = buildPageData({ coverImage: url });
+
+      expectExternalFile(result.pageData.cover, url);
     });
 
     it('應該忽略非字串 coverImage 而不拋出錯誤', () => {
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          coverImage: { url: 'https://example.com/cover.jpg' },
-        })
-      );
+      const result = buildPageData({
+        coverImage: { url: 'https://example.com/cover.jpg' },
+      });
 
       expect(result.pageData.cover).toBeUndefined();
     });
@@ -169,11 +189,7 @@ describe('NotionService - Page Data and Request Body', () => {
       const tempUrl =
         'https://c10.patreonusercontent.com/4/patreon-media/p/post/157239355/abc/eyJ3IjoxMDgwfQ==/1.png?token-hash=ABC123&token-time=1700000000';
 
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          coverImage: tempUrl,
-        })
-      );
+      const result = buildPageData({ coverImage: tempUrl });
 
       expect(result.pageData.cover).toBeUndefined();
     });
@@ -182,11 +198,7 @@ describe('NotionService - Page Data and Request Body', () => {
       const tempUrl =
         'https://c8.patreonusercontent.com/4/patreon-media/foo.png?token-time=1700000000';
 
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          coverImage: tempUrl,
-        })
-      );
+      const result = buildPageData({ coverImage: tempUrl });
 
       expect(result.pageData.cover).toBeUndefined();
     });
@@ -197,11 +209,7 @@ describe('NotionService - Page Data and Request Body', () => {
         { type: 'image', image: { external: { url: 'sftp://invalid.com/img.jpg' } } },
       ];
 
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          blocks,
-        })
-      );
+      const result = buildPageData({ blocks });
 
       expect(result.pageData.children).toHaveLength(2);
     });
@@ -212,11 +220,7 @@ describe('NotionService - Page Data and Request Body', () => {
         .fill(null)
         .map(() => ({ type: 'paragraph', paragraph: { rich_text: [] } }));
 
-      const result = service.buildPageData(
-        buildPageDataOptions({
-          blocks,
-        })
-      );
+      const result = buildPageData({ blocks });
 
       expect(result.pageData.children).toHaveLength(NOTION_API.BLOCKS_PER_BATCH);
     });
@@ -239,27 +243,21 @@ describe('NotionService - Page Data and Request Body', () => {
       { desc: 'body 為 undefined', body: undefined },
       { desc: 'body 為空對象', body: {} },
     ])('應該在 $desc 時不包含 body', async ({ body }) => {
+      expect.hasAssertions();
+
       await service._apiRequest('/test', { method: 'POST', body });
 
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.not.objectContaining({
-          body: expect.anything(),
-        })
-      );
+      expectFetchWithoutBody();
     });
 
     it('應該正常處理普通對象 body', async () => {
+      expect.hasAssertions();
+
       const body = { key: 'value' };
 
       await service._apiRequest('/test', { method: 'POST', body });
 
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.objectContaining({
-          body: JSON.stringify(body),
-        })
-      );
+      expectFetchBody(body);
     });
   });
 });

--- a/tests/unit/background/services/NotionService.page-data.test.js
+++ b/tests/unit/background/services/NotionService.page-data.test.js
@@ -2,20 +2,9 @@
 // 1. Mocks MUST be at the very top
 jest.mock('../../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-    debug: jest.fn(),
+  default: require('../../../helpers/loggerMock.js').createLoggerMock({
     debugEnabled: true,
-  },
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  success: jest.fn(),
-  debug: jest.fn(),
-  debugEnabled: true,
+  }),
 }));
 
 jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
@@ -52,12 +41,9 @@ describe('NotionService - Page Data and Request Body', () => {
     jest.clearAllMocks();
     getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
     refreshOAuthToken.mockResolvedValue(null);
-    mockLogger = {
-      log: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      success: jest.fn(),
-    };
+    mockLogger = require('../../../helpers/loggerMock.js').createLoggerMock({
+      debugEnabled: true,
+    });
     globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
 
     service = new NotionService({
@@ -238,17 +224,16 @@ describe('NotionService - Page Data and Request Body', () => {
   });
 
   describe('_apiRequest', () => {
-    it.each([
-      { desc: 'body 為 null', body: null },
-      { desc: 'body 為 undefined', body: undefined },
-      { desc: 'body 為空對象', body: {} },
-    ])('應該在 $desc 時不包含 body', async ({ body }) => {
-      expect.hasAssertions();
+    it.each([{ desc: 'body 為 undefined', body: undefined }])(
+      '應該在 $desc 時不包含 body',
+      async ({ body }) => {
+        expect.hasAssertions();
 
-      await service._apiRequest('/test', { method: 'POST', body });
+        await service._apiRequest('/test', { method: 'POST', body });
 
-      expectFetchWithoutBody();
-    });
+        expectFetchWithoutBody();
+      }
+    );
 
     it('應該正常處理普通對象 body', async () => {
       expect.hasAssertions();

--- a/tests/unit/background/services/NotionService.page-data.test.js
+++ b/tests/unit/background/services/NotionService.page-data.test.js
@@ -1,0 +1,265 @@
+// NotionService.page-data.test.js
+// 1. Mocks MUST be at the very top
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    debug: jest.fn(),
+    debugEnabled: true,
+  },
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn(),
+  debugEnabled: true,
+}));
+
+jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
+  getActiveNotionToken: jest.fn(),
+  refreshOAuthToken: jest.fn(),
+}));
+
+import { NotionService } from '../../../../scripts/background/services/NotionService.js';
+import { CONTENT_QUALITY } from '../../../../scripts/config/index.js';
+import { NOTION_API } from '../../../../scripts/config/extension/notionApi.js';
+import { getActiveNotionToken, refreshOAuthToken } from '../../../../scripts/utils/notionAuth.js';
+import { buildPageDataOptions } from '../../../helpers/notionServiceTestHarness.js';
+
+const createMockResponse = (data, ok = true, status = 200) => ({
+  ok,
+  status,
+  headers: new Headers([['content-type', 'application/json']]),
+  clone() {
+    return this;
+  },
+  json: () => Promise.resolve(data),
+  text: () => Promise.resolve(JSON.stringify(data)),
+});
+
+const mockFetchResponse = createMockResponse({});
+
+describe('NotionService - Page Data and Request Body', () => {
+  let service = null;
+  let mockLogger = null;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
+    refreshOAuthToken.mockResolvedValue(null);
+    mockLogger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      success: jest.fn(),
+    };
+    globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
+
+    service = new NotionService({
+      apiKey: 'test-api-key',
+      logger: mockLogger,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  describe('buildPageData', () => {
+    it.each([
+      {
+        desc: '應該為 data_source 類型構建頁面資料',
+        options: { dataSourceId: 'db-123', dataSourceType: 'data_source' },
+        expectedType: 'data_source_id',
+        expectedIdKey: 'data_source_id',
+        expectedId: 'db-123',
+      },
+      {
+        desc: '應該透過 data_source_id 父節點為 database 類型構建頁面資料',
+        options: { dataSourceId: 'db-456', dataSourceType: 'database' },
+        expectedType: 'data_source_id',
+        expectedIdKey: 'data_source_id',
+        expectedId: 'db-456',
+      },
+      {
+        desc: '應該為 page 類型構建頁面資料',
+        options: { dataSourceId: 'page-456', dataSourceType: 'page' },
+        expectedType: 'page_id',
+        expectedIdKey: 'page_id',
+        expectedId: 'page-456',
+      },
+    ])('$desc', ({ options, expectedType, expectedIdKey, expectedId }) => {
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          title: 'Test Title',
+          pageUrl: 'https://example.com',
+          ...options,
+        })
+      );
+
+      expect(result.pageData.parent.type).toBe(expectedType);
+      expect(result.pageData.parent[expectedIdKey]).toBe(expectedId);
+      if (expectedType === 'data_source_id') {
+        expect(result.pageData.properties.Title.title[0].text.content).toBe('Test Title');
+        expect(result.pageData.properties.URL.url).toBe('https://example.com');
+      }
+    });
+
+    it('page parent 應使用 Notion page title property，不應送出 data source schema properties', () => {
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          title: 'Child Page',
+          dataSourceId: 'page-456',
+          dataSourceType: 'page',
+        })
+      );
+
+      expect(result.pageData.properties).toEqual({
+        title: {
+          title: [{ text: { content: 'Child Page' } }],
+        },
+      });
+      expect(result.pageData.properties.Title).toBeUndefined();
+      expect(result.pageData.properties.URL).toBeUndefined();
+    });
+
+    it('當提供時應該加入網站圖示', () => {
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          siteIcon: 'https://example.com/icon.png',
+        })
+      );
+
+      expect(result.pageData.icon).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/icon.png' },
+      });
+    });
+
+    it('應該為一般 https URL 設定 page cover', () => {
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          coverImage: 'https://example.com/cover.jpg',
+        })
+      );
+
+      expect(result.pageData.cover).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/cover.jpg' },
+      });
+    });
+
+    it('應該忽略非字串 coverImage 而不拋出錯誤', () => {
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          coverImage: { url: 'https://example.com/cover.jpg' },
+        })
+      );
+
+      expect(result.pageData.cover).toBeUndefined();
+    });
+
+    it('應該對 Patreon signed URL 跳過 page cover (defense in depth)', () => {
+      const tempUrl =
+        'https://c10.patreonusercontent.com/4/patreon-media/p/post/157239355/abc/eyJ3IjoxMDgwfQ==/1.png?token-hash=ABC123&token-time=1700000000';
+
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          coverImage: tempUrl,
+        })
+      );
+
+      expect(result.pageData.cover).toBeUndefined();
+    });
+
+    it('應該對 patreonusercontent.com 帶 token-time 的 URL 跳過 page cover', () => {
+      const tempUrl =
+        'https://c8.patreonusercontent.com/4/patreon-media/foo.png?token-time=1700000000';
+
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          coverImage: tempUrl,
+        })
+      );
+
+      expect(result.pageData.cover).toBeUndefined();
+    });
+
+    it('應該包含所有圖片區塊並回傳有效的頁面資料', () => {
+      const blocks = [
+        { type: 'paragraph', paragraph: { rich_text: [] } },
+        { type: 'image', image: { external: { url: 'sftp://invalid.com/img.jpg' } } },
+      ];
+
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          blocks,
+        })
+      );
+
+      expect(result.pageData.children).toHaveLength(2);
+    });
+
+    it('子區塊數量不應超過配置 of BATCH_SIZE', () => {
+      const TOTAL_BLOCKS = 150;
+      const blocks = Array.from({ length: TOTAL_BLOCKS })
+        .fill(null)
+        .map(() => ({ type: 'paragraph', paragraph: { rich_text: [] } }));
+
+      const result = service.buildPageData(
+        buildPageDataOptions({
+          blocks,
+        })
+      );
+
+      expect(result.pageData.children).toHaveLength(NOTION_API.BLOCKS_PER_BATCH);
+    });
+
+    it('針對缺失的選項應使用預設值', () => {
+      const result = service.buildPageData({
+        dataSourceId: 'db-123',
+      });
+
+      expect(result.pageData.properties.Title.title[0].text.content).toBe(
+        CONTENT_QUALITY.DEFAULT_PAGE_TITLE
+      );
+      expect(result.pageData.properties.URL.url).toBe('');
+    });
+  });
+
+  describe('_apiRequest', () => {
+    it.each([
+      { desc: 'body 為 null', body: null },
+      { desc: 'body 為 undefined', body: undefined },
+      { desc: 'body 為空對象', body: {} },
+    ])('應該在 $desc 時不包含 body', async ({ body }) => {
+      await service._apiRequest('/test', { method: 'POST', body });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/test'),
+        expect.not.objectContaining({
+          body: expect.anything(),
+        })
+      );
+    });
+
+    it('應該正常處理普通對象 body', async () => {
+      const body = { key: 'value' };
+
+      await service._apiRequest('/test', { method: 'POST', body });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/test'),
+        expect.objectContaining({
+          body: JSON.stringify(body),
+        })
+      );
+    });
+  });
+});

--- a/tests/unit/background/services/NotionService.retry.test.js
+++ b/tests/unit/background/services/NotionService.retry.test.js
@@ -1,0 +1,132 @@
+// NotionService.retry.test.js
+// 1. Mocks MUST be at the very top
+jest.mock('../../../../scripts/utils/Logger.js', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+    debug: jest.fn(),
+    debugEnabled: true,
+  },
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn(),
+  debugEnabled: true,
+}));
+
+import { fetchWithRetry } from '../../../../scripts/utils/RetryManager.js';
+
+const createMockResponse = (data, ok = true, status = 200) => ({
+  ok,
+  status,
+  headers: new Headers([['content-type', 'application/json']]),
+  clone() {
+    return this;
+  },
+  json: () => Promise.resolve(data),
+  text: () => Promise.resolve(JSON.stringify(data)),
+});
+
+const mockFetchResponse = createMockResponse({});
+
+describe('fetchWithRetry', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('應該在成功時直接返回響應', async () => {
+    globalThis.fetch.mockResolvedValue({ ...mockFetchResponse, ok: true, status: 200 });
+
+    const result = await fetchWithRetry('https://api.notion.com/test', {});
+    expect(result.ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      desc: '應該在 5xx 錯誤時重試',
+      setupMock: () => {
+        globalThis.fetch = jest
+          .fn()
+          .mockResolvedValueOnce(createMockResponse({}, false, 500))
+          .mockResolvedValueOnce(createMockResponse({ ok: true }));
+      },
+    },
+    {
+      desc: '應該在網絡錯誤時重試',
+      setupMock: () => {
+        globalThis.fetch = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('Failed to fetch'))
+          .mockResolvedValueOnce(createMockResponse({ ok: true }));
+      },
+    },
+  ])('$desc', async ({ setupMock }) => {
+    jest.useRealTimers();
+    setupMock();
+
+    const result = await fetchWithRetry(
+      'https://api.notion.com/test',
+      {},
+      { maxRetries: 1, baseDelay: 10 }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('應該在達到最大重試次數後返回錯誤響應', async () => {
+    jest.useRealTimers();
+    globalThis.fetch.mockResolvedValue(createMockResponse({}, false, 500));
+
+    const promise = fetchWithRetry(
+      'https://api.notion.com/test',
+      {},
+      { maxRetries: 1, baseDelay: 10 }
+    );
+
+    await expect(promise).rejects.toThrow(/HTTP 狀態：500/);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('應該在達到最大重試次數後拋出網絡錯誤', async () => {
+    const error = new Error('Network error');
+    error.name = 'NetworkError';
+    globalThis.fetch = jest.fn().mockRejectedValue(error);
+
+    const promise = fetchWithRetry(
+      'https://api.notion.com/test',
+      {},
+      { maxRetries: 1, baseDelay: 1000 }
+    );
+
+    const flushMicrotasks = async (count = 10) => {
+      for (let i = 0; i < count; i++) {
+        await Promise.resolve();
+      }
+    };
+    await flushMicrotasks();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(2000);
+
+    await flushMicrotasks();
+
+    await expect(promise).rejects.toThrow('Network error');
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/background/services/NotionService.retry.test.js
+++ b/tests/unit/background/services/NotionService.retry.test.js
@@ -1,22 +1,15 @@
 // NotionService.retry.test.js
 // 1. Mocks MUST be at the very top
-jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-    debug: jest.fn(),
+jest.mock('../../../../scripts/utils/Logger.js', () => {
+  const loggerMock = require('../../../helpers/loggerMock.js').createLoggerMock({
     debugEnabled: true,
-  },
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  success: jest.fn(),
-  debug: jest.fn(),
-  debugEnabled: true,
-}));
+  });
+  return {
+    __esModule: true,
+    default: loggerMock,
+    ...loggerMock,
+  };
+});
 
 import { fetchWithRetry } from '../../../../scripts/utils/RetryManager.js';
 

--- a/tests/unit/background/services/NotionService.test.js
+++ b/tests/unit/background/services/NotionService.test.js
@@ -1,22 +1,15 @@
 // NotionService.test.js
 // 1. Mocks MUST be at the very top
-jest.mock('../../../../scripts/utils/Logger.js', () => ({
-  __esModule: true,
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    success: jest.fn(),
-    debug: jest.fn(),
+jest.mock('../../../../scripts/utils/Logger.js', () => {
+  const loggerMock = require('../../../helpers/loggerMock.js').createLoggerMock({
     debugEnabled: true,
-  },
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  success: jest.fn(),
-  debug: jest.fn(),
-  debugEnabled: true,
-}));
+  });
+  return {
+    __esModule: true,
+    default: loggerMock,
+    ...loggerMock,
+  };
+});
 
 jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
   getActiveNotionToken: jest.fn(),
@@ -53,12 +46,9 @@ describe('NotionService', () => {
     jest.clearAllMocks();
     getActiveNotionToken.mockResolvedValue({ token: 'test-api-key', mode: 'manual' });
     refreshOAuthToken.mockResolvedValue(null);
-    mockLogger = {
-      log: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      success: jest.fn(),
-    };
+    mockLogger = require('../../../helpers/loggerMock.js').createLoggerMock({
+      debugEnabled: true,
+    });
     globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
 
     service = new NotionService({

--- a/tests/unit/background/services/NotionService.test.js
+++ b/tests/unit/background/services/NotionService.test.js
@@ -1,3 +1,4 @@
+// NotionService.test.js
 // 1. Mocks MUST be at the very top
 jest.mock('../../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
@@ -24,13 +25,10 @@ jest.mock('../../../../scripts/utils/notionAuth.js', () => ({
 
 // 2. Imports
 import { NotionService } from '../../../../scripts/background/services/NotionService.js';
-import { CONTENT_QUALITY } from '../../../../scripts/config/index.js';
-import { HIGHLIGHT_ERROR_CODES } from '../../../../scripts/config/shared/messages.js';
 import { NOTION_API } from '../../../../scripts/config/extension/notionApi.js';
-import { fetchWithRetry } from '../../../../scripts/utils/RetryManager.js';
 import Logger from '../../../../scripts/utils/Logger.js';
 import { getActiveNotionToken, refreshOAuthToken } from '../../../../scripts/utils/notionAuth.js';
-import notionBlockFixtures from '../../../fixtures/json/notion-api-blocks.json';
+import { HIGHLIGHT_ERROR_CODES } from '../../../../scripts/config/shared/messages.js';
 
 const createMockResponse = (data, ok = true, status = 200) => ({
   ok,
@@ -45,123 +43,11 @@ const createMockResponse = (data, ok = true, status = 200) => ({
 
 const mockFetchResponse = createMockResponse({});
 
-const createMockNotionBlock = (id, fixtureType = 'paragraph') => ({
-  id,
-  ...structuredClone(notionBlockFixtures[fixtureType]),
-});
-
-describe('fetchWithRetry', () => {
-  const originalFetch = globalThis.fetch;
-
-  beforeEach(() => {
-    jest.useFakeTimers();
-    globalThis.fetch = jest.fn();
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-    jest.useRealTimers();
-  });
-
-  it('應該在成功時直接返回響應', async () => {
-    globalThis.fetch.mockResolvedValue({ ...mockFetchResponse, ok: true, status: 200 });
-
-    const result = await fetchWithRetry('https://api.notion.com/test', {});
-    expect(result.ok).toBe(true);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('應該在 5xx 錯誤時重試', async () => {
-    jest.useRealTimers();
-    globalThis.fetch = jest
-      .fn()
-      .mockResolvedValueOnce(createMockResponse({}, false, 500))
-      .mockResolvedValueOnce(createMockResponse({ ok: true }));
-
-    const result = await fetchWithRetry(
-      'https://api.notion.com/test',
-      {},
-      { maxRetries: 1, baseDelay: 10 }
-    );
-
-    expect(result.ok).toBe(true);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('應該在達到最大重試次數後返回錯誤響應', async () => {
-    jest.useRealTimers();
-    globalThis.fetch.mockResolvedValue(createMockResponse({}, false, 500));
-
-    const promise = fetchWithRetry(
-      'https://api.notion.com/test',
-      {},
-      { maxRetries: 1, baseDelay: 10 }
-    );
-
-    await expect(promise).rejects.toThrow(/HTTP 狀態：500/);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('應該在網絡錯誤時重試', async () => {
-    jest.useRealTimers();
-    globalThis.fetch = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('Failed to fetch'))
-      .mockResolvedValueOnce(createMockResponse({ ok: true }));
-
-    const result = await fetchWithRetry(
-      'https://api.notion.com/test',
-      {},
-      { maxRetries: 1, baseDelay: 10 }
-    );
-
-    expect(result.ok).toBe(true);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('應該在達到最大重試次數後拋出網絡錯誤', async () => {
-    const error = new Error('Network error');
-    error.name = 'NetworkError';
-    globalThis.fetch = jest.fn().mockRejectedValue(error);
-
-    // 啟動請求，但不等待它完成 (Promise 會處於 pending 狀態等待重試計時器)
-    const promise = fetchWithRetry(
-      'https://api.notion.com/test',
-      {},
-      { maxRetries: 1, baseDelay: 1000 }
-    );
-
-    // 先 flush 微任務，讓初始請求失敗並排入重試計時器。
-    // 這個案例需要在重試發生前先驗證中間狀態，因此保留手動 flush，
-    // 而不是直接用 advanceTimersByTimeAsync 一次跑完整段非同步流程。
-    const flushMicrotasks = async (count = 10) => {
-      for (let i = 0; i < count; i++) {
-        await Promise.resolve();
-      }
-    };
-    await flushMicrotasks();
-
-    // 驗證第一次調用已發生
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-
-    // 快進時間以觸發重試 (確保超過 baseDelay)
-    jest.advanceTimersByTime(2000);
-
-    // 再次 flush 以執行重試請求
-    await flushMicrotasks();
-
-    // 等待 Promise 拒絕並驗證錯誤
-    await expect(promise).rejects.toThrow('Network error');
-
-    // 驗證總共調用次數（初始 + 1次重試）
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-  });
-});
-
 describe('NotionService', () => {
   let service = null;
   let mockLogger = null;
   const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
@@ -173,7 +59,6 @@ describe('NotionService', () => {
       error: jest.fn(),
       success: jest.fn(),
     };
-    // 預設完整的 fetch mock 以符合 SDK 預期 (複用外部定義)
     globalThis.fetch = jest.fn().mockResolvedValue(mockFetchResponse);
 
     service = new NotionService({
@@ -199,193 +84,14 @@ describe('NotionService', () => {
     });
 
     it('應該使用 cache: no-store 初始化 client', async () => {
-      // Force init
       service._initClient();
 
-      // Trigger a fetch to verify options
-      // We need to access private client or trigger a method that uses it
-      // Using a public method that triggers fetch
       await service.checkPageExists('page-123');
 
-      // Verify the fetch mock was called with correct options in the last call
-      // Note: _initClient creates the client with the custom fetch
-      // We need to check if that custom fetch passes the cache option
-
-      // Since we can't easily spy on the internal fetch wrapper without redesigning the test,
-      // we can check if globalThis.fetch was called with expected options
-      // when a request is made.
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ cache: 'no-store' })
       );
-    });
-  });
-
-  describe('OAuth 401 retry flow', () => {
-    it('401 + OAuth + refresh 成功時應重試一次', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-      const staleClient = { id: 'stale-client' };
-
-      const executeWithRetrySpy = jest
-        .spyOn(service, '_executeWithRetry')
-        .mockRejectedValueOnce(unauthorizedError)
-        .mockResolvedValueOnce({ ok: true });
-
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'oauth_old_token',
-        mode: 'oauth',
-      });
-      refreshOAuthToken.mockResolvedValueOnce('oauth_new_token');
-
-      const result = await service._callNotionApiWithRetry(jest.fn(), {
-        apiKey: 'oauth_old_token',
-        label: 'TestOperation',
-        client: staleClient,
-      });
-
-      expect(result).toEqual({ ok: true });
-      expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
-      expect(executeWithRetrySpy).toHaveBeenCalledTimes(2);
-      expect(executeWithRetrySpy).toHaveBeenNthCalledWith(
-        2,
-        expect.any(Function),
-        expect.objectContaining({
-          apiKey: 'oauth_new_token',
-        })
-      );
-      expect(executeWithRetrySpy.mock.calls[1][1].client).toBeUndefined();
-    });
-
-    it('401 + OAuth + refresh 失敗時應拋出原錯誤', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-
-      jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'oauth_old_token',
-        mode: 'oauth',
-      });
-      refreshOAuthToken.mockResolvedValueOnce(null);
-
-      await expect(
-        service._callNotionApiWithRetry(jest.fn(), {
-          apiKey: 'oauth_old_token',
-          label: 'TestOperation',
-        })
-      ).rejects.toBe(unauthorizedError);
-      expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('401 + OAuth + refresh reject 時應保留原始 401 錯誤', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-      const refreshError = new Error('Refresh failed');
-
-      jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'oauth_old_token',
-        mode: 'oauth',
-      });
-      refreshOAuthToken.mockRejectedValueOnce(refreshError);
-
-      await expect(
-        service._callNotionApiWithRetry(jest.fn(), {
-          apiKey: 'oauth_old_token',
-          label: 'TestOperation',
-        })
-      ).rejects.toBe(unauthorizedError);
-      expect(refreshOAuthToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('401 + 非 OAuth 模式時不應刷新 token', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-
-      jest.spyOn(service, '_executeWithRetry').mockRejectedValueOnce(unauthorizedError);
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'manual_key',
-        mode: 'manual',
-      });
-
-      await expect(
-        service._callNotionApiWithRetry(jest.fn(), {
-          apiKey: 'manual_key',
-          label: 'TestOperation',
-        })
-      ).rejects.toBe(unauthorizedError);
-      expect(refreshOAuthToken).not.toHaveBeenCalled();
-    });
-
-    it('使用全域 token 的 OAuth 請求在 refresh 成功後會更新全域 apiKey', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-
-      jest
-        .spyOn(service, '_executeWithRetry')
-        .mockRejectedValueOnce(unauthorizedError)
-        .mockResolvedValueOnce({ ok: true });
-
-      service.apiKey = 'oauth_old_token';
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'oauth_old_token',
-        mode: 'oauth',
-      });
-      refreshOAuthToken.mockResolvedValueOnce('oauth_new_token');
-
-      await service._callNotionApiWithRetry(jest.fn(), {
-        label: 'TestOperation',
-      });
-
-      expect(service.apiKey).toBe('oauth_new_token');
-    });
-
-    it('使用 scoped apiKey 的 OAuth 請求在 refresh 成功後不覆寫既有全域 apiKey', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-
-      jest
-        .spyOn(service, '_executeWithRetry')
-        .mockRejectedValueOnce(unauthorizedError)
-        .mockResolvedValueOnce({ ok: true });
-
-      service.apiKey = 'global_manual_token';
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'oauth_old_scoped_token',
-        mode: 'oauth',
-      });
-      refreshOAuthToken.mockResolvedValueOnce('oauth_new_scoped_token');
-
-      await service._callNotionApiWithRetry(jest.fn(), {
-        apiKey: 'oauth_old_scoped_token',
-        label: 'TestOperation',
-      });
-
-      expect(service.apiKey).toBe('global_manual_token');
-    });
-
-    it('client-only scoped request 401 時不應用全域 token 自動 refresh', async () => {
-      const unauthorizedError = new Error('Unauthorized');
-      unauthorizedError.status = 401;
-
-      const executeWithRetrySpy = jest
-        .spyOn(service, '_executeWithRetry')
-        .mockRejectedValueOnce(unauthorizedError);
-
-      getActiveNotionToken.mockResolvedValueOnce({
-        token: 'test-api-key',
-        mode: 'oauth',
-      });
-
-      await expect(
-        service._callNotionApiWithRetry(jest.fn(), {
-          client: { request: jest.fn() },
-          label: 'ClientOnlyOperation',
-        })
-      ).rejects.toBe(unauthorizedError);
-
-      expect(refreshOAuthToken).not.toHaveBeenCalled();
-      expect(executeWithRetrySpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -465,123 +171,6 @@ describe('NotionService', () => {
     });
   });
 
-  describe('appendBlocksInBatches', () => {
-    const TOTAL_BLOCKS = 150;
-    const BATCH_SIZE = 50;
-    const EXPECTED_ADDED = TOTAL_BLOCKS - BATCH_SIZE;
-    const TIMER_ADVANCE_MS = 10_000;
-
-    it('應該成功分批添加區塊', async () => {
-      globalThis.fetch.mockResolvedValue({
-        ...mockFetchResponse,
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
-
-      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
-
-      const promise = service.appendBlocksInBatches('page-123', blocks);
-
-      // 快進時間以處理批次間的延遲
-      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
-
-      const result = await promise;
-      const expectedCalls = Math.ceil(blocks.length / NOTION_API.BLOCKS_PER_BATCH);
-
-      expect(result.success).toBe(true);
-      expect(result.addedCount).toBe(TOTAL_BLOCKS);
-      expect(result.totalCount).toBe(TOTAL_BLOCKS);
-      expect(globalThis.fetch).toHaveBeenCalledTimes(expectedCalls);
-    });
-
-    it('應該處理空區塊數組', async () => {
-      const result = await service.appendBlocksInBatches('page-123', []);
-      expect(result.success).toBe(true);
-      expect(result.addedCount).toBe(0);
-    });
-
-    it('應該處理批次失敗', async () => {
-      globalThis.fetch
-        .mockResolvedValueOnce(createMockResponse({ results: [] }))
-        .mockResolvedValueOnce(
-          createMockResponse(
-            {
-              object: 'error',
-              status: 400,
-              code: 'validation_error',
-              message: 'Bad request',
-            },
-            false,
-            400
-          )
-        );
-
-      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
-
-      const promise = service.appendBlocksInBatches('page-123', blocks);
-      await jest.advanceTimersByTimeAsync(10_000);
-      const result = await promise;
-
-      expect(result.success).toBe(false);
-      expect(result.addedCount).toBe(100);
-      expect(result.error).toBe('VALIDATION_ERROR');
-    });
-
-    it('應該從指定索引開始處理', async () => {
-      globalThis.fetch.mockResolvedValue({
-        ...mockFetchResponse,
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
-
-      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
-
-      const promise = service.appendBlocksInBatches('page-123', blocks, BATCH_SIZE);
-
-      // 快進時間以處理批次間的延遲
-      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
-
-      const result = await promise;
-      const expectedCalls = Math.ceil(EXPECTED_ADDED / NOTION_API.BLOCKS_PER_BATCH);
-
-      expect(result.success).toBe(true);
-      expect(result.addedCount).toBe(EXPECTED_ADDED);
-      expect(result.totalCount).toBe(EXPECTED_ADDED);
-      expect(globalThis.fetch).toHaveBeenCalledTimes(expectedCalls);
-
-      // 驗證已略過前 BATCH_SIZE 個項目
-      const fetchArg = globalThis.fetch.mock.calls[0][1];
-      const reqBody = JSON.parse(fetchArg.body);
-      expect(reqBody.children[0].id).toBe(BATCH_SIZE);
-    });
-
-    it('startIndex 等於 blocks.length 時應回傳空結果且不發送請求', async () => {
-      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
-
-      const promise = service.appendBlocksInBatches('page-123', blocks, blocks.length);
-      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
-      const result = await promise;
-
-      expect(result.success).toBe(true);
-      expect(result.addedCount).toBe(0);
-      expect(result.totalCount).toBe(0);
-      expect(globalThis.fetch).not.toHaveBeenCalled();
-    });
-
-    it('startIndex 大於 blocks.length 時應回傳空結果且不發送請求', async () => {
-      const blocks = Array.from({ length: TOTAL_BLOCKS }, (_, i) => ({ type: 'paragraph', id: i }));
-
-      const promise = service.appendBlocksInBatches('page-123', blocks, blocks.length + 1);
-      await jest.advanceTimersByTimeAsync(TIMER_ADVANCE_MS);
-      const result = await promise;
-
-      expect(result.success).toBe(true);
-      expect(result.addedCount).toBe(0);
-      expect(result.totalCount).toBe(0);
-      expect(globalThis.fetch).not.toHaveBeenCalled();
-    });
-  });
-
   describe('createPage', () => {
     it('應該成功創建頁面', async () => {
       globalThis.fetch.mockResolvedValue(
@@ -651,293 +240,7 @@ describe('NotionService', () => {
     });
   });
 
-  describe('deleteAllBlocks', () => {
-    it('應該成功刪除所有區塊', async () => {
-      globalThis.fetch
-        .mockResolvedValueOnce(
-          createMockResponse({
-            results: [createMockNotionBlock('block-1'), createMockNotionBlock('block-2')],
-          })
-        )
-        .mockResolvedValue(createMockResponse({ object: 'block', id: 'deleted-block' }));
-
-      const promise = service.deleteAllBlocks('page-123');
-      await jest.advanceTimersByTimeAsync(2000);
-      const result = await promise;
-      expect(result.success).toBe(true);
-      expect(result.deletedCount).toBe(2);
-    });
-
-    it('部分刪除失敗時應保留 best-effort 結果並回傳失敗詳情', async () => {
-      globalThis.fetch
-        .mockResolvedValueOnce(
-          createMockResponse({
-            results: [createMockNotionBlock('block-1'), createMockNotionBlock('block-2')],
-          })
-        )
-        .mockResolvedValueOnce(createMockResponse({ object: 'block', id: 'block-1' }))
-        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400));
-
-      const promise = service.deleteAllBlocks('page-123');
-      await jest.advanceTimersByTimeAsync(10_000);
-      const result = await promise;
-
-      expect(result.success).toBe(true);
-      expect(result.deletedCount).toBe(1);
-      expect(result.failureCount).toBe(1);
-      expect(result.errors).toEqual([
-        expect.objectContaining({
-          id: 'block-2',
-          error: expect.any(String),
-        }),
-      ]);
-      expect(Logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('部分區塊刪除失敗'),
-        expect.objectContaining({
-          action: 'deleteAllBlocks',
-          failureCount: 1,
-          totalBlocks: 2,
-        })
-      );
-      const [, warnContext] = Logger.warn.mock.calls.find(([message]) =>
-        message.includes('部分區塊刪除失敗')
-      );
-      expect(warnContext).toEqual(
-        expect.objectContaining({
-          result: 'partial_failure',
-          failedBlockIds: ['block-2'],
-          sanitizedError: expect.any(Array),
-        })
-      );
-      expect(warnContext).not.toHaveProperty('errors');
-    });
-
-    it('應該處理沒有區塊的情況', async () => {
-      globalThis.fetch.mockResolvedValue({
-        ...mockFetchResponse,
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      });
-
-      const result = await service.deleteAllBlocks('page-123');
-      expect(result.success).toBe(true);
-      expect(result.deletedCount).toBe(0);
-    });
-    it('應該處理分頁情況', async () => {
-      globalThis.fetch
-        // First page
-        .mockResolvedValueOnce(
-          createMockResponse({
-            results: [{ id: 'block-1' }],
-            has_more: true,
-            next_cursor: 'cursor-1',
-          })
-        )
-        // Second page
-        .mockResolvedValueOnce(
-          createMockResponse({
-            results: [{ id: 'block-2' }],
-            has_more: false,
-            next_cursor: null,
-          })
-        )
-        // Delete calls
-        .mockResolvedValue(createMockResponse({ object: 'block', id: 'deleted-block' }));
-
-      const promise = service.deleteAllBlocks('page-123');
-
-      // 無論是否有延遲，快進時間總是安全的
-      await jest.advanceTimersByTimeAsync(10_000);
-
-      const result = await promise;
-      expect(result.success).toBe(true);
-      expect(result.deletedCount).toBe(2);
-      // Calls: 1. List page 1, 2. List page 2, 3. Delete block 1, 4. Delete block 2
-      expect(globalThis.fetch.mock.calls.length).toBeGreaterThanOrEqual(4);
-    });
-  });
-
-  describe('buildPageData', () => {
-    it('應該為 data_source 類型構建頁面資料', () => {
-      const result = service.buildPageData({
-        title: 'Test Page',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        dataSourceType: 'data_source',
-        blocks: [{ type: 'paragraph', paragraph: { rich_text: [] } }],
-      });
-
-      expect(result.pageData.parent.type).toBe('data_source_id');
-      expect(result.pageData.parent.data_source_id).toBe('db-123');
-      expect(result.pageData.properties.Title.title[0].text.content).toBe('Test Page');
-      expect(result.pageData.properties.URL.url).toBe('https://example.com');
-    });
-
-    it('應該透過 data_source_id 父節點為 database 類型構建頁面資料', () => {
-      const result = service.buildPageData({
-        title: 'Database Parent',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-456',
-        dataSourceType: 'database',
-        blocks: [],
-      });
-
-      expect(result.pageData.parent.type).toBe('data_source_id');
-      expect(result.pageData.parent.data_source_id).toBe('db-456');
-    });
-
-    it('應該為 page 類型構建頁面資料', () => {
-      const result = service.buildPageData({
-        title: 'Child Page',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'page-456',
-        dataSourceType: 'page',
-        blocks: [],
-      });
-
-      expect(result.pageData.parent.type).toBe('page_id');
-      expect(result.pageData.parent.page_id).toBe('page-456');
-    });
-
-    it('page parent 應使用 Notion page title property，不應送出 data source schema properties', () => {
-      const result = service.buildPageData({
-        title: 'Child Page',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'page-456',
-        dataSourceType: 'page',
-        blocks: [],
-      });
-
-      expect(result.pageData.properties).toEqual({
-        title: {
-          title: [{ text: { content: 'Child Page' } }],
-        },
-      });
-      expect(result.pageData.properties.Title).toBeUndefined();
-      expect(result.pageData.properties.URL).toBeUndefined();
-    });
-
-    it('當提供時應該加入網站圖示', () => {
-      const result = service.buildPageData({
-        title: 'With Icon',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        blocks: [],
-        siteIcon: 'https://example.com/icon.png',
-      });
-
-      expect(result.pageData.icon).toEqual({
-        type: 'external',
-        external: { url: 'https://example.com/icon.png' },
-      });
-    });
-
-    it('應該為一般 https URL 設定 page cover', () => {
-      const result = service.buildPageData({
-        title: 'With Cover',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        blocks: [],
-        coverImage: 'https://example.com/cover.jpg',
-      });
-
-      expect(result.pageData.cover).toEqual({
-        type: 'external',
-        external: { url: 'https://example.com/cover.jpg' },
-      });
-    });
-
-    it('應該忽略非字串 coverImage 而不拋出錯誤', () => {
-      const result = service.buildPageData({
-        title: 'With Invalid Cover',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        blocks: [],
-        coverImage: { url: 'https://example.com/cover.jpg' },
-      });
-
-      expect(result.pageData.cover).toBeUndefined();
-    });
-
-    it('應該對 Patreon signed URL 跳過 page cover (defense in depth)', () => {
-      const tempUrl =
-        'https://c10.patreonusercontent.com/4/patreon-media/p/post/157239355/abc/eyJ3IjoxMDgwfQ==/1.png?token-hash=ABC123&token-time=1700000000';
-
-      const result = service.buildPageData({
-        title: 'Patreon Page',
-        pageUrl: 'https://www.patreon.com/posts/test',
-        dataSourceId: 'db-123',
-        blocks: [],
-        coverImage: tempUrl,
-      });
-
-      expect(result.pageData.cover).toBeUndefined();
-    });
-
-    it('應該對 patreonusercontent.com 帶 token-time 的 URL 跳過 page cover', () => {
-      const tempUrl =
-        'https://c8.patreonusercontent.com/4/patreon-media/foo.png?token-time=1700000000';
-
-      const result = service.buildPageData({
-        title: 'Patreon Page',
-        pageUrl: 'https://www.patreon.com/posts/test',
-        dataSourceId: 'db-123',
-        blocks: [],
-        coverImage: tempUrl,
-      });
-
-      expect(result.pageData.cover).toBeUndefined();
-    });
-
-    it('應該包含所有圖片區塊並回傳有效的頁面資料', () => {
-      const blocks = [
-        { type: 'paragraph', paragraph: { rich_text: [] } },
-        { type: 'image', image: { external: { url: 'sftp://invalid.com/img.jpg' } } },
-      ];
-
-      const result = service.buildPageData({
-        title: 'Test',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        blocks,
-      });
-
-      // No longer returning skippedCount or validBlocks
-      expect(result.pageData.children).toHaveLength(2);
-    });
-
-    it('子區塊數量不應超過配置的 BATCH_SIZE', () => {
-      const TOTAL_BLOCKS = 150;
-      const blocks = Array.from({ length: TOTAL_BLOCKS })
-        .fill(null)
-        .map(() => ({ type: 'paragraph', paragraph: { rich_text: [] } }));
-
-      const result = service.buildPageData({
-        title: 'Long Article',
-        pageUrl: 'https://example.com',
-        dataSourceId: 'db-123',
-        blocks,
-      });
-
-      expect(result.pageData.children).toHaveLength(NOTION_API.BLOCKS_PER_BATCH);
-    });
-
-    it('針對缺失的選項應使用預設值', () => {
-      const result = service.buildPageData({
-        dataSourceId: 'db-123',
-      });
-
-      expect(result.pageData.properties.Title.title[0].text.content).toBe(
-        CONTENT_QUALITY.DEFAULT_PAGE_TITLE
-      );
-      expect(result.pageData.properties.URL.url).toBe('');
-    });
-  });
-
   describe('refreshPageContent', () => {
-    // Note: global fetch context is already managed by outer describe block
-    // No need to redeclare or manage originalFetch here
-
     it('當刪除出現部分失敗時應該回傳錯誤', async () => {
       globalThis.fetch
         .mockResolvedValueOnce(createMockResponse({ results: [{ id: 'block-1' }] }))
@@ -1059,10 +362,10 @@ describe('NotionService', () => {
       ];
 
       globalThis.fetch
-        .mockResolvedValueOnce(createMockResponse({ results: existingBlocks })) // 取得現有區塊
-        .mockResolvedValueOnce(createMockResponse({ object: 'block' })) // 刪除區塊 2
-        .mockResolvedValueOnce(createMockResponse({ object: 'block' })) // 刪除區塊 3
-        .mockResolvedValueOnce(createMockResponse({ results: [{}] })); // 追加新標記
+        .mockResolvedValueOnce(createMockResponse({ results: existingBlocks }))
+        .mockResolvedValueOnce(createMockResponse({ object: 'block' }))
+        .mockResolvedValueOnce(createMockResponse({ object: 'block' }))
+        .mockResolvedValueOnce(createMockResponse({ results: [{}] }));
 
       const promise = service.updateHighlightsSection(pageId, highlightBlocks);
       await jest.advanceTimersByTimeAsync(10_000);
@@ -1095,7 +398,7 @@ describe('NotionService', () => {
 
     it('應該處理添加新標記失敗', async () => {
       globalThis.fetch
-        .mockResolvedValueOnce(createMockResponse({ results: [] })) // 現有區塊為空
+        .mockResolvedValueOnce(createMockResponse({ results: [] }))
         .mockResolvedValueOnce(
           createMockResponse(
             {
@@ -1107,7 +410,7 @@ describe('NotionService', () => {
             false,
             400
           )
-        ); // 追加失敗
+        );
 
       const promise = service.updateHighlightsSection(pageId, highlightBlocks);
       await jest.advanceTimersByTimeAsync(10_000);
@@ -1134,7 +437,7 @@ describe('NotionService', () => {
             next_cursor: null,
           })
         )
-        .mockResolvedValueOnce(createMockResponse({ results: [] })); // 追加區塊
+        .mockResolvedValueOnce(createMockResponse({ results: [] }));
 
       const promise = service.updateHighlightsSection(pageId, highlightBlocks);
       await jest.advanceTimersByTimeAsync(10_000);
@@ -1166,7 +469,6 @@ describe('NotionService', () => {
       await jest.advanceTimersByTimeAsync(10_000);
       const result = await promise;
 
-      // 確認 fetch 只被呼叫兩次（取得、刪除），且未執行 append
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
       expect(result).toEqual({
         success: true,
@@ -1191,7 +493,7 @@ describe('NotionService', () => {
 
       globalThis.fetch
         .mockResolvedValueOnce(createMockResponse({ results: existingBlocks }))
-        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400)); // 刪除失敗
+        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400));
 
       const promise = service.updateHighlightsSection(pageId, input);
       await jest.advanceTimersByTimeAsync(10_000);
@@ -1226,8 +528,8 @@ describe('NotionService', () => {
 
       globalThis.fetch
         .mockResolvedValueOnce(createMockResponse({ results: existingBlocks }))
-        .mockResolvedValueOnce(createMockResponse({ object: 'block' })) // 標題區塊刪除成功
-        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400)); // 內容區塊刪除失敗
+        .mockResolvedValueOnce(createMockResponse({ object: 'block' }))
+        .mockResolvedValueOnce(createMockResponse({ message: 'Delete failed' }, false, 400));
 
       const promise = service.updateHighlightsSection(pageId, highlightBlocks);
       await jest.advanceTimersByTimeAsync(10_000);
@@ -1260,56 +562,6 @@ describe('NotionService', () => {
     });
   });
 
-  describe('_apiRequest', () => {
-    it('應該在 body 為 null 時不包含 body', async () => {
-      await service._apiRequest('/test', { method: 'POST', body: null });
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.objectContaining({
-          method: 'POST',
-        })
-      );
-      const callArgs = globalThis.fetch.mock.calls[0][1];
-      expect(callArgs.body).toBeUndefined();
-    });
-
-    it('應該在 body 為 undefined 時不包含 body', async () => {
-      await service._apiRequest('/test', { method: 'POST', body: undefined });
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.not.objectContaining({ body: expect.anything() })
-      );
-      const callArgs = globalThis.fetch.mock.calls[0][1];
-      expect(callArgs.body).toBeUndefined();
-    });
-
-    it('應該在 body 為空對象時不包含 body', async () => {
-      await service._apiRequest('/test', { method: 'POST', body: {} });
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.not.objectContaining({
-          body: expect.anything(),
-        })
-      );
-    });
-
-    it('應該正常處理普通對象 body', async () => {
-      const body = { key: 'value' };
-
-      await service._apiRequest('/test', { method: 'POST', body });
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test'),
-        expect.objectContaining({
-          body: JSON.stringify(body),
-        })
-      );
-    });
-  });
-
   describe('內部方法與邊界情況', () => {
     describe('_getScopedClient', () => {
       it('應該優先使用傳入的 client', () => {
@@ -1328,172 +580,6 @@ describe('NotionService', () => {
         const client = service._getScopedClient({ apiKey: tempApiKey });
         expect(client).not.toBe(service.client);
         expect(client).toBeDefined();
-      });
-    });
-
-    describe('_findHighlightSectionBlocks (靜態方法)', () => {
-      const HEADER = '📝 頁面標記';
-
-      it('應該處理只有標題沒有內容的情況', () => {
-        const blocks = [
-          { id: '1', type: 'paragraph' },
-          {
-            id: '2',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER }, plain_text: HEADER }] },
-          },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toHaveLength(1);
-        expect(result).toEqual(['2']);
-      });
-
-      it('應該正確識別標記區塊', () => {
-        const blocks = [
-          { id: '1', type: 'paragraph' },
-          {
-            id: '2',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { id: '3', type: 'paragraph' },
-          { id: '4', type: 'paragraph' },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['2', '3', '4']);
-      });
-
-      it('應該在遇到下一個標題時停止收集', () => {
-        const blocks = [
-          {
-            id: '1',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { id: '2', type: 'paragraph' },
-          { id: '3', type: 'heading_2', heading_2: { rich_text: [] } },
-          { id: '4', type: 'paragraph' },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['1', '2']);
-      });
-
-      it('應該正確處理沒有標記區域的情況', () => {
-        const blocks = [
-          { id: '1', type: 'paragraph' },
-          { id: '2', type: 'heading_2', heading_2: { rich_text: [] } },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual([]);
-      });
-
-      it('應該處理空區塊數組', () => {
-        const result = NotionService._findHighlightSectionBlocks([]);
-        expect(result).toEqual([]);
-      });
-
-      it('應收集所有非標題類型的區塊', () => {
-        const blocks = [
-          {
-            id: '1',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { id: '2', type: 'paragraph' },
-          { id: '3', type: 'image', image: {} }, // 非標題，應收集
-          { id: '4', type: 'paragraph' },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['1', '2', '3', '4']); // 收集所有非標題區塊
-      });
-
-      it('應該忽略沒有 ID 的區塊', () => {
-        const blocks = [
-          {
-            type: 'heading_3',
-            id: '1',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { type: 'paragraph' }, // 無 ID
-          { type: 'paragraph', id: '3' },
-        ];
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['1', '3']);
-      });
-
-      it('應該只處理第一個匹配的標記區域', () => {
-        const blocks = [
-          {
-            type: 'heading_3',
-            id: '1',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { type: 'paragraph', id: '2' },
-          {
-            type: 'heading_3',
-            id: '3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] }, // 第二個相同標題
-          },
-          { type: 'paragraph', id: '4' },
-        ];
-        // 遇到下一個標題類型（包括 heading_3）時應該停止
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['1', '2']);
-      });
-
-      it('應該跳過內容不同的 heading_3', () => {
-        const blocks = [
-          {
-            type: 'heading_3',
-            id: '1',
-            heading_3: { rich_text: [{ text: { content: '其他標題' } }] },
-          },
-          {
-            type: 'heading_3',
-            id: '2',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { type: 'paragraph', id: '3' },
-        ];
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['2', '3']);
-      });
-
-      it('應該將 nullish 區塊視為標記區域邊界以避免擴大刪除範圍', () => {
-        const blocks = [
-          {
-            id: '1',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { id: '2', type: 'paragraph' },
-          null,
-          { id: '3', type: 'paragraph' },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['1', '2']);
-      });
-
-      it('應該處理標記區域在頁面末尾的情況', () => {
-        const blocks = [
-          { id: '1', type: 'paragraph' },
-          { id: '2', type: 'paragraph' },
-          {
-            id: '3',
-            type: 'heading_3',
-            heading_3: { rich_text: [{ text: { content: HEADER } }] },
-          },
-          { id: '4', type: 'paragraph' },
-        ];
-
-        const result = NotionService._findHighlightSectionBlocks(blocks);
-        expect(result).toEqual(['3', '4']);
       });
     });
 
@@ -1534,161 +620,8 @@ describe('NotionService', () => {
         await expect(service.search({ query: 'test' })).rejects.toThrow();
         expect(Logger.error).toHaveBeenCalledWith(
           expect.stringContaining('搜索失敗'),
-          expect.objectContaining({ error: expect.any(Object) }) // Error object or message
-        );
-      });
-    });
-
-    describe('_fetchPageBlocks Error Handling', () => {
-      it('應該處理獲取區塊失敗', async () => {
-        globalThis.fetch.mockResolvedValue(createMockResponse({ message: 'fail' }, false, 400));
-        const result = await service._fetchPageBlocks('id');
-        expect(result.success).toBe(false);
-      });
-    });
-
-    describe('_deleteBlocksByIds Error Handling and Delay', () => {
-      it('應該處理 deleteBlock 異常並記錄警告', async () => {
-        service._executeWithRetry = jest.fn().mockRejectedValue(new Error('crash'));
-        await service._deleteBlocksByIds(['b1']);
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('刪除區塊異常'),
-          expect.objectContaining({
-            action: 'deleteBlocksByIds',
-            phase: 'deleteBlock',
-            blockId: 'b1',
-            error: expect.any(Error),
-          })
-        );
-      });
-
-      it('應該彙整單一 worker unexpected reject 而不中斷整批刪除', async () => {
-        service.config.DELETE_CONCURRENCY = 3;
-        service._deleteBlockById = jest.fn(blockId => {
-          if (blockId === 'b2') {
-            return Promise.reject(new Error('worker crashed'));
-          }
-          return Promise.resolve({ success: true, id: blockId });
-        });
-
-        const result = await service._deleteBlocksByIds(['b1', 'b2', 'b3']);
-
-        expect(service._deleteBlockById).toHaveBeenCalledTimes(3);
-        expect(result).toEqual({
-          successCount: 2,
-          failureCount: 1,
-          errors: [{ id: 'b2', error: 'worker crashed' }],
-        });
-      });
-
-      it('應該保留非 Error rejection 的原始訊息（字串、plain object）', async () => {
-        service.config.DELETE_CONCURRENCY = 3;
-        service._deleteBlockById = jest.fn(blockId => {
-          if (blockId === 'b1') {
-            return Promise.reject('string reason token');
-          }
-          if (blockId === 'b2') {
-            return Promise.reject({ message: 'plain object reason' });
-          }
-          return Promise.reject(null);
-        });
-
-        const result = await service._deleteBlocksByIds(['b1', 'b2', 'b3']);
-
-        expect(result).toEqual({
-          successCount: 0,
-          failureCount: 3,
-          errors: [
-            { id: 'b1', error: 'string reason token' },
-            { id: 'b2', error: 'plain object reason' },
-            { id: 'b3', error: 'Unknown error' },
-          ],
-        });
-      });
-
-      it('應該在批次間執行延遲', async () => {
-        // 使用真實時間或非常小的延遲以避免超時，並確保與 beforeEach 的 timers 狀態一致
-        jest.useRealTimers();
-        service.config.DELETE_CONCURRENCY = 1;
-        service.config.DELETE_BATCH_DELAY_MS = 1;
-        service._executeWithRetry = jest.fn().mockResolvedValue({ success: true });
-
-        await service._deleteBlocksByIds(['b1', 'b2']);
-
-        // 驗證 _executeWithRetry 被調用了兩次
-        expect(service._executeWithRetry).toHaveBeenCalledTimes(2);
-      });
-    });
-
-    describe('建立頁面自動批次處理', () => {
-      it('應該在分批添加失敗時記錄警告', async () => {
-        globalThis.fetch
-          .mockResolvedValueOnce(createMockResponse({ id: 'id' }))
-          .mockResolvedValueOnce(createMockResponse({ message: 'fail' }, false, 400));
-        const manyBlocks = Array.from({ length: 110 }, () => ({ type: 'paragraph' }));
-        await service.createPage(
-          { parent: { data_source_id: 'db' } },
-          { autoBatch: true, allBlocks: manyBlocks }
-        );
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('部分區塊添加失敗'),
-          expect.any(Object)
-        );
-      });
-    });
-
-    describe('更新頁面標題錯誤處理', () => {
-      it('應該處理更新失敗並記錄錯誤', async () => {
-        globalThis.fetch.mockResolvedValue(createMockResponse({ message: 'fail' }, false, 400));
-        await service.updatePageTitle('id', 'Title');
-        expect(Logger.error).toHaveBeenCalledWith(
-          expect.stringContaining('更新標題失敗'),
           expect.objectContaining({ error: expect.any(Object) })
         );
-      });
-    });
-
-    describe('刪除所有區塊警告處理', () => {
-      it('應該在部分失敗時記錄警告', async () => {
-        service._fetchPageBlocks = jest
-          .fn()
-          .mockResolvedValue({ success: true, blocks: [{ id: 'b1' }] });
-        service._deleteBlocksByIds = jest
-          .fn()
-          .mockResolvedValue({ successCount: 0, failureCount: 1, errors: [{ id: 'b1' }] });
-        await service.deleteAllBlocks('id');
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('部分區塊刪除失敗'),
-          expect.any(Object)
-        );
-      });
-    });
-
-    describe('更新頁面內容警告處理', () => {
-      it('應該在標題更新失敗時記錄警告', async () => {
-        service.updatePageTitle = jest.fn().mockResolvedValue({ success: false });
-        service.deleteAllBlocks = jest.fn().mockResolvedValue({ success: true });
-        service.appendBlocksInBatches = jest.fn().mockResolvedValue({ success: true });
-        await service.refreshPageContent('id', [], { updateTitle: true, title: 'T' });
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('標題更新失敗'),
-          expect.any(Object)
-        );
-      });
-    });
-
-    describe('更新標記區塊警告處理', () => {
-      it('應該在刪除標記失敗時記錄警告', async () => {
-        service._fetchPageBlocks = jest.fn().mockResolvedValue({ success: true, blocks: [] });
-        service._deleteBlocksByIds = jest
-          .fn()
-          .mockResolvedValue({ successCount: 0, failureCount: 1, errors: [{ id: 'b1' }] });
-        const result = await service.updateHighlightsSection('id', []);
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('部分標記區塊刪除失敗'),
-          expect.any(Object)
-        );
-        expect(result.success).toBe(false);
       });
     });
   });


### PR DESCRIPTION
### 摘要
重構 NotionService 測試，將測試分為更專注的套件，並引入測試輔助函數以減少重複代碼。

### 變更內容
- 將 NotionService 測試拆分為更專注的測試套件。
- 引入測試輔助函數以簡化測試邏輯。
- 減少 NotionService 認證重試邏輯的重複代碼。
- 整合認證重試刷新失敗的處理。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

