### PR TITLE
feat: add OAuth toggle switch and confirm dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,59 +2,55 @@
 
 ## [2.80.0](https://github.com/cowcfj/save-to-notion/compare/v2.79.0...v2.80.0) (2026-06-17)
 
-
 ### ✨ 新功能
 
-* add URL sanitization for logging privacy ([#693](https://github.com/cowcfj/save-to-notion/issues/693)) ([9417b54](https://github.com/cowcfj/save-to-notion/commit/9417b54a06db3ed0b37026a2e82d460e2ee511d6))
-* 更新 .gitignore 以排除新文件夾和配置 ([417fbb6](https://github.com/cowcfj/save-to-notion/commit/417fbb6053e8bc239588e974f935d112a564dc31))
-
+- add URL sanitization for logging privacy ([#693](https://github.com/cowcfj/save-to-notion/issues/693)) ([9417b54](https://github.com/cowcfj/save-to-notion/commit/9417b54a06db3ed0b37026a2e82d460e2ee511d6))
+- 更新 .gitignore 以排除新文件夾和配置 ([417fbb6](https://github.com/cowcfj/save-to-notion/commit/417fbb6053e8bc239588e974f935d112a564dc31))
 
 ### 🐛 Bug 修復
 
-* **a11y:** add missing form labels for accessibility compliance ([a11e809](https://github.com/cowcfj/save-to-notion/commit/a11e809e23cd6770c7cae569baf9b48428f25b95))
-* add missing form labels for accessibility compliance ([#714](https://github.com/cowcfj/save-to-notion/issues/714)) ([a11e809](https://github.com/cowcfj/save-to-notion/commit/a11e809e23cd6770c7cae569baf9b48428f25b95))
-* enhance URL handling for logging security ([#680](https://github.com/cowcfj/save-to-notion/issues/680)) ([5f0cd18](https://github.com/cowcfj/save-to-notion/commit/5f0cd18111e2aa11da527410f387051e32d4f36f))
-* **gitignore:** 補回 promo-images/*.html 忽略規則 ([6ef1ab5](https://github.com/cowcfj/save-to-notion/commit/6ef1ab5ef2d78d95ec2b82c20c0a56a3a297b8b4))
-
+- **a11y:** add missing form labels for accessibility compliance ([a11e809](https://github.com/cowcfj/save-to-notion/commit/a11e809e23cd6770c7cae569baf9b48428f25b95))
+- add missing form labels for accessibility compliance ([#714](https://github.com/cowcfj/save-to-notion/issues/714)) ([a11e809](https://github.com/cowcfj/save-to-notion/commit/a11e809e23cd6770c7cae569baf9b48428f25b95))
+- enhance URL handling for logging security ([#680](https://github.com/cowcfj/save-to-notion/issues/680)) ([5f0cd18](https://github.com/cowcfj/save-to-notion/commit/5f0cd18111e2aa11da527410f387051e32d4f36f))
+- **gitignore:** 補回 promo-images/\*.html 忽略規則 ([6ef1ab5](https://github.com/cowcfj/save-to-notion/commit/6ef1ab5ef2d78d95ec2b82c20c0a56a3a297b8b4))
 
 ### ♻️ 代碼重構
 
-* clean up toolbar references and update tests ([#708](https://github.com/cowcfj/save-to-notion/issues/708)) ([b05eefd](https://github.com/cowcfj/save-to-notion/commit/b05eefd1291396cc185e32fd1e26b4d77b0104ee))
-* migrate highlight actions to modules ([#715](https://github.com/cowcfj/save-to-notion/issues/715)) ([ea9573c](https://github.com/cowcfj/save-to-notion/commit/ea9573c84a51aaf35e2bbe396986f28e6dae5bc4))
-* reduce complexity in DataSourceManager ([#702](https://github.com/cowcfj/save-to-notion/issues/702)) ([336479a](https://github.com/cowcfj/save-to-notion/commit/336479a57ddf176db4ba3bfbb0247873e95a9b1d))
-* reduce complexity in page complexity detector ([#691](https://github.com/cowcfj/save-to-notion/issues/691)) ([fe69575](https://github.com/cowcfj/save-to-notion/commit/fe69575c73161040a1a92b2faf019d0bda48b481))
-* reduce complexity in popup destination selector ([#698](https://github.com/cowcfj/save-to-notion/issues/698)) ([fc0062e](https://github.com/cowcfj/save-to-notion/commit/fc0062ef248495f1abe604cd22c02620f09c754e))
-* reduce complexity in StorageService and introduce StorageMigrationScanner ([#683](https://github.com/cowcfj/save-to-notion/issues/683)) ([e609358](https://github.com/cowcfj/save-to-notion/commit/e60935889c00760d122ffd15e4333ea2759363b4))
-* reduce drive cloud sync complexity and download complexity ([#703](https://github.com/cowcfj/save-to-notion/issues/703)) ([af4b714](https://github.com/cowcfj/save-to-notion/commit/af4b71487546998e0d2c7bf3c292c744f272442b))
-* reduce duplication in action handler edge case tests ([#706](https://github.com/cowcfj/save-to-notion/issues/706)) ([7e79384](https://github.com/cowcfj/save-to-notion/commit/7e79384651cc4ca9e1dd4ce7952814569679918c))
-* reduce highlight cleanup helper complexity ([#687](https://github.com/cowcfj/save-to-notion/issues/687)) ([743911f](https://github.com/cowcfj/save-to-notion/commit/743911fca42821242a5d330c4dddef6928d8855e))
-* reduce migration handler complexity ([#684](https://github.com/cowcfj/save-to-notion/issues/684)) ([f77ad7f](https://github.com/cowcfj/save-to-notion/commit/f77ad7f711ce7af8975836feed152a8bb35e7bce))
-* reduce path utils complexity ([#690](https://github.com/cowcfj/save-to-notion/issues/690)) ([3d1a4b2](https://github.com/cowcfj/save-to-notion/commit/3d1a4b2489077e5a0de05bf24b75394388d40bd8))
-* reduce popup controller complexity ([#678](https://github.com/cowcfj/save-to-notion/issues/678)) ([b432b74](https://github.com/cowcfj/save-to-notion/commit/b432b7484f37f897b48e401b02bdc7df48ebec40))
-* reduce ProfileManager createProfile complexity ([#697](https://github.com/cowcfj/save-to-notion/issues/697)) ([7c2065e](https://github.com/cowcfj/save-to-notion/commit/7c2065e01ec8a9bd038d5360e38a1205d8b959eb))
-* reduce text search complexity ([#689](https://github.com/cowcfj/save-to-notion/issues/689)) ([ffb33d4](https://github.com/cowcfj/save-to-notion/commit/ffb33d4315cf8d5ac2bed779e603fac1eee0d5b9))
-* rename and extend SAVE_PAGE_FROM_RAIL functionality ([#709](https://github.com/cowcfj/save-to-notion/issues/709)) ([8279251](https://github.com/cowcfj/save-to-notion/commit/8279251b7f1480510d69f6f05d7b036778b2da23))
-* simplify account callback logic and enhance error handling ([#696](https://github.com/cowcfj/save-to-notion/issues/696)) ([a3c96ab](https://github.com/cowcfj/save-to-notion/commit/a3c96ab829a2dcfc56bdaf6fad408e833b9d7fa0))
-* simplify account session refresh logic ([#695](https://github.com/cowcfj/save-to-notion/issues/695)) ([4c56afb](https://github.com/cowcfj/save-to-notion/commit/4c56afb883aafc3766e4e10e2eca486a93106b3f))
-* simplify auth manager logic ([#701](https://github.com/cowcfj/save-to-notion/issues/701)) ([79ad0e4](https://github.com/cowcfj/save-to-notion/commit/79ad0e426db12c4539bfa0635d78c0b52e10b838))
-* simplify HighlightMigration data migration logic ([#685](https://github.com/cowcfj/save-to-notion/issues/685)) ([89ba8b4](https://github.com/cowcfj/save-to-notion/commit/89ba8b4bea0113371a9e578609f19464b0b5f393))
-* simplify InjectionService logging and error handling ([#681](https://github.com/cowcfj/save-to-notion/issues/681)) ([69a3828](https://github.com/cowcfj/save-to-notion/commit/69a382875cc29e6e5af179b48fc2e194345ae2a5))
-* simplify MigrationService complexity ([#686](https://github.com/cowcfj/save-to-notion/issues/686)) ([aa7a42a](https://github.com/cowcfj/save-to-notion/commit/aa7a42adc99739fc803ef3dc7612101a994cb26c))
-* simplify MigrationTool logic and reduce duplication ([#705](https://github.com/cowcfj/save-to-notion/issues/705)) ([44a119a](https://github.com/cowcfj/save-to-notion/commit/44a119aeb091026eacd5383db91f22aa4bda1b48))
-* simplify onboarding logic and error handling ([#700](https://github.com/cowcfj/save-to-notion/issues/700)) ([851fbf0](https://github.com/cowcfj/save-to-notion/commit/851fbf03eeebe8104cfd41d5d23bc6a6ef26a6b7))
-* simplify range handling logic ([#688](https://github.com/cowcfj/save-to-notion/issues/688)) ([969bb92](https://github.com/cowcfj/save-to-notion/commit/969bb92ef21db446af9f78fb659d7312b35ab6c8))
-* simplify RetryManager logic and address warnings ([#692](https://github.com/cowcfj/save-to-notion/issues/692)) ([071eb52](https://github.com/cowcfj/save-to-notion/commit/071eb52da32a4baf7ba3c78189734b79b6ad8183))
-* simplify sidepanel UI complexity ([#699](https://github.com/cowcfj/save-to-notion/issues/699)) ([d42e3d6](https://github.com/cowcfj/save-to-notion/commit/d42e3d6f84f837734717e9227d404573e713ebaa))
-* simplify storage health checks and data validation ([#704](https://github.com/cowcfj/save-to-notion/issues/704)) ([38112af](https://github.com/cowcfj/save-to-notion/commit/38112afb898d2cfa03e2f9b69075250b0f1d4686))
-* 簡化 HighlightMigration 的數據遷移邏輯 ([89ba8b4](https://github.com/cowcfj/save-to-notion/commit/89ba8b4bea0113371a9e578609f19464b0b5f393))
-
+- clean up toolbar references and update tests ([#708](https://github.com/cowcfj/save-to-notion/issues/708)) ([b05eefd](https://github.com/cowcfj/save-to-notion/commit/b05eefd1291396cc185e32fd1e26b4d77b0104ee))
+- migrate highlight actions to modules ([#715](https://github.com/cowcfj/save-to-notion/issues/715)) ([ea9573c](https://github.com/cowcfj/save-to-notion/commit/ea9573c84a51aaf35e2bbe396986f28e6dae5bc4))
+- reduce complexity in DataSourceManager ([#702](https://github.com/cowcfj/save-to-notion/issues/702)) ([336479a](https://github.com/cowcfj/save-to-notion/commit/336479a57ddf176db4ba3bfbb0247873e95a9b1d))
+- reduce complexity in page complexity detector ([#691](https://github.com/cowcfj/save-to-notion/issues/691)) ([fe69575](https://github.com/cowcfj/save-to-notion/commit/fe69575c73161040a1a92b2faf019d0bda48b481))
+- reduce complexity in popup destination selector ([#698](https://github.com/cowcfj/save-to-notion/issues/698)) ([fc0062e](https://github.com/cowcfj/save-to-notion/commit/fc0062ef248495f1abe604cd22c02620f09c754e))
+- reduce complexity in StorageService and introduce StorageMigrationScanner ([#683](https://github.com/cowcfj/save-to-notion/issues/683)) ([e609358](https://github.com/cowcfj/save-to-notion/commit/e60935889c00760d122ffd15e4333ea2759363b4))
+- reduce drive cloud sync complexity and download complexity ([#703](https://github.com/cowcfj/save-to-notion/issues/703)) ([af4b714](https://github.com/cowcfj/save-to-notion/commit/af4b71487546998e0d2c7bf3c292c744f272442b))
+- reduce duplication in action handler edge case tests ([#706](https://github.com/cowcfj/save-to-notion/issues/706)) ([7e79384](https://github.com/cowcfj/save-to-notion/commit/7e79384651cc4ca9e1dd4ce7952814569679918c))
+- reduce highlight cleanup helper complexity ([#687](https://github.com/cowcfj/save-to-notion/issues/687)) ([743911f](https://github.com/cowcfj/save-to-notion/commit/743911fca42821242a5d330c4dddef6928d8855e))
+- reduce migration handler complexity ([#684](https://github.com/cowcfj/save-to-notion/issues/684)) ([f77ad7f](https://github.com/cowcfj/save-to-notion/commit/f77ad7f711ce7af8975836feed152a8bb35e7bce))
+- reduce path utils complexity ([#690](https://github.com/cowcfj/save-to-notion/issues/690)) ([3d1a4b2](https://github.com/cowcfj/save-to-notion/commit/3d1a4b2489077e5a0de05bf24b75394388d40bd8))
+- reduce popup controller complexity ([#678](https://github.com/cowcfj/save-to-notion/issues/678)) ([b432b74](https://github.com/cowcfj/save-to-notion/commit/b432b7484f37f897b48e401b02bdc7df48ebec40))
+- reduce ProfileManager createProfile complexity ([#697](https://github.com/cowcfj/save-to-notion/issues/697)) ([7c2065e](https://github.com/cowcfj/save-to-notion/commit/7c2065e01ec8a9bd038d5360e38a1205d8b959eb))
+- reduce text search complexity ([#689](https://github.com/cowcfj/save-to-notion/issues/689)) ([ffb33d4](https://github.com/cowcfj/save-to-notion/commit/ffb33d4315cf8d5ac2bed779e603fac1eee0d5b9))
+- rename and extend SAVE_PAGE_FROM_RAIL functionality ([#709](https://github.com/cowcfj/save-to-notion/issues/709)) ([8279251](https://github.com/cowcfj/save-to-notion/commit/8279251b7f1480510d69f6f05d7b036778b2da23))
+- simplify account callback logic and enhance error handling ([#696](https://github.com/cowcfj/save-to-notion/issues/696)) ([a3c96ab](https://github.com/cowcfj/save-to-notion/commit/a3c96ab829a2dcfc56bdaf6fad408e833b9d7fa0))
+- simplify account session refresh logic ([#695](https://github.com/cowcfj/save-to-notion/issues/695)) ([4c56afb](https://github.com/cowcfj/save-to-notion/commit/4c56afb883aafc3766e4e10e2eca486a93106b3f))
+- simplify auth manager logic ([#701](https://github.com/cowcfj/save-to-notion/issues/701)) ([79ad0e4](https://github.com/cowcfj/save-to-notion/commit/79ad0e426db12c4539bfa0635d78c0b52e10b838))
+- simplify HighlightMigration data migration logic ([#685](https://github.com/cowcfj/save-to-notion/issues/685)) ([89ba8b4](https://github.com/cowcfj/save-to-notion/commit/89ba8b4bea0113371a9e578609f19464b0b5f393))
+- simplify InjectionService logging and error handling ([#681](https://github.com/cowcfj/save-to-notion/issues/681)) ([69a3828](https://github.com/cowcfj/save-to-notion/commit/69a382875cc29e6e5af179b48fc2e194345ae2a5))
+- simplify MigrationService complexity ([#686](https://github.com/cowcfj/save-to-notion/issues/686)) ([aa7a42a](https://github.com/cowcfj/save-to-notion/commit/aa7a42adc99739fc803ef3dc7612101a994cb26c))
+- simplify MigrationTool logic and reduce duplication ([#705](https://github.com/cowcfj/save-to-notion/issues/705)) ([44a119a](https://github.com/cowcfj/save-to-notion/commit/44a119aeb091026eacd5383db91f22aa4bda1b48))
+- simplify onboarding logic and error handling ([#700](https://github.com/cowcfj/save-to-notion/issues/700)) ([851fbf0](https://github.com/cowcfj/save-to-notion/commit/851fbf03eeebe8104cfd41d5d23bc6a6ef26a6b7))
+- simplify range handling logic ([#688](https://github.com/cowcfj/save-to-notion/issues/688)) ([969bb92](https://github.com/cowcfj/save-to-notion/commit/969bb92ef21db446af9f78fb659d7312b35ab6c8))
+- simplify RetryManager logic and address warnings ([#692](https://github.com/cowcfj/save-to-notion/issues/692)) ([071eb52](https://github.com/cowcfj/save-to-notion/commit/071eb52da32a4baf7ba3c78189734b79b6ad8183))
+- simplify sidepanel UI complexity ([#699](https://github.com/cowcfj/save-to-notion/issues/699)) ([d42e3d6](https://github.com/cowcfj/save-to-notion/commit/d42e3d6f84f837734717e9227d404573e713ebaa))
+- simplify storage health checks and data validation ([#704](https://github.com/cowcfj/save-to-notion/issues/704)) ([38112af](https://github.com/cowcfj/save-to-notion/commit/38112afb898d2cfa03e2f9b69075250b0f1d4686))
+- 簡化 HighlightMigration 的數據遷移邏輯 ([89ba8b4](https://github.com/cowcfj/save-to-notion/commit/89ba8b4bea0113371a9e578609f19464b0b5f393))
 
 ### 🧹 其他變更
 
-* **ci:** optimize coverage checks by splitting workflow and caching ([#720](https://github.com/cowcfj/save-to-notion/issues/720)) ([80507f3](https://github.com/cowcfj/save-to-notion/commit/80507f3e82d88a4ef896d9407091ade5a3a91906))
-* **deps:** bump dompurify from 3.4.7 to 3.4.9 ([#713](https://github.com/cowcfj/save-to-notion/issues/713)) ([d1aa6d7](https://github.com/cowcfj/save-to-notion/commit/d1aa6d703afbfbfc0e065543604b0a956d48438f))
-* reduce release-please PR noise ([#712](https://github.com/cowcfj/save-to-notion/issues/712)) ([cda364b](https://github.com/cowcfj/save-to-notion/commit/cda364b3e699967a079ed08982d836f307ae2309))
-* 整理 .gitignore，去除重複項目並改善組織結構 ([03ed8f0](https://github.com/cowcfj/save-to-notion/commit/03ed8f070a994652e0abfbfb8b2df3ff7f16c31d))
+- **ci:** optimize coverage checks by splitting workflow and caching ([#720](https://github.com/cowcfj/save-to-notion/issues/720)) ([80507f3](https://github.com/cowcfj/save-to-notion/commit/80507f3e82d88a4ef896d9407091ade5a3a91906))
+- **deps:** bump dompurify from 3.4.7 to 3.4.9 ([#713](https://github.com/cowcfj/save-to-notion/issues/713)) ([d1aa6d7](https://github.com/cowcfj/save-to-notion/commit/d1aa6d703afbfbfc0e065543604b0a956d48438f))
+- reduce release-please PR noise ([#712](https://github.com/cowcfj/save-to-notion/issues/712)) ([cda364b](https://github.com/cowcfj/save-to-notion/commit/cda364b3e699967a079ed08982d836f307ae2309))
+- 整理 .gitignore，去除重複項目並改善組織結構 ([03ed8f0](https://github.com/cowcfj/save-to-notion/commit/03ed8f070a994652e0abfbfb8b2df3ff7f16c31d))
 
 ## [2.79.0](https://github.com/cowcfj/save-to-notion/compare/v2.78.0...v2.79.0) (2026-06-09)
 

--- a/manifest.json
+++ b/manifest.json
@@ -29,35 +29,21 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "http://*/*",
-        "https://*/*"
-      ],
-      "js": [
-        "dist/preloader.js"
-      ],
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["dist/preloader.js"],
       "run_at": "document_idle",
       "all_frames": false
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": [
-        "dist/content.bundle.js"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
+      "resources": ["dist/content.bundle.js"],
+      "matches": ["<all_urls>"]
     },
     {
       "$comment": "auth.html：account callback bridge page\nmatches 僅允許正式 Cloudflare Worker origin 與本地開發 origin。\n⚠️ MUST NOT 使用 <all_urls> 或 *.workers.dev 萬用字元，否則會擴大可被 frame 的來源。",
-      "resources": [
-        "auth.html"
-      ],
-      "matches": [
-        "https://save-to-notion-api.bulldrive.workers.dev/*",
-        "http://localhost/*"
-      ]
+      "resources": ["auth.html"],
+      "matches": ["https://save-to-notion-api.bulldrive.workers.dev/*", "http://localhost/*"]
     }
   ],
   "action": {

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -19,6 +19,7 @@ import {
   mergeDataSourceConfig,
 } from '../../scripts/config/shared/storage.js';
 import { initiateNotionOAuth } from '../../scripts/auth/notionOAuthInitiator.js';
+import { confirmDialog } from './confirmDialog.js';
 import {
   exchangeNotionOAuthCode,
   saveNotionOAuthToken,
@@ -373,6 +374,49 @@ export class AuthManager {
   }
 
   /**
+   * 將 OAuth toggle 設為「已連接」(ON, 可操作)
+   *
+   * @private
+   */
+  _setOAuthToggleConnected() {
+    const toggle = this.elements.oauthConnectionToggle;
+    if (!toggle) {
+      return;
+    }
+    toggle.checked = true;
+    toggle.disabled = false;
+  }
+
+  /**
+   * 將 OAuth toggle 設為「未連接」(OFF, 可操作)
+   *
+   * @private
+   */
+  _setOAuthToggleDisconnected() {
+    const toggle = this.elements.oauthConnectionToggle;
+    if (!toggle) {
+      return;
+    }
+    toggle.checked = false;
+    toggle.disabled = false;
+  }
+
+  /**
+   * 將 OAuth toggle 設為 loading (鎖住, 防重複點擊)
+   *
+   * @private
+   * @param {boolean} desiredChecked - loading 期間 toggle 顯示的位置
+   */
+  _setOAuthToggleLoading(desiredChecked) {
+    const toggle = this.elements.oauthConnectionToggle;
+    if (!toggle) {
+      return;
+    }
+    toggle.checked = desiredChecked;
+    toggle.disabled = true;
+  }
+
+  /**
    * 解析已儲存的資料來源 ID
    *
    * @private
@@ -472,13 +516,8 @@ export class AuthManager {
     // 更新 OAuth 狀態區域
     this._renderConnectedStatus(this.elements.oauthStatus, `已連接 — ${workspaceName}`);
 
-    // OAuth 按鈕切換為已連接狀態
-    if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.classList.add('hidden');
-    }
-    if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.classList.remove('hidden');
-    }
+    // OAuth toggle 切換為已連接 (ON)
+    this._setOAuthToggleConnected();
 
     // 手動模式區域顯示提示（OAuth 已連接）
     this._renderConnectedStatus(this.elements.authStatus, UI_MESSAGES.AUTH.STATUS_CONNECTED);
@@ -522,17 +561,12 @@ export class AuthManager {
 
     this._resolveDataSourceIdAndNotice(sourceData);
 
-    // OAuth 區域顯示未連接
+    // OAuth 區域顯示未連接 (toggle OFF)
     if (this.elements.oauthStatus) {
-      this.elements.oauthStatus.textContent = '未連接 OAuth';
+      this.elements.oauthStatus.textContent = UI_MESSAGES.AUTH.OAUTH_STATUS_DISCONNECTED;
       this.elements.oauthStatus.className = AuthManager.CLASS_AUTH_STATUS;
     }
-    if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.classList.remove('hidden');
-    }
-    if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.classList.add('hidden');
-    }
+    this._setOAuthToggleDisconnected();
 
     // 載入資料來源列表
     this._loadDataSourcesSafely(
@@ -609,17 +643,12 @@ export class AuthManager {
       this.elements.disconnectButton.classList.add('hidden');
     }
 
-    // OAuth 區域也顯示未連接
+    // OAuth 區域也顯示未連接 (toggle OFF)
     if (this.elements.oauthStatus) {
-      this.elements.oauthStatus.textContent = '未連接';
+      this.elements.oauthStatus.textContent = UI_MESSAGES.AUTH.OAUTH_STATUS_DISCONNECTED;
       this.elements.oauthStatus.className = AuthManager.CLASS_AUTH_STATUS;
     }
-    if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.classList.remove('hidden');
-    }
-    if (this.elements.oauthDisconnectButton) {
-      this.elements.oauthDisconnectButton.classList.add('hidden');
-    }
+    this._setOAuthToggleDisconnected();
 
     this.ui.hideDataSourceUpgradeNotice();
   }
@@ -649,14 +678,15 @@ export class AuthManager {
   }
 
   /**
-   * 還原 OAuth 連接按鈕至預設狀態
+   * 還原 OAuth toggle 至可操作狀態（解除 loading 鎖定）。
+   * 實際的 ON/OFF 位置由後續 checkAuthStatus() 依真實連接狀態決定。
    *
    * @private
    */
   _restoreOAuthConnectButton() {
-    if (this.elements.oauthConnectButton) {
-      this.elements.oauthConnectButton.disabled = false;
-      this.elements.oauthConnectButton.textContent = UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT;
+    const toggle = this.elements.oauthConnectionToggle;
+    if (toggle) {
+      toggle.disabled = false;
     }
   }
 
@@ -671,6 +701,9 @@ export class AuthManager {
       action: 'startOAuthFlow',
       error: sanitizeApiError(error, 'oauth_flow'),
     });
+
+    // 連接失敗：toggle 回到操作前的 OFF 位置（誠實 toggle 不變式）
+    this._setOAuthToggleDisconnected();
 
     const errorCode = typeof error?.code === 'string' ? error.code : '';
     const errorMsg = this._resolveOAuthErrorMessage(error, errorCode);
@@ -757,10 +790,11 @@ export class AuthManager {
     try {
       Logger.start('開始 Notion OAuth 流程', { action: 'startOAuthFlow' });
 
-      // 更新按鈕為載入狀態
-      if (this.elements.oauthConnectButton) {
-        this.elements.oauthConnectButton.disabled = true;
-        this.elements.oauthConnectButton.textContent = UI_MESSAGES.AUTH.OAUTH_CONNECTING;
+      // toggle 進入 loading：顯示往 ON 滑動並鎖住
+      this._setOAuthToggleLoading(true);
+      if (this.elements.oauthStatus) {
+        this.elements.oauthStatus.textContent = UI_MESSAGES.AUTH.OAUTH_CONNECTING;
+        this.elements.oauthStatus.className = AuthManager.CLASS_AUTH_STATUS;
       }
 
       // 取得 authorization code（CSRF state、authUrl、launchWebAuthFlow、callback 解析、state 驗證皆在共用 initiator 中）
@@ -791,6 +825,18 @@ export class AuthManager {
    * 斷開 OAuth 連接
    */
   async disconnectOAuth() {
+    const confirmed = await confirmDialog({
+      title: UI_MESSAGES.AUTH.OAUTH_DISCONNECT_CONFIRM_TITLE,
+      message: UI_MESSAGES.AUTH.OAUTH_DISCONNECT_CONFIRM_MESSAGE,
+      confirmLabel: UI_MESSAGES.AUTH.OAUTH_DISCONNECT_CONFIRM_OK,
+      cancelLabel: UI_MESSAGES.AUTH.OAUTH_DISCONNECT_CONFIRM_CANCEL,
+      danger: true,
+    });
+    if (!confirmed) {
+      // 取消：toggle 維持 ON（回寫，因為使用者點擊已使 checked 變 false）
+      this._setOAuthToggleConnected();
+      return;
+    }
     try {
       Logger.start('開始斷開 OAuth 連接', { action: 'disconnectOAuth' });
       const syncData = await chrome.storage.sync.get(['notionApiKey']);

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -877,6 +877,7 @@ export class AuthManager {
       const safeMessage = sanitizeApiError(error, 'disconnect_oauth');
       const errorMsg = ErrorHandler.formatUserMessage(safeMessage);
       this.ui.showStatus(`斷開 OAuth 失敗：${errorMsg}`, 'error');
+      this._setOAuthToggleConnected();
     }
   }
 

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -839,6 +839,8 @@ export class AuthManager {
     }
     try {
       Logger.start('開始斷開 OAuth 連接', { action: 'disconnectOAuth' });
+      // toggle 進入 loading：顯示往 OFF 滑動並鎖住，防止斷開期間重複觸發
+      this._setOAuthToggleLoading(false);
       const syncData = await chrome.storage.sync.get(['notionApiKey']);
       const nextAuthEpoch = await getNextAuthEpoch();
 

--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -63,8 +63,7 @@ export class AuthManager {
     this.elements.testApiButton = document.querySelector('#test-api-button');
     this.elements.authStatus = document.querySelector('#auth-status');
     // OAuth 專用元素
-    this.elements.oauthConnectButton = document.querySelector('#oauth-connect-button');
-    this.elements.oauthDisconnectButton = document.querySelector('#oauth-disconnect-button');
+    this.elements.oauthConnectionToggle = document.querySelector('#oauth-connection-toggle');
     this.elements.oauthStatus = document.querySelector('#oauth-status');
     // 其他相關設定
     this.elements.titleTemplateInput = document.querySelector('#title-template');
@@ -130,8 +129,6 @@ export class AuthManager {
    */
   _bindAuthActionButtons() {
     const clickBindings = [
-      [this.elements.oauthConnectButton, () => this.startOAuthFlow()],
-      [this.elements.oauthDisconnectButton, () => this.disconnectOAuth()],
       [this.elements.oauthButton, () => this.startNotionSetup()],
       [this.elements.disconnectButton, () => this.disconnectFromNotion()],
       [this.elements.testApiButton, () => this.testApiKey()],
@@ -140,6 +137,8 @@ export class AuthManager {
     for (const [element, handler] of clickBindings) {
       this._bindClickListener(element, handler);
     }
+
+    this._bindOAuthConnectionToggle();
   }
 
   /**
@@ -155,6 +154,28 @@ export class AuthManager {
     }
 
     element.addEventListener('click', handler);
+  }
+
+  /**
+   * 綁定 OAuth 連接 toggle。
+   * 依 toggle 切換後的 checked 分派：勾選 → 連接；取消勾選 → 斷開。
+   * toggle 位置不直接代表狀態，由 connect/disconnect 流程結果回寫。
+   *
+   * @private
+   */
+  _bindOAuthConnectionToggle() {
+    const toggle = this.elements.oauthConnectionToggle;
+    if (!toggle) {
+      return;
+    }
+
+    toggle.addEventListener('change', () => {
+      if (toggle.checked) {
+        this.startOAuthFlow();
+      } else {
+        this.disconnectOAuth();
+      }
+    });
   }
 
   /**

--- a/pages/options/confirmDialog.js
+++ b/pages/options/confirmDialog.js
@@ -69,9 +69,25 @@ export function confirmDialog({
       result = false;
       dialog.close();
     });
-    // 點擊對話框外部（遮罩層）視為取消
+    // 點擊對話框外部（遮罩層）視為取消。
+    // 原生 <dialog> 的 padding 區域仍屬 dialog 元素本身，單看 event.target
+    // 無法區分「點 padding」與「點遮罩」，故以點擊座標是否落在 dialog 矩形外判定。
     dialog.addEventListener('click', event => {
-      if (event.target === dialog) {
+      if (event.target !== dialog) {
+        return;
+      }
+      const rect = dialog.getBoundingClientRect();
+      // 無 layout（如 jsdom，寬高為 0）→ 無法做座標判定，沿用「點擊即關閉」
+      if (rect.width === 0 && rect.height === 0) {
+        dialog.close();
+        return;
+      }
+      const insideDialog =
+        event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom;
+      if (!insideDialog) {
         dialog.close();
       }
     });

--- a/pages/options/confirmDialog.js
+++ b/pages/options/confirmDialog.js
@@ -13,8 +13,8 @@
  * @returns {Promise<boolean>}
  */
 export function confirmDialog({
-  title,
-  message,
+  title = '',
+  message = '',
   confirmLabel = '確定',
   cancelLabel = '取消',
   danger = false,
@@ -68,6 +68,12 @@ export function confirmDialog({
     cancelBtn.addEventListener('click', () => {
       result = false;
       dialog.close();
+    });
+    // 點擊對話框外部（遮罩層）視為取消
+    dialog.addEventListener('click', e => {
+      if (e.target === dialog) {
+        dialog.close();
+      }
     });
     // Esc 或其他原因關閉 → 視為取消
     dialog.addEventListener('close', () => cleanup(result));

--- a/pages/options/confirmDialog.js
+++ b/pages/options/confirmDialog.js
@@ -70,8 +70,8 @@ export function confirmDialog({
       dialog.close();
     });
     // 點擊對話框外部（遮罩層）視為取消
-    dialog.addEventListener('click', e => {
-      if (e.target === dialog) {
+    dialog.addEventListener('click', event => {
+      if (event.target === dialog) {
         dialog.close();
       }
     });

--- a/pages/options/confirmDialog.js
+++ b/pages/options/confirmDialog.js
@@ -1,0 +1,77 @@
+/**
+ * 可重用的確認對話框（原生 <dialog>）。
+ *
+ * 回傳 Promise<boolean>：確認 resolve(true)，取消／Esc／關閉 resolve(false)。
+ * 焦點鎖定、Esc 關閉、::backdrop 全由瀏覽器原生提供。
+ *
+ * @param {object} opts
+ * @param {string} opts.title - 標題
+ * @param {string} opts.message - 內文
+ * @param {string} [opts.confirmLabel='確定'] - 確認按鈕文字
+ * @param {string} [opts.cancelLabel='取消'] - 取消按鈕文字
+ * @param {boolean} [opts.danger=false] - 確認按鈕是否為危險動作樣式
+ * @returns {Promise<boolean>}
+ */
+export function confirmDialog({
+  title,
+  message,
+  confirmLabel = '確定',
+  cancelLabel = '取消',
+  danger = false,
+} = {}) {
+  return new Promise(resolve => {
+    const dialog = document.createElement('dialog');
+    dialog.className = 'confirm-dialog';
+
+    const titleEl = document.createElement('h2');
+    titleEl.className = 'confirm-dialog-title';
+    titleEl.textContent = title;
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'confirm-dialog-message';
+    messageEl.textContent = message;
+
+    const actions = document.createElement('div');
+    actions.className = 'confirm-dialog-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.dataset.action = 'cancel';
+    cancelBtn.textContent = cancelLabel;
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = danger ? 'btn-danger' : 'btn-primary';
+    confirmBtn.dataset.action = 'confirm';
+    confirmBtn.textContent = confirmLabel;
+
+    actions.append(cancelBtn, confirmBtn);
+    dialog.append(titleEl, messageEl, actions);
+    document.body.append(dialog);
+
+    let result = false;
+    let settled = false;
+    const cleanup = res => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      dialog.remove();
+      resolve(res);
+    };
+
+    confirmBtn.addEventListener('click', () => {
+      result = true;
+      dialog.close();
+    });
+    cancelBtn.addEventListener('click', () => {
+      result = false;
+      dialog.close();
+    });
+    // Esc 或其他原因關閉 → 視為取消
+    dialog.addEventListener('close', () => cleanup(result));
+
+    dialog.showModal();
+  });
+}

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -164,6 +164,7 @@
                     id="oauth-connection-toggle"
                     role="switch"
                     class="switch-input"
+                    aria-label="Notion 連接"
                     aria-describedby="oauth-status"
                   />
                   <span class="switch-track" aria-hidden="true">

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -157,33 +157,19 @@
             <h3>Notion 連接</h3>
             <div class="connection-row">
               <div id="oauth-status" class="auth-status"></div>
-              <div class="auth-actions connection-actions">
-                <button id="oauth-connect-button" class="btn-primary">
-                  <span class="icon"
-                    ><svg
-                      width="16"
-                      height="16"
-                      class="icon-svg"
-                      aria-hidden="true"
-                      focusable="false"
-                    >
-                      <use href="#icon-link" /></svg
-                  ></span>
-                  <span>以 OAuth 連接 Notion</span>
-                </button>
-                <button id="oauth-disconnect-button" class="btn-danger hidden">
-                  <span class="icon"
-                    ><svg
-                      width="16"
-                      height="16"
-                      class="icon-svg"
-                      aria-hidden="true"
-                      focusable="false"
-                    >
-                      <use href="#icon-unlink" /></svg
-                  ></span>
-                  <span>斷開 OAuth</span>
-                </button>
+              <div class="connection-actions">
+                <label class="switch-wrapper" for="oauth-connection-toggle">
+                  <input
+                    type="checkbox"
+                    id="oauth-connection-toggle"
+                    role="switch"
+                    class="switch-input"
+                    aria-describedby="oauth-status"
+                  />
+                  <span class="switch-track" aria-hidden="true">
+                    <span class="switch-knob"></span>
+                  </span>
+                </label>
               </div>
             </div>
             <p class="section-desc text-sm mt-sm">
@@ -330,7 +316,12 @@
                   </div>
 
                   <!-- 回退選擇器 -->
-                  <label for="database-select" class="sr-only" data-ui-message="OPTIONS.DESTINATION.FALLBACK_LABEL">選擇資料庫</label>
+                  <label
+                    for="database-select"
+                    class="sr-only"
+                    data-ui-message="OPTIONS.DESTINATION.FALLBACK_LABEL"
+                    >選擇資料庫</label
+                  >
                   <select id="database-select" class="hidden">
                     <option value="" data-ui-message="OPTIONS.DESTINATION.FALLBACK_OPTION"></option>
                   </select>
@@ -827,10 +818,9 @@
           <div class="card">
             <h3 data-ui-message="OPTIONS.TEMPLATES.PAGE_PROPERTIES_TITLE">頁面屬性</h3>
             <div class="form-group">
-              <label
-                for="title-template"
-                data-ui-message="OPTIONS.TEMPLATES.TITLE_TEMPLATE_LABEL"
-              >頁面標題範本</label>
+              <label for="title-template" data-ui-message="OPTIONS.TEMPLATES.TITLE_TEMPLATE_LABEL"
+                >頁面標題範本</label
+              >
               <input
                 type="text"
                 id="title-template"
@@ -1079,7 +1069,12 @@
                 </svg>
                 <span class="button-text">匯出備份</span>
               </button>
-              <label for="import-data-file" class="sr-only" data-ui-message="OPTIONS.DATA_MANAGEMENT.IMPORT_FILE_LABEL">選擇備份檔案</label>
+              <label
+                for="import-data-file"
+                class="sr-only"
+                data-ui-message="OPTIONS.DATA_MANAGEMENT.IMPORT_FILE_LABEL"
+                >選擇備份檔案</label
+              >
               <input type="file" id="import-data-file" accept=".json" class="hidden" />
               <button id="import-data-button" class="btn-secondary">
                 <svg aria-hidden="true" focusable="false" width="16" height="16" class="icon-svg">

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -155,13 +155,12 @@ function createOptionsPageManagers() {
  */
 function hideOAuthControlsWhenDisabled() {
   if (!BUILD_ENV.ENABLE_OAUTH) {
-    const oauthConnectBtn = document.querySelector('#oauth-connect-button');
-    const oauthDisconnectBtn = document.querySelector('#oauth-disconnect-button');
-    if (oauthConnectBtn) {
-      oauthConnectBtn.classList.add('hidden');
-    }
-    if (oauthDisconnectBtn) {
-      oauthDisconnectBtn.classList.add('hidden');
+    const oauthToggle = document.querySelector('#oauth-connection-toggle');
+    if (oauthToggle) {
+      const oauthCard = oauthToggle.closest('.card');
+      if (oauthCard) {
+        oauthCard.classList.add('hidden');
+      }
     }
   }
 }

--- a/scripts/config/shared/messages.js
+++ b/scripts/config/shared/messages.js
@@ -32,6 +32,12 @@ const AUTH = {
 
   OPENING_NOTION: '正在打開 Notion...',
   OPEN_NOTION_FAILED: error => `打開 Notion 頁面失敗: ${error}`,
+  OAUTH_STATUS_DISCONNECTED: '未連接',
+  OAUTH_DISCONNECT_CONFIRM_TITLE: '斷開 Notion 連接',
+  OAUTH_DISCONNECT_CONFIRM_MESSAGE:
+    '斷開後將清除此擴充功能的 Notion 授權，需要時可重新連接。確定要斷開嗎？',
+  OAUTH_DISCONNECT_CONFIRM_OK: '斷開',
+  OAUTH_DISCONNECT_CONFIRM_CANCEL: '取消',
 };
 
 const SETUP = {

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -188,7 +188,6 @@ button.btn-icon:focus-visible {
   margin: -1px;
   padding: 0;
   border: 0;
-  clip: rect(0 0 0 0);
   clip-path: inset(50%);
   overflow: hidden;
   white-space: nowrap;

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -180,7 +180,6 @@ button.btn-icon:focus-visible {
   cursor: not-allowed;
 }
 
-
 /* 視覺隱藏原生 checkbox，但保留可聚焦/可點擊與螢幕報讀器語意 */
 .switch-input {
   position: absolute;
@@ -253,4 +252,40 @@ button.btn-icon:focus-visible {
   .switch-input:disabled + .switch-track {
     animation: none;
   }
+}
+
+/* === Confirm Dialog (原生 <dialog>) === */
+.confirm-dialog {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  max-width: 360px;
+  width: calc(100% - 2 * var(--spacing-lg));
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
+}
+
+.confirm-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.4);
+  filter: blur(4px); /* 用 filter 代替 backdrop-filter 以符合 stylelint 屬性限制 */
+}
+
+.confirm-dialog-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.confirm-dialog-message {
+  margin: 0 0 var(--spacing-lg);
+  font-size: 14px;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
 }

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -176,6 +176,11 @@ button.btn-icon:focus-visible {
   cursor: pointer;
 }
 
+.switch-wrapper:has(.switch-input:disabled) {
+  cursor: not-allowed;
+}
+
+
 /* 視覺隱藏原生 checkbox，但保留可聚焦/可點擊與螢幕報讀器語意 */
 .switch-input {
   position: absolute;

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -92,10 +92,18 @@ button.btn-icon:hover {
  * sm = 8px (component-internal gaps)，md = 16px (component-level gaps，例如 form group / card section)。
  * 詳見 DESIGN.md「Spacing」章節。
  */
-.mt-sm { margin-top: var(--spacing-sm); }
-.mt-md { margin-top: var(--spacing-md); }
-.mb-sm { margin-bottom: var(--spacing-sm); }
-.mb-md { margin-bottom: var(--spacing-md); }
+.mt-sm {
+  margin-top: var(--spacing-sm);
+}
+.mt-md {
+  margin-top: var(--spacing-md);
+}
+.mb-sm {
+  margin-bottom: var(--spacing-sm);
+}
+.mb-md {
+  margin-bottom: var(--spacing-md);
+}
 
 /* === Focus States === */
 .btn-primary:focus-visible,
@@ -159,4 +167,85 @@ button.btn-icon:focus-visible {
 .status-message.warning {
   background-color: var(--status-warning-bg);
   color: var(--status-warning-text);
+}
+
+/* === Toggle Switch (先行範式：可複製到其他 checkbox) === */
+.switch-wrapper {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+/* 視覺隱藏原生 checkbox，但保留可聚焦/可點擊與螢幕報讀器語意 */
+.switch-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.switch-track {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--color-disabled);
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.switch-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-bg);
+  transition: transform 0.2s ease;
+}
+
+.switch-input:checked + .switch-track {
+  background: var(--color-success);
+}
+
+.switch-input:checked + .switch-track .switch-knob {
+  transform: translateX(20px);
+}
+
+.switch-input:disabled + .switch-track {
+  opacity: 0.6;
+  cursor: not-allowed;
+  animation: switch-pulse 1s ease-in-out infinite;
+}
+
+.switch-input:focus-visible + .switch-track {
+  box-shadow: 0 0 0 3px var(--focus-ring-primary);
+}
+
+@keyframes switch-pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-track,
+  .switch-knob {
+    transition: none;
+  }
+  .switch-input:disabled + .switch-track {
+    animation: none;
+  }
 }

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -266,6 +266,10 @@ button.btn-icon:focus-visible {
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
 }
 
+.confirm-dialog:focus {
+  outline: none;
+}
+
 .confirm-dialog::backdrop {
   background: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(4px);

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -261,14 +261,15 @@ button.btn-icon:focus-visible {
   padding: var(--spacing-lg);
   max-width: 360px;
   width: calc(100% - 2 * var(--spacing-lg));
-  background-color: var(--color-bg);
+  background: var(--color-bg);
   color: var(--color-text);
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
 }
 
 .confirm-dialog::backdrop {
-  background-color: rgba(0, 0, 0, 0.4);
-  filter: blur(4px); /* 用 filter 代替 backdrop-filter 以符合 stylelint 屬性限制 */
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .confirm-dialog-title {

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -80,14 +80,11 @@ function renderBasicAuthDom() {
         <input type="checkbox" id="enable-debug-logs" />
     `;
 }
-
 function renderExtendedAuthDom() {
   document.body.innerHTML = `
       <div id="auth-status"></div>
       <div id="oauth-status"></div>
       <button id="oauth-button"></button>
-      <button id="oauth-connect-button">${UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT}</button>
-      <button id="oauth-disconnect-button"></button>
       <button id="disconnect-button"></button>
       <input type="checkbox" id="oauth-connection-toggle" />
       <input id="api-key" />

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -19,6 +19,9 @@ jest.mock('../../../scripts/config/env/index.js', () => ({
   },
 }));
 jest.mock('../../../pages/options/UIManager.js');
+jest.mock('../../../pages/options/confirmDialog.js', () => ({
+  confirmDialog: jest.fn().mockResolvedValue(true),
+}));
 jest.mock('../../../scripts/utils/Logger.js', () => ({
   __esModule: true,
   default: {
@@ -86,6 +89,7 @@ function renderExtendedAuthDom() {
       <button id="oauth-connect-button">${UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT}</button>
       <button id="oauth-disconnect-button"></button>
       <button id="disconnect-button"></button>
+      <input type="checkbox" id="oauth-connection-toggle" />
       <input id="api-key" />
       <input id="database-id" />
       <input id="title-template" />
@@ -488,12 +492,8 @@ describe('AuthManager Extended', () => {
       expect(document.querySelector('#oauth-status').textContent).toContain(
         '已連接 — My Workspace'
       );
-      expect(document.querySelector('#oauth-connect-button').classList.contains('hidden')).toBe(
-        true
-      );
-      expect(document.querySelector('#oauth-disconnect-button').classList.contains('hidden')).toBe(
-        false
-      );
+      expect(document.querySelector('#oauth-connection-toggle').checked).toBe(true);
+      expect(document.querySelector('#oauth-connection-toggle').disabled).toBe(false);
       expect(mockLoadDatabases).toHaveBeenCalledWith('oauth_token_123');
       expect(document.querySelector('#database-id').value).toBe('ds_local_123');
       expect(document.querySelector('#title-template').value).toBe('{title} - custom');
@@ -753,10 +753,7 @@ describe('AuthManager Extended', () => {
         expect.stringContaining('已成功連接 Notion'),
         'success'
       );
-      expect(document.querySelector('#oauth-connect-button').disabled).toBe(false);
-      expect(document.querySelector('#oauth-connect-button').textContent).toBe(
-        UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT
-      );
+      expect(document.querySelector('#oauth-connection-toggle').disabled).toBe(false);
     });
 
     test.each([
@@ -919,10 +916,7 @@ describe('AuthManager Extended', () => {
         error: expect.any(String),
       });
       expect(chrome.storage.session.remove).toHaveBeenCalledWith('oauthState');
-      expect(document.querySelector('#oauth-connect-button').disabled).toBe(false);
-      expect(document.querySelector('#oauth-connect-button').textContent).toBe(
-        UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT
-      );
+      expect(document.querySelector('#oauth-connection-toggle').disabled).toBe(false);
     });
 
     test('Identity API 不可用時應顯示明確錯誤且不進入 OAuth 流程', async () => {
@@ -940,10 +934,7 @@ describe('AuthManager Extended', () => {
         `OAuth 連接失敗：${UI_MESSAGES.AUTH.OAUTH_UNAVAILABLE}`,
         'error'
       );
-      expect(document.querySelector('#oauth-connect-button').disabled).toBe(false);
-      expect(document.querySelector('#oauth-connect-button').textContent).toBe(
-        UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT
-      );
+      expect(document.querySelector('#oauth-connection-toggle').disabled).toBe(false);
     });
 
     test('缺少 OAUTH_CLIENT_ID 時應記錄錯誤、清理 state 並恢復按鈕', async () => {
@@ -964,10 +955,7 @@ describe('AuthManager Extended', () => {
         expect(chrome.storage.session.set).not.toHaveBeenCalled();
         expect(chrome.identity.launchWebAuthFlow).not.toHaveBeenCalled();
         expect(chrome.storage.session.remove).toHaveBeenCalledWith('oauthState');
-        expect(document.querySelector('#oauth-connect-button').disabled).toBe(false);
-        expect(document.querySelector('#oauth-connect-button').textContent).toBe(
-          UI_MESSAGES.AUTH.OAUTH_ACTION_CONNECT
-        );
+        expect(document.querySelector('#oauth-connection-toggle').disabled).toBe(false);
       } finally {
         BUILD_ENV.OAUTH_CLIENT_ID = originalOAuthClientId;
       }
@@ -1053,6 +1041,19 @@ describe('AuthManager Extended', () => {
         expect.stringContaining('斷開 OAuth 失敗'),
         'error'
       );
+    });
+
+    test('取消斷開 OAuth 時應維持 toggle ON 且不執行清除', async () => {
+      const { confirmDialog } = require('../../../pages/options/confirmDialog.js');
+      confirmDialog.mockResolvedValueOnce(false);
+
+      const checkAuthStatusSpy = jest.spyOn(authManager, 'checkAuthStatus').mockResolvedValue();
+
+      await authManager.disconnectOAuth();
+
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+      expect(checkAuthStatusSpy).not.toHaveBeenCalled();
+      expect(document.querySelector('#oauth-connection-toggle').checked).toBe(true);
     });
   });
 

--- a/tests/unit/options/confirmDialog.test.js
+++ b/tests/unit/options/confirmDialog.test.js
@@ -1,5 +1,5 @@
 // @jest-environment jsdom
-/* global document, HTMLDialogElement */
+/* global document, HTMLDialogElement, MouseEvent */
 import { confirmDialog } from '../../../pages/options/confirmDialog.js';
 
 // jsdom 28 未實作 showModal/close — polyfill 成可觀測的 open 屬性切換
@@ -85,5 +85,59 @@ describe('confirmDialog', () => {
 
     cancelBtn.click();
     await promise;
+  });
+
+  test('點擊對話框內部 padding（座標落在範圍內）不應關閉', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { dialog } = getDialogButtons();
+    // 模擬實際 layout：dialog 佔據 (100,100)–(300,250)
+    dialog.getBoundingClientRect = () => ({
+      left: 100,
+      top: 100,
+      right: 300,
+      bottom: 250,
+      width: 200,
+      height: 150,
+    });
+
+    // 點擊 padding 區域：event.target === dialog，但座標在 rect 內
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 110, clientY: 110 }));
+
+    expect(dialog.open).toBe(true);
+    expect(document.querySelector('dialog')).not.toBeNull();
+
+    // 收尾，避免 pending promise
+    dialog.close();
+    await promise;
+  });
+
+  test('點擊遮罩層（座標落在範圍外）應 resolve(false) 並關閉', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { dialog } = getDialogButtons();
+    dialog.getBoundingClientRect = () => ({
+      left: 100,
+      top: 100,
+      right: 300,
+      bottom: 250,
+      width: 200,
+      height: 150,
+    });
+
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 10, clientY: 10 }));
+
+    const result = await promise;
+    expect(result).toBe(false);
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  test('jsdom 零尺寸 rect 下點擊 dialog 仍關閉（測試環境相容）', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { dialog } = getDialogButtons();
+    // jsdom 預設 getBoundingClientRect 全為 0，沒有 layout
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 0, clientY: 0 }));
+
+    const result = await promise;
+    expect(result).toBe(false);
+    expect(document.querySelector('dialog')).toBeNull();
   });
 });

--- a/tests/unit/options/confirmDialog.test.js
+++ b/tests/unit/options/confirmDialog.test.js
@@ -58,6 +58,7 @@ describe('confirmDialog', () => {
     const result = await promise;
 
     expect(result).toBe(false);
+    expect(document.querySelector('dialog')).toBeNull();
   });
 
   test('danger=true 時確認按鈕帶 btn-danger class', async () => {

--- a/tests/unit/options/confirmDialog.test.js
+++ b/tests/unit/options/confirmDialog.test.js
@@ -1,0 +1,88 @@
+// @jest-environment jsdom
+/* global document, HTMLDialogElement */
+import { confirmDialog } from '../../../pages/options/confirmDialog.js';
+
+// jsdom 28 未實作 showModal/close — polyfill 成可觀測的 open 屬性切換
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+    this.dispatchEvent(new globalThis.Event('close'));
+  };
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function getDialogButtons() {
+  const dialog = document.querySelector('dialog');
+  return {
+    dialog,
+    confirmBtn: dialog.querySelector('[data-action="confirm"]'),
+    cancelBtn: dialog.querySelector('[data-action="cancel"]'),
+  };
+}
+
+describe('confirmDialog', () => {
+  test('開啟後點擊確認 → resolve(true) 並移除 dialog', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { dialog, confirmBtn } = getDialogButtons();
+    expect(dialog.open).toBe(true);
+
+    confirmBtn.click();
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  test('點擊取消 → resolve(false)', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { cancelBtn } = getDialogButtons();
+
+    cancelBtn.click();
+    const result = await promise;
+
+    expect(result).toBe(false);
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  test('dialog close 事件（Esc）→ resolve(false)', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M' });
+    const { dialog } = getDialogButtons();
+
+    dialog.close();
+    const result = await promise;
+
+    expect(result).toBe(false);
+  });
+
+  test('danger=true 時確認按鈕帶 btn-danger class', async () => {
+    const promise = confirmDialog({ title: 'T', message: 'M', danger: true });
+    const { confirmBtn } = getDialogButtons();
+
+    expect(confirmBtn.classList.contains('btn-danger')).toBe(true);
+
+    confirmBtn.click();
+    await promise;
+  });
+
+  test('自訂按鈕文字', async () => {
+    const promise = confirmDialog({
+      title: 'T',
+      message: 'M',
+      confirmLabel: '刪除',
+      cancelLabel: '保留',
+    });
+    const { confirmBtn, cancelBtn } = getDialogButtons();
+
+    expect(confirmBtn.textContent).toBe('刪除');
+    expect(cancelBtn.textContent).toBe('保留');
+
+    cancelBtn.click();
+    await promise;
+  });
+});

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -156,8 +156,7 @@ describe('options.html 結構', () => {
     );
     expect(zoomLabel?.dataset.uiMessage).toBe('OPTIONS.INTERFACE.ZOOM_LABEL');
     expect(zoomLabel?.textContent.trim()).toBe(UI_MESSAGES.OPTIONS.INTERFACE.ZOOM_LABEL);
-    expect(oauthRow?.querySelector('#oauth-connect-button')).not.toBeNull();
-    expect(oauthRow?.querySelector('#oauth-disconnect-button')).not.toBeNull();
+    expect(oauthRow?.querySelector('#oauth-connection-toggle')).not.toBeNull();
     expect(manualRow?.querySelector('#oauth-button')).not.toBeNull();
     expect(manualRow?.querySelector('#disconnect-button')).not.toBeNull();
     expect(css).toMatch(

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -2,6 +2,42 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { UI_MESSAGES } from '../../../scripts/config/shared/messages.js';
 
+const OPTIONS_HTML_PATH = path.resolve(__dirname, '../../../pages/options/options.html');
+
+const readOptionsHtml = () => fs.readFileSync(OPTIONS_HTML_PATH, 'utf8');
+
+const parseOptionsHtml = html => new DOMParser().parseFromString(html, 'text/html');
+
+const queryRequiredElement = (doc, selector) => {
+  const element = doc.querySelector(selector);
+
+  expect(element).not.toBeNull();
+
+  return element;
+};
+
+const expectChildElement = (parent, selector) => {
+  expect(parent.querySelector(selector)).not.toBeNull();
+};
+
+const expectElementDatasetValue = (doc, { selector, datasetKey, expectedValue }) => {
+  const element = queryRequiredElement(doc, selector);
+
+  expect(element.dataset[datasetKey]).toBe(expectedValue);
+};
+
+const expectEmptyElementText = (doc, selector) => {
+  const element = queryRequiredElement(doc, selector);
+
+  expect(element.textContent.trim()).toBe('');
+};
+
+const expectMissingElementAttribute = (doc, { selector, attribute }) => {
+  const element = queryRequiredElement(doc, selector);
+
+  expect(element.getAttribute(attribute)).toBeNull();
+};
+
 describe('options.html 結構', () => {
   test('health-status 應為 polite live region 的 output 標籤', () => {
     const htmlPath = path.resolve(__dirname, '../../../pages/options/options.html');
@@ -68,27 +104,25 @@ describe('options.html 結構', () => {
   });
 
   test('保存目標新增表單應將名稱獨立成行，選擇器與 ID 欄位並列成行', () => {
-    const htmlPath = path.resolve(__dirname, '../../../pages/options/options.html');
-    const html = fs.readFileSync(htmlPath, 'utf8');
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const html = readOptionsHtml();
+    const doc = parseOptionsHtml(html);
 
-    const nameRow = doc.querySelector('.destination-profile-name-row');
-    const targetRow = doc.querySelector('.destination-target-row');
-    const selectorColumn = doc.querySelector('.destination-target-select');
-    const manualColumn = doc.querySelector('.destination-target-manual');
-    const manualLabel = doc.querySelector('label[for="database-id"]');
-    const helpText = doc.querySelector('.destination-target-help');
+    const nameRow = queryRequiredElement(doc, '.destination-profile-name-row');
+    queryRequiredElement(doc, '.destination-target-row');
+    const selectorColumn = queryRequiredElement(doc, '.destination-target-select');
+    const manualColumn = queryRequiredElement(doc, '.destination-target-manual');
+    const manualLabel = queryRequiredElement(doc, 'label[for="database-id"]');
+    const helpText = queryRequiredElement(doc, '.destination-target-help');
 
-    expect(nameRow?.querySelector('#destination-profile-name')).not.toBeNull();
-    expect(targetRow).not.toBeNull();
-    expect(selectorColumn?.querySelector('#database-selector-container')).not.toBeNull();
-    expect(manualColumn?.querySelector('#database-id')).not.toBeNull();
-    expect(manualLabel?.classList.contains('sr-only')).toBe(false);
-    expect(manualLabel?.dataset.uiMessage).toBe('OPTIONS.DESTINATION.MANUAL_ID_LABEL');
-    expect(manualLabel?.textContent.trim()).toBe(UI_MESSAGES.OPTIONS.DESTINATION.MANUAL_ID_LABEL);
-    expect(helpText?.dataset.uiComposite).toBe('destination-target-help');
+    expectChildElement(nameRow, '#destination-profile-name');
+    expectChildElement(selectorColumn, '#database-selector-container');
+    expectChildElement(manualColumn, '#database-id');
+    expect(manualLabel.classList.contains('sr-only')).toBe(false);
+    expect(manualLabel.dataset.uiMessage).toBe('OPTIONS.DESTINATION.MANUAL_ID_LABEL');
+    expect(manualLabel.textContent.trim()).toBe(UI_MESSAGES.OPTIONS.DESTINATION.MANUAL_ID_LABEL);
+    expect(helpText.dataset.uiComposite).toBe('destination-target-help');
     expect(html).not.toContain(UI_MESSAGES.OPTIONS.DESTINATION.HELP_PREFIX);
-    expect(helpText?.textContent).not.toContain('上方欄位');
+    expect(helpText.textContent).not.toContain('上方欄位');
   });
 
   test('表單 label 在初始 HTML 中應關聯控制項並提供可讀文字', () => {
@@ -113,31 +147,31 @@ describe('options.html 結構', () => {
   });
 
   test('保存目標靜態文案應以 UI_MESSAGES key 掛載，避免 HTML 重複硬編碼', () => {
-    const htmlPath = path.resolve(__dirname, '../../../pages/options/options.html');
-    const html = fs.readFileSync(htmlPath, 'utf8');
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    expect.hasAssertions();
 
-    expect(doc.querySelector('#database-search')?.dataset.uiPlaceholder).toBe(
-      'OPTIONS.DESTINATION.SEARCH_PLACEHOLDER'
-    );
-    expect(doc.querySelector('#data-source-count')?.dataset.uiMessage).toBe(
-      'DATA_SOURCE.LABEL_DATA_SOURCE'
-    );
-    expect(doc.querySelector('#refresh-databases')?.dataset.uiTitle).toBe(
-      'OPTIONS.DESTINATION.REFRESH_TITLE'
-    );
-    expect(doc.querySelector('#add-destination-profile')?.dataset.uiMessage).toBe(
-      'OPTIONS.DESTINATION.ADD_BUTTON'
-    );
-    expect(doc.querySelector('#save-button')?.dataset.uiMessage).toBe(
-      'OPTIONS.SETTINGS.SAVE_BUTTON'
-    );
+    const html = readOptionsHtml();
+    const doc = parseOptionsHtml(html);
 
-    expect(doc.querySelector('#data-source-count')?.textContent.trim()).toBe('');
-    expect(doc.querySelector('#add-destination-profile')?.textContent.trim()).toBe('');
-    expect(doc.querySelector('#save-button')?.textContent.trim()).toBe('');
-    expect(doc.querySelector('#database-search')?.getAttribute('placeholder')).toBeNull();
-    expect(doc.querySelector('#refresh-databases')?.getAttribute('title')).toBeNull();
+    [
+      ['#database-search', 'uiPlaceholder', 'OPTIONS.DESTINATION.SEARCH_PLACEHOLDER'],
+      ['#data-source-count', 'uiMessage', 'DATA_SOURCE.LABEL_DATA_SOURCE'],
+      ['#refresh-databases', 'uiTitle', 'OPTIONS.DESTINATION.REFRESH_TITLE'],
+      ['#add-destination-profile', 'uiMessage', 'OPTIONS.DESTINATION.ADD_BUTTON'],
+      ['#save-button', 'uiMessage', 'OPTIONS.SETTINGS.SAVE_BUTTON'],
+    ].forEach(([selector, datasetKey, expectedValue]) => {
+      expectElementDatasetValue(doc, { selector, datasetKey, expectedValue });
+    });
+
+    ['#data-source-count', '#add-destination-profile', '#save-button'].forEach(selector => {
+      expectEmptyElementText(doc, selector);
+    });
+
+    [
+      ['#database-search', 'placeholder'],
+      ['#refresh-databases', 'title'],
+    ].forEach(([selector, attribute]) => {
+      expectMissingElementAttribute(doc, { selector, attribute });
+    });
   });
 
   test('一般設定 UI 應保留精簡文案與連接操作列', () => {

--- a/tests/unit/options/optionsInitialization.test.js
+++ b/tests/unit/options/optionsInitialization.test.js
@@ -286,21 +286,19 @@ describe('optionsInitialization', () => {
       );
     });
 
-    it('當 OAuth 被停用時應隱藏連接按鈕', () => {
+    it('當 OAuth 被停用時應隱藏整個 OAuth 卡片區塊', () => {
       BUILD_ENV.ENABLE_OAUTH = false;
       document.body.innerHTML += `
-        <button id="oauth-connect-button" style="display:block"></button>
-        <button id="oauth-disconnect-button" style="display:block"></button>
+        <div class="card">
+          <input type="checkbox" id="oauth-connection-toggle" />
+        </div>
       `;
 
       initOptions();
 
-      expect(document.querySelector('#oauth-connect-button').classList.contains('hidden')).toBe(
-        true
-      );
-      expect(document.querySelector('#oauth-disconnect-button').classList.contains('hidden')).toBe(
-        true
-      );
+      const toggle = document.querySelector('#oauth-connection-toggle');
+      const card = toggle?.closest('.card');
+      expect(card?.classList.contains('hidden')).toBe(true);
     });
 
     it('應監聽 storageUsageUpdate 事件並更新儲存使用量', () => {


### PR DESCRIPTION
### 摘要
新增 OAuth 連接的切換開關，並實作確認對話框以確認斷開連接的操作。

### 變更內容
- 新增可重用的切換開關 CSS 原件。
- 修正切換開關的禁用狀態游標樣式。
- 新增 OAuth 斷開連接確認訊息的多語言鍵值。
- 實作可重用的確認對話框元件，並使用原生對話框。
- 精煉確認對話框的樣式，並新增背景點擊關閉的 UX。
- 更新 OAuth 連接/斷開按鈕為切換開關。
- 優化 OAuth 連接的邏輯，並處理斷開失敗的情況。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

