### PR TITLE
feat: add active profile management and session storage support

### DIFF
--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -34,6 +34,7 @@ export class AuthManager {
   // 將常數綁定到類別上供實例使用
   static CLASS_AUTH_SUCCESS = 'auth-status success';
   static CLASS_AUTH_STATUS = 'auth-status';
+  static ATTR_ARIA_CHECKED = 'aria-checked';
   static MIN_API_KEY_LENGTH_FOR_DATASOURCE_LOAD = 20;
   static API_KEY_INPUT_DEBOUNCE_MS = 1000;
 
@@ -384,6 +385,7 @@ export class AuthManager {
       return;
     }
     toggle.checked = true;
+    toggle.setAttribute(AuthManager.ATTR_ARIA_CHECKED, 'true');
     toggle.disabled = false;
   }
 
@@ -398,6 +400,7 @@ export class AuthManager {
       return;
     }
     toggle.checked = false;
+    toggle.setAttribute(AuthManager.ATTR_ARIA_CHECKED, 'false');
     toggle.disabled = false;
   }
 
@@ -413,6 +416,7 @@ export class AuthManager {
       return;
     }
     toggle.checked = desiredChecked;
+    toggle.setAttribute(AuthManager.ATTR_ARIA_CHECKED, desiredChecked ? 'true' : 'false');
     toggle.disabled = true;
   }
 

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -727,7 +727,7 @@ select:focus {
 
 .destination-profile-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 8px;
   align-items: center;
   min-height: 48px;
@@ -738,7 +738,7 @@ select:focus {
   background: var(--card-bg);
 }
 
-.destination-profile-row > div:first-child {
+.destination-profile-row > div:first-of-type {
   min-width: 0;
 }
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -165,6 +165,7 @@
                     role="switch"
                     class="switch-input"
                     aria-label="Notion 連接"
+                    aria-checked="false"
                     aria-describedby="oauth-status"
                   />
                   <span class="switch-track" aria-hidden="true">

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -50,6 +50,7 @@ const NOTION_ID_LENGTH = 32;
 const NOTION_UUID_SEGMENT_LENGTH = 36;
 const NOTION_ID_SEGMENT_LENGTHS = new Set([NOTION_ID_LENGTH, NOTION_UUID_SEGMENT_LENGTH]);
 const NOTION_ID_HEX_DIGITS = new Set('0123456789abcdefABCDEF'.split(''));
+const ARIA_HIDDEN_ATTRIBUTE = 'aria-hidden';
 let destinationProfilesUIController = null;
 
 function normalizeDestinationProfileName(value) {
@@ -88,6 +89,46 @@ function resolveCreateDestinationProfileErrorMessage(error) {
     : UI_MESSAGES.OPTIONS.DESTINATION.CREATE_FAILED;
 }
 
+function hasRemainingDestinationProfiles(remainingProfiles) {
+  if (!remainingProfiles) {
+    return false;
+  }
+  return remainingProfiles.length > 0;
+}
+
+function shouldReassignActiveDestinationProfile(
+  activeProfileId,
+  deletedProfileId,
+  remainingProfiles
+) {
+  if (activeProfileId !== deletedProfileId) {
+    return false;
+  }
+  return hasRemainingDestinationProfiles(remainingProfiles);
+}
+
+function resolveDestinationProfileId(profile) {
+  if (!profile) {
+    return null;
+  }
+  return profile.id ?? null;
+}
+
+function warnActiveDestinationProfileLookupFailure({
+  action,
+  error,
+  errorContext,
+  shouldLogConsoleError = false,
+}) {
+  if (shouldLogConsoleError) {
+    console.error('DEBUG ACTIVE PROFILE ERROR:', error);
+  }
+  Logger.warn('讀取啟用保存目標失敗', {
+    action,
+    error: sanitizeApiError(error, errorContext),
+  });
+}
+
 function createDestinationProfileService() {
   return new ProfileManager({
     repository: new LocalDestinationProfileRepository(),
@@ -118,10 +159,10 @@ function activateSidebarSection(sectionName, navItems, sections) {
   for (const section of sections) {
     if (section.id === targetSectionId) {
       section.classList.add('active');
-      section.setAttribute('aria-hidden', 'false');
+      section.setAttribute(ARIA_HIDDEN_ATTRIBUTE, 'false');
     } else {
       section.classList.remove('active');
-      section.setAttribute('aria-hidden', 'true');
+      section.setAttribute(ARIA_HIDDEN_ATTRIBUTE, 'true');
     }
   }
 
@@ -369,7 +410,7 @@ async function initDestinationProfilesUI(ui) {
 
     const track = document.createElement('span');
     track.className = 'switch-track';
-    track.setAttribute('aria-hidden', 'true');
+    track.setAttribute(ARIA_HIDDEN_ATTRIBUTE, 'true');
     const knob = document.createElement('span');
     knob.className = 'switch-knob';
     track.append(knob);
@@ -480,64 +521,90 @@ async function initDestinationProfilesUI(ui) {
     addButton.title = limitMessage;
   };
 
-  const renderDestinationProfiles = async () => {
-    let profiles = cachedProfiles;
-    let entitlement = DEFAULT_DESTINATION_ENTITLEMENT;
-
+  const listDestinationProfilesForRender = async () => {
     try {
-      profiles = await service.listProfiles();
+      const profiles = await service.listProfiles();
       cachedProfiles = profiles;
+      return profiles;
     } catch (error) {
       const safeError = sanitizeApiError(error, 'destinationProfileList');
       Logger.warn('讀取保存目標列表失敗', {
         action: 'renderDestinationProfiles',
         error: safeError,
       });
+      return cachedProfiles;
     }
+  };
 
+  const resolveDestinationEntitlementForRender = async () => {
     try {
-      entitlement = await service.getDestinationEntitlement();
+      return await service.getDestinationEntitlement();
     } catch (error) {
       const safeError = sanitizeApiError(error, 'destinationProfileEntitlement');
       Logger.warn('讀取保存目標權限失敗', {
         action: 'renderDestinationProfiles',
         error: safeError,
       });
+      return DEFAULT_DESTINATION_ENTITLEMENT;
     }
+  };
 
-    list.innerHTML = '';
-
-    let activeProfileId = null;
+  const resolveActiveDestinationProfileId = async (
+    action,
+    errorContext,
+    shouldLogConsoleError = false
+  ) => {
+    if (typeof service.getActiveProfile !== 'function') {
+      return null;
+    }
     try {
-      if (typeof service.getActiveProfile === 'function') {
-        const activeProfile = await service.getActiveProfile();
-        activeProfileId = activeProfile?.id ?? null;
-      }
+      const activeProfile = await service.getActiveProfile();
+      return resolveDestinationProfileId(activeProfile);
     } catch (error) {
-      console.error('DEBUG ACTIVE PROFILE ERROR:', error);
-      Logger.warn('讀取啟用保存目標失敗', {
-        action: 'renderDestinationProfiles',
-        error: sanitizeApiError(error, 'destinationProfileActive'),
+      warnActiveDestinationProfileLookupFailure({
+        action,
+        error,
+        errorContext,
+        shouldLogConsoleError,
       });
+      return null;
     }
+  };
 
+  const createDestinationProfileRow = (profile, activeProfileId, canDeleteProfile) => {
+    const isActive = profile.id === activeProfileId;
+    const row = document.createElement('div');
+    row.className = 'destination-profile-row';
+    row.setAttribute('role', 'radio');
+    row.setAttribute('aria-checked', isActive ? 'true' : 'false');
+    row.style.borderLeftColor = profile.color || '#2563eb';
+
+    const activeSwitch = createDestinationActiveSwitch(profile, isActive);
+    const content = renderProfileContent(profile);
+    const actions = renderProfileActions(profile, canDeleteProfile);
+
+    row.append(activeSwitch, content, actions);
+    return row;
+  };
+
+  const renderDestinationProfileRows = (profiles, activeProfileId) => {
+    list.innerHTML = '';
+    const canDeleteProfile = profiles.length > 1;
     for (const profile of profiles) {
-      const isActive = profile.id === activeProfileId;
-      const row = document.createElement('div');
-      row.className = 'destination-profile-row';
-      row.setAttribute('role', 'radio');
-      row.setAttribute('aria-checked', isActive ? 'true' : 'false');
-      row.style.borderLeftColor = profile.color || '#2563eb';
-
-      const canDeleteProfile = profiles.length > 1;
-      const activeSwitch = createDestinationActiveSwitch(profile, isActive);
-      const content = renderProfileContent(profile);
-      const actions = renderProfileActions(profile, canDeleteProfile);
-
-      row.append(activeSwitch, content, actions);
-      list.append(row);
+      list.append(createDestinationProfileRow(profile, activeProfileId, canDeleteProfile));
     }
+  };
 
+  const renderDestinationProfiles = async () => {
+    const profiles = await listDestinationProfilesForRender();
+    const entitlement = await resolveDestinationEntitlementForRender();
+    const activeProfileId = await resolveActiveDestinationProfileId(
+      'renderDestinationProfiles',
+      'destinationProfileActive',
+      true
+    );
+
+    renderDestinationProfileRows(profiles, activeProfileId);
     updateDestinationLimitState(profiles, entitlement);
   };
 
@@ -568,33 +635,40 @@ async function initDestinationProfilesUI(ui) {
     await renderDestinationProfiles();
   };
 
-  const deleteDestinationProfile = async profileId => {
-    let activeProfileId = null;
-    try {
-      if (typeof service.getActiveProfile === 'function') {
-        const activeProfile = await service.getActiveProfile();
-        activeProfileId = activeProfile?.id ?? null;
-      }
-    } catch (error) {
-      Logger.warn('讀取啟用保存目標失敗', {
-        action: 'deleteDestinationProfile',
-        error: sanitizeApiError(error, 'getActiveProfile'),
-      });
+  const reassignActiveDestinationProfileAfterDelete = async (
+    activeProfileId,
+    deletedProfileId,
+    remainingProfiles
+  ) => {
+    if (
+      !shouldReassignActiveDestinationProfile(activeProfileId, deletedProfileId, remainingProfiles)
+    ) {
+      return;
     }
 
-    const remainingProfiles = await service.deleteProfile(profileId);
-    if (activeProfileId === profileId && remainingProfiles && remainingProfiles.length > 0) {
-      try {
-        if (typeof service.setActiveProfile === 'function') {
-          await service.setActiveProfile(remainingProfiles[0].id);
-        }
-      } catch (error) {
-        Logger.warn('轉移啟用保存目標失敗', {
-          action: 'deleteDestinationProfile',
-          error: sanitizeApiError(error, 'setActiveProfile'),
-        });
+    try {
+      if (typeof service.setActiveProfile === 'function') {
+        await service.setActiveProfile(remainingProfiles[0].id);
       }
+    } catch (error) {
+      Logger.warn('轉移啟用保存目標失敗', {
+        action: 'deleteDestinationProfile',
+        error: sanitizeApiError(error, 'setActiveProfile'),
+      });
     }
+  };
+
+  const deleteDestinationProfile = async profileId => {
+    const activeProfileId = await resolveActiveDestinationProfileId(
+      'deleteDestinationProfile',
+      'getActiveProfile'
+    );
+    const remainingProfiles = await service.deleteProfile(profileId);
+    await reassignActiveDestinationProfileAfterDelete(
+      activeProfileId,
+      profileId,
+      remainingProfiles
+    );
     await renderDestinationProfiles();
   };
 

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -681,13 +681,6 @@ async function initDestinationProfilesUI(ui) {
     }
     const profileId = input.dataset.profileId;
 
-    // 不可關閉當前 active：嘗試關掉已勾選列 → 還原並提示
-    if (!input.checked) {
-      input.checked = true;
-      ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.AT_LEAST_ONE_REQUIRED, 'info');
-      return;
-    }
-
     try {
       await service.setActiveProfile(profileId);
       const profile = await service.getProfile(profileId);

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -34,7 +34,6 @@ const DESTINATION_PROFILE_ACTIONS = {
   RENAME: 'rename',
   CANCEL_NAME: 'cancel-name',
   SAVE_NAME: 'save-name',
-  EDIT: 'edit',
   DELETE: 'delete',
 };
 const DESTINATION_TARGET_FIELD_SELECTORS = {
@@ -193,6 +192,7 @@ function initializeOptionsManagers({ ui, auth, dataSource, storage, migration })
  */
 function refreshDestinationProfilesUI(ui) {
   initDestinationProfilesUI(ui).catch(error => {
+    console.error('INIT UI CRITICAL ERROR:', error);
     const safeError = sanitizeApiError(error, 'initDestinationProfilesUI');
     Logger.warn('初始化保存目標 UI 失敗', {
       action: 'initDestinationProfilesUI',
@@ -352,6 +352,32 @@ async function initDestinationProfilesUI(ui) {
     ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.PROFILE_NAME_REQUIRED, 'error');
   };
 
+  const createDestinationActiveSwitch = (profile, isActive) => {
+    const label = document.createElement('label');
+    label.className = 'switch-wrapper';
+
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = 'active-destination';
+    input.className = 'switch-input';
+    input.checked = isActive;
+    input.dataset.profileId = profile.id;
+    input.setAttribute(
+      'aria-label',
+      `啟用保存目標：${profile.name || UI_MESSAGES.OPTIONS.DESTINATION.DEFAULT_PROFILE_NAME}`
+    );
+
+    const track = document.createElement('span');
+    track.className = 'switch-track';
+    track.setAttribute('aria-hidden', 'true');
+    const knob = document.createElement('span');
+    knob.className = 'switch-knob';
+    track.append(knob);
+
+    label.append(input, track);
+    return label;
+  };
+
   const createDestinationActionButton = ({
     action,
     profileId,
@@ -422,11 +448,6 @@ async function initDestinationProfilesUI(ui) {
         action: DESTINATION_PROFILE_ACTIONS.RENAME,
         profileId: profile.id,
         text: UI_MESSAGES.OPTIONS.DESTINATION.ACTION_RENAME,
-      }),
-      createDestinationActionButton({
-        action: DESTINATION_PROFILE_ACTIONS.EDIT,
-        profileId: profile.id,
-        text: UI_MESSAGES.OPTIONS.DESTINATION.ACTION_APPLY,
       })
     );
 
@@ -486,16 +507,34 @@ async function initDestinationProfilesUI(ui) {
 
     list.innerHTML = '';
 
+    let activeProfileId = null;
+    try {
+      if (typeof service.getActiveProfile === 'function') {
+        const activeProfile = await service.getActiveProfile();
+        activeProfileId = activeProfile?.id ?? null;
+      }
+    } catch (error) {
+      console.error('DEBUG ACTIVE PROFILE ERROR:', error);
+      Logger.warn('讀取啟用保存目標失敗', {
+        action: 'renderDestinationProfiles',
+        error: sanitizeApiError(error, 'destinationProfileActive'),
+      });
+    }
+
     for (const profile of profiles) {
+      const isActive = profile.id === activeProfileId;
       const row = document.createElement('div');
       row.className = 'destination-profile-row';
+      row.setAttribute('role', 'radio');
+      row.setAttribute('aria-checked', isActive ? 'true' : 'false');
       row.style.borderLeftColor = profile.color || '#2563eb';
 
       const canDeleteProfile = profiles.length > 1;
+      const activeSwitch = createDestinationActiveSwitch(profile, isActive);
       const content = renderProfileContent(profile);
       const actions = renderProfileActions(profile, canDeleteProfile);
 
-      row.append(content, actions);
+      row.append(activeSwitch, content, actions);
       list.append(row);
     }
 
@@ -529,17 +568,33 @@ async function initDestinationProfilesUI(ui) {
     await renderDestinationProfiles();
   };
 
-  const applyDestinationProfileToForm = async profileId => {
-    const profile = await service.getProfile(profileId);
-    document.querySelector(DESTINATION_TARGET_FIELD_SELECTORS.ID).value =
-      profile.notionDataSourceId;
-    document.querySelector(DESTINATION_TARGET_FIELD_SELECTORS.TYPE).value =
-      profile.notionDataSourceType;
-    ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.APPLY_SUCCESS(profile.name), 'info');
-  };
-
   const deleteDestinationProfile = async profileId => {
-    await service.deleteProfile(profileId);
+    let activeProfileId = null;
+    try {
+      if (typeof service.getActiveProfile === 'function') {
+        const activeProfile = await service.getActiveProfile();
+        activeProfileId = activeProfile?.id ?? null;
+      }
+    } catch (error) {
+      Logger.warn('讀取啟用保存目標失敗', {
+        action: 'deleteDestinationProfile',
+        error: sanitizeApiError(error, 'getActiveProfile'),
+      });
+    }
+
+    const remainingProfiles = await service.deleteProfile(profileId);
+    if (activeProfileId === profileId && remainingProfiles && remainingProfiles.length > 0) {
+      try {
+        if (typeof service.setActiveProfile === 'function') {
+          await service.setActiveProfile(remainingProfiles[0].id);
+        }
+      } catch (error) {
+        Logger.warn('轉移啟用保存目標失敗', {
+          action: 'deleteDestinationProfile',
+          error: sanitizeApiError(error, 'setActiveProfile'),
+        });
+      }
+    }
     await renderDestinationProfiles();
   };
 
@@ -571,7 +626,6 @@ async function initDestinationProfilesUI(ui) {
     [DESTINATION_PROFILE_ACTIONS.RENAME]: enterDestinationProfileNameEdit,
     [DESTINATION_PROFILE_ACTIONS.CANCEL_NAME]: cancelDestinationProfileNameEdit,
     [DESTINATION_PROFILE_ACTIONS.SAVE_NAME]: saveDestinationProfileName,
-    [DESTINATION_PROFILE_ACTIONS.EDIT]: applyDestinationProfileToForm,
     [DESTINATION_PROFILE_ACTIONS.DELETE]: deleteDestinationProfile,
   };
 
@@ -594,6 +648,33 @@ async function initDestinationProfilesUI(ui) {
         error: safeError,
       });
       ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.ACTION_FAILED, 'error');
+    }
+  });
+
+  list.addEventListener('change', async event => {
+    const input = event.target;
+    if (!input?.matches?.('input[name="active-destination"]')) {
+      return;
+    }
+    const profileId = input.dataset.profileId;
+
+    // 不可關閉當前 active：嘗試關掉已勾選列 → 還原並提示
+    if (!input.checked) {
+      input.checked = true;
+      ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.AT_LEAST_ONE_REQUIRED, 'info');
+      return;
+    }
+
+    try {
+      await service.setActiveProfile(profileId);
+      const profile = await service.getProfile(profileId);
+      ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.ACTIVATED(profile.name), 'success');
+      await renderDestinationProfiles();
+    } catch (error) {
+      const safeError = sanitizeApiError(error, 'destinationProfileActivate');
+      Logger.warn('啟用保存目標失敗', { action: 'activateDestinationProfile', error: safeError });
+      ui.showStatus(UI_MESSAGES.OPTIONS.DESTINATION.ACTION_FAILED, 'error');
+      await renderDestinationProfiles(); // 還原 UI 至實際 active
     }
   });
 

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -89,24 +89,6 @@ function resolveCreateDestinationProfileErrorMessage(error) {
     : UI_MESSAGES.OPTIONS.DESTINATION.CREATE_FAILED;
 }
 
-function hasRemainingDestinationProfiles(remainingProfiles) {
-  if (!remainingProfiles) {
-    return false;
-  }
-  return remainingProfiles.length > 0;
-}
-
-function shouldReassignActiveDestinationProfile(
-  activeProfileId,
-  deletedProfileId,
-  remainingProfiles
-) {
-  if (activeProfileId !== deletedProfileId) {
-    return false;
-  }
-  return hasRemainingDestinationProfiles(remainingProfiles);
-}
-
 function resolveDestinationProfileId(profile) {
   if (!profile) {
     return null;
@@ -233,7 +215,6 @@ function initializeOptionsManagers({ ui, auth, dataSource, storage, migration })
  */
 function refreshDestinationProfilesUI(ui) {
   initDestinationProfilesUI(ui).catch(error => {
-    console.error('INIT UI CRITICAL ERROR:', error);
     const safeError = sanitizeApiError(error, 'initDestinationProfilesUI');
     Logger.warn('初始化保存目標 UI 失敗', {
       action: 'initDestinationProfilesUI',
@@ -635,40 +616,8 @@ async function initDestinationProfilesUI(ui) {
     await renderDestinationProfiles();
   };
 
-  const reassignActiveDestinationProfileAfterDelete = async (
-    activeProfileId,
-    deletedProfileId,
-    remainingProfiles
-  ) => {
-    if (
-      !shouldReassignActiveDestinationProfile(activeProfileId, deletedProfileId, remainingProfiles)
-    ) {
-      return;
-    }
-
-    try {
-      if (typeof service.setActiveProfile === 'function') {
-        await service.setActiveProfile(remainingProfiles[0].id);
-      }
-    } catch (error) {
-      Logger.warn('轉移啟用保存目標失敗', {
-        action: 'deleteDestinationProfile',
-        error: sanitizeApiError(error, 'setActiveProfile'),
-      });
-    }
-  };
-
   const deleteDestinationProfile = async profileId => {
-    const activeProfileId = await resolveActiveDestinationProfileId(
-      'deleteDestinationProfile',
-      'getActiveProfile'
-    );
-    const remainingProfiles = await service.deleteProfile(profileId);
-    await reassignActiveDestinationProfileAfterDelete(
-      activeProfileId,
-      profileId,
-      remainingProfiles
-    );
+    await service.deleteProfile(profileId);
     await renderDestinationProfiles();
   };
 

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -36,6 +36,7 @@ import {
   getPopupAccountState,
   startAccountLogin,
   openAccountManagement,
+  setPopupTempProfile,
 } from './popupActions.js';
 import Logger from '../../scripts/utils/Logger.js';
 import { BUILD_ENV } from '../../scripts/config/env/index.js';
@@ -268,6 +269,7 @@ function registerPopupEventListeners(elements, context) {
         return;
       }
       selectedDestinationProfileId = profileId;
+      void setPopupTempProfile(profileId);
       renderDestinationSelector(elements, {
         profiles: destinationProfiles,
         selectedProfileId: profileId,

--- a/pages/popup/popupActions.js
+++ b/pages/popup/popupActions.js
@@ -41,78 +41,169 @@ const POPUP_TEMP_PROFILE_SESSION_KEY = 'popupTempDestinationProfileId';
  */
 export async function checkSettings() {
   try {
-    const [syncResult, localResult] = await Promise.all([
-      chrome.storage.sync.get(['notionApiKey', 'notionDataSourceId', 'notionDatabaseId']),
-      chrome.storage.local.get([
-        'notionAuthMode',
-        'notionOAuthToken',
-        'notionDataSourceId',
-        'notionDatabaseId',
-      ]),
-    ]);
-    const isOAuth = localResult.notionAuthMode === AuthMode.OAUTH && localResult.notionOAuthToken;
+    const { syncResult, localResult } = await readSettingsStorage();
+    const authState = resolveSettingsAuthState(syncResult, localResult);
+    const dataSourceId = await resolveSettingsDataSourceId(syncResult, localResult);
 
-    // SOT：activeProfileId 指向的 profile 為當前生效目標；legacy 頂層 key 僅作安全網
-    let activeProfileDataSourceId = null;
-    try {
-      const service = new ProfileManager({ repository: new LocalDestinationProfileRepository() });
-      const activeProfile = await service.getActiveProfile();
-      activeProfileDataSourceId = activeProfile?.notionDataSourceId || null;
-    } catch (error) {
-      Logger.warn('checkSettings: failed to resolve active profile', {
-        action: 'checkSettings',
-        error: sanitizeApiError(error, 'checkSettings.getActiveProfile'),
-      });
-    }
+    await migratePopupDataSourceKeys(syncResult, localResult);
 
-    const legacyDataSourceId =
-      localResult.notionDataSourceId ||
-      localResult.notionDatabaseId ||
-      syncResult.notionDataSourceId ||
-      syncResult.notionDatabaseId;
-    const dataSourceId = activeProfileDataSourceId || legacyDataSourceId;
-    const hasManualApiKey = Boolean(syncResult.notionApiKey);
-    const hasAuth = Boolean(hasManualApiKey || isOAuth);
-    const valid = Boolean(hasAuth && dataSourceId);
-
-    await migrateDataSourceKeys({
-      localData: localResult,
-      syncData: syncResult,
-      storageArea: chrome.storage.local,
-      logger: Logger,
-      action: 'checkSettings',
-      retryContext: 'popup',
-    });
-
-    let authMode = null;
-    if (isOAuth) {
-      authMode = AuthMode.OAUTH;
-    } else if (hasManualApiKey) {
-      authMode = AuthMode.MANUAL;
-    }
-
-    let missingReason;
-    if (!valid) {
-      if (hasAuth) {
-        missingReason = 'missing_data_source';
-      } else {
-        missingReason = 'missing_auth';
-      }
-    }
-
-    return {
-      valid,
-      apiKey: syncResult.notionApiKey,
+    return buildSettingsCheckResult({
+      syncResult,
       dataSourceId,
-      authMode,
-      hasOAuthToken: Boolean(isOAuth),
-      hasManualApiKey,
-      missingReason,
-    };
+      authState,
+    });
   } catch (error) {
     Logger.warn('Failed to check settings:', error);
     return { valid: false, missingReason: 'unknown' };
   }
+}
+
+/**
+ * 讀取設置存儲
+ *
+ * @returns {Promise<{syncResult: object, localResult: object}>}
+ */
+async function readSettingsStorage() {
+  const [syncResult, localResult] = await Promise.all([
+    chrome.storage.sync.get(['notionApiKey', 'notionDataSourceId', 'notionDatabaseId']),
+    chrome.storage.local.get([
+      'notionAuthMode',
+      'notionOAuthToken',
+      'notionDataSourceId',
+      'notionDatabaseId',
+    ]),
+  ]);
+  return { syncResult, localResult };
+}
+
+/**
+ * 解析設置授權狀態
+ *
+ * @param {object} syncResult - 同步存儲讀取結果
+ * @param {object} localResult - 本地存儲讀取結果
+ * @returns {{isOAuth: boolean, hasManualApiKey: boolean, hasAuth: boolean}}
+ */
+function resolveSettingsAuthState(syncResult, localResult) {
+  const isOAuth = Boolean(
+    localResult.notionAuthMode === AuthMode.OAUTH && localResult.notionOAuthToken
+  );
+  const hasManualApiKey = Boolean(syncResult.notionApiKey);
+  const hasAuth = Boolean(hasManualApiKey || isOAuth);
+  return { isOAuth, hasManualApiKey, hasAuth };
+}
+
+/**
+ * 解析設置中的數據源 ID
+ *
+ * @param {object} syncResult - 同步存儲讀取結果
+ * @param {object} localResult - 本地存儲讀取結果
+ * @returns {Promise<string|null>}
+ */
+async function resolveSettingsDataSourceId(syncResult, localResult) {
+  const activeProfileDataSourceId = await resolveActiveProfileDataSourceId();
+  const legacyDataSourceId = resolveLegacyDataSourceId(syncResult, localResult);
+  return activeProfileDataSourceId || legacyDataSourceId;
+}
+
+/**
+ * 解析當前活動配置文件的數據源 ID
+ *
+ * @returns {Promise<string|null>}
+ */
+async function resolveActiveProfileDataSourceId() {
+  try {
+    const service = new ProfileManager({ repository: new LocalDestinationProfileRepository() });
+    const activeProfile = await service.getActiveProfile();
+    return activeProfile?.notionDataSourceId || null;
+  } catch (error) {
+    Logger.warn('checkSettings: failed to resolve active profile', {
+      action: 'checkSettings',
+      error: sanitizeApiError(error, 'checkSettings.getActiveProfile'),
+    });
+    return null;
+  }
+}
+
+/**
+ * 解析舊版數據源 ID
+ *
+ * @param {object} syncResult - 同步存儲讀取結果
+ * @param {object} localResult - 本地存儲讀取結果
+ * @returns {string|null}
+ */
+function resolveLegacyDataSourceId(syncResult, localResult) {
+  return (
+    localResult.notionDataSourceId ||
+    localResult.notionDatabaseId ||
+    syncResult.notionDataSourceId ||
+    syncResult.notionDatabaseId ||
+    null
+  );
+}
+
+/**
+ * 遷移彈出窗口數據源密鑰
+ *
+ * @param {object} syncResult - 同步存儲讀取結果
+ * @param {object} localResult - 本地存儲讀取結果
+ * @returns {Promise<void>}
+ */
+async function migratePopupDataSourceKeys(syncResult, localResult) {
+  await migrateDataSourceKeys({
+    localData: localResult,
+    syncData: syncResult,
+    storageArea: chrome.storage.local,
+    logger: Logger,
+    action: 'checkSettings',
+    retryContext: 'popup',
+  });
+}
+
+/**
+ * 構建設置檢查結果
+ *
+ * @param {object} params - 參數對象
+ * @param {object} params.syncResult - 同步結果
+ * @param {string|null} params.dataSourceId - 數據源 ID
+ * @param {object} params.authState - 授權狀態
+ * @returns {object}
+ */
+function buildSettingsCheckResult({ syncResult, dataSourceId, authState }) {
+  const { isOAuth, hasManualApiKey, hasAuth } = authState;
+  const valid = Boolean(hasAuth && dataSourceId);
+
+  let authMode = null;
+  if (isOAuth) {
+    authMode = AuthMode.OAUTH;
+  } else if (hasManualApiKey) {
+    authMode = AuthMode.MANUAL;
+  }
+
+  const missingReason = resolveMissingSettingsReason(valid, hasAuth);
+
+  return {
+    valid,
+    apiKey: syncResult.notionApiKey,
+    dataSourceId,
+    authMode,
+    hasOAuthToken: Boolean(isOAuth),
+    hasManualApiKey,
+    missingReason,
+  };
+}
+
+/**
+ * 解析缺失設置的原因
+ *
+ * @param {boolean} valid - 是否有效
+ * @param {boolean} hasAuth - 是否有授權
+ * @returns {'missing_data_source'|'missing_auth'|undefined}
+ */
+function resolveMissingSettingsReason(valid, hasAuth) {
+  if (valid) {
+    return undefined;
+  }
+  return hasAuth ? 'missing_data_source' : 'missing_auth';
 }
 
 /**
@@ -179,62 +270,19 @@ export async function savePage(profileId) {
  */
 export async function getDestinationState() {
   try {
-    const service = new ProfileManager({
-      repository: new LocalDestinationProfileRepository(),
-      entitlementProvider: new AccountGatedDestinationEntitlementProvider(),
-    });
-    const profiles = await service.listProfiles().catch(error => {
-      Logger.warn({
-        action: 'getDestinationState',
-        operation: 'listProfiles',
-        error: sanitizeApiError(error, 'getDestinationState.listProfiles'),
-      });
-      return [];
-    });
-    const tempResult = await chrome.storage.session
-      .get(POPUP_TEMP_PROFILE_SESSION_KEY)
-      .catch(error => {
-        Logger.warn({
-          action: 'getDestinationState',
-          operation: 'getSessionTempProfile',
-          error: sanitizeApiError(error, 'getDestinationState.getSessionTempProfile'),
-        });
-        return null;
-      });
-    const tempProfileId = tempResult?.[POPUP_TEMP_PROFILE_SESSION_KEY] || null;
-
-    const activeProfile = await service.getActiveProfile().catch(error => {
-      Logger.warn({
-        action: 'getDestinationState',
-        operation: 'getActiveProfile',
-        error: sanitizeApiError(error, 'getDestinationState.getActiveProfile'),
-      });
-      return null;
-    });
-
-    const entitlement = await service.getDestinationEntitlement().catch(error => {
-      Logger.warn({
-        action: 'getDestinationState',
-        operation: 'getDestinationEntitlement',
-        error: sanitizeApiError(error, 'getDestinationState.getDestinationEntitlement'),
-      });
-      return { maxProfiles: 1 };
-    });
-
-    const allowedProfiles = profiles.slice(0, entitlement.maxProfiles);
-    const tempIsValid = allowedProfiles.some(profile => profile.id === tempProfileId);
-    let selectedProfileId = allowedProfiles[0]?.id ?? null;
-    if (tempIsValid) {
-      selectedProfileId = tempProfileId;
-    } else if (allowedProfiles.some(profile => profile.id === activeProfile?.id)) {
-      selectedProfileId = activeProfile.id;
-    }
-
-    return {
+    const service = createDestinationProfileService();
+    const profiles = await readDestinationProfiles(service);
+    const tempProfileId = await readPopupTempProfileId();
+    const activeProfile = await readActiveDestinationProfile(service);
+    const entitlement = await readDestinationEntitlement(service);
+    const selectedProfileId = resolveSelectedDestinationProfileId({
       profiles,
-      selectedProfileId,
       entitlement,
-    };
+      tempProfileId,
+      activeProfile,
+    });
+
+    return { profiles, selectedProfileId, entitlement };
   } catch (error) {
     Logger.warn({
       action: 'getDestinationState',
@@ -243,6 +291,119 @@ export async function getDestinationState() {
     });
     return { profiles: [], selectedProfileId: null, entitlement: { maxProfiles: 1 } };
   }
+}
+
+/**
+ * 創建目標配置文件服務
+ *
+ * @returns {ProfileManager}
+ */
+function createDestinationProfileService() {
+  return new ProfileManager({
+    repository: new LocalDestinationProfileRepository(),
+    entitlementProvider: new AccountGatedDestinationEntitlementProvider(),
+  });
+}
+
+/**
+ * 記錄目標狀態警告日誌
+ *
+ * @param {string} operation - 操作名稱
+ * @param {Error|any} error - 錯誤對象
+ */
+function logDestinationStateWarning(operation, error) {
+  Logger.warn({
+    action: 'getDestinationState',
+    operation,
+    error: sanitizeApiError(error, `getDestinationState.${operation}`),
+  });
+}
+
+/**
+ * 讀取保存目標列表
+ *
+ * @param {ProfileManager} service - 配置文件服務實例
+ * @returns {Promise<Array<object>>}
+ */
+async function readDestinationProfiles(service) {
+  try {
+    return await service.listProfiles();
+  } catch (error) {
+    logDestinationStateWarning('listProfiles', error);
+    return [];
+  }
+}
+
+/**
+ * 讀取彈出窗口臨時配置文件 ID
+ *
+ * @returns {Promise<string|null>}
+ */
+async function readPopupTempProfileId() {
+  try {
+    const tempResult = await chrome.storage.session.get(POPUP_TEMP_PROFILE_SESSION_KEY);
+    return tempResult?.[POPUP_TEMP_PROFILE_SESSION_KEY] || null;
+  } catch (error) {
+    logDestinationStateWarning('getSessionTempProfile', error);
+    return null;
+  }
+}
+
+/**
+ * 讀取活動目標配置文件
+ *
+ * @param {ProfileManager} service - 配置文件服務實例
+ * @returns {Promise<object|null>}
+ */
+async function readActiveDestinationProfile(service) {
+  try {
+    return await service.getActiveProfile();
+  } catch (error) {
+    logDestinationStateWarning('getActiveProfile', error);
+    return null;
+  }
+}
+
+/**
+ * 讀取目標權益資訊
+ *
+ * @param {ProfileManager} service - 配置文件服務實例
+ * @returns {Promise<{maxProfiles: number}>}
+ */
+async function readDestinationEntitlement(service) {
+  try {
+    return await service.getDestinationEntitlement();
+  } catch (error) {
+    logDestinationStateWarning('getDestinationEntitlement', error);
+    return { maxProfiles: 1 };
+  }
+}
+
+/**
+ * 解析已選擇的目標配置文件 ID
+ *
+ * @param {object} params - 參數對象
+ * @param {Array<object>} params.profiles - 配置文件列表
+ * @param {object} params.entitlement - 權益資訊
+ * @param {string|null} params.tempProfileId - 臨時配置文件 ID
+ * @param {object|null} params.activeProfile - 活動配置文件
+ * @returns {string|null}
+ */
+function resolveSelectedDestinationProfileId({
+  profiles,
+  entitlement,
+  tempProfileId,
+  activeProfile,
+}) {
+  const allowedProfiles = profiles.slice(0, entitlement.maxProfiles);
+  const tempIsValid = allowedProfiles.some(profile => profile.id === tempProfileId);
+  if (tempIsValid) {
+    return tempProfileId;
+  }
+  if (allowedProfiles.some(profile => profile.id === activeProfile?.id)) {
+    return activeProfile.id;
+  }
+  return allowedProfiles[0]?.id ?? null;
 }
 
 /**

--- a/pages/popup/popupActions.js
+++ b/pages/popup/popupActions.js
@@ -24,6 +24,8 @@ import {
 } from '../../scripts/destinations/ProfileStore.js';
 import { ProfileManager } from '../../scripts/destinations/ProfileManager.js';
 
+const POPUP_TEMP_PROFILE_SESSION_KEY = 'popupTempDestinationProfileId';
+
 /**
  * 檢查設置是否完整
  *
@@ -189,14 +191,27 @@ export async function getDestinationState() {
       });
       return [];
     });
-    const selectedProfile = await service.getLastUsedProfile().catch(error => {
+    const tempResult = await chrome.storage.session
+      .get(POPUP_TEMP_PROFILE_SESSION_KEY)
+      .catch(error => {
+        Logger.warn({
+          action: 'getDestinationState',
+          operation: 'getSessionTempProfile',
+          error: sanitizeApiError(error, 'getDestinationState.getSessionTempProfile'),
+        });
+        return null;
+      });
+    const tempProfileId = tempResult?.[POPUP_TEMP_PROFILE_SESSION_KEY] || null;
+
+    const activeProfile = await service.getActiveProfile().catch(error => {
       Logger.warn({
         action: 'getDestinationState',
-        operation: 'getLastUsedProfile',
-        error: sanitizeApiError(error, 'getDestinationState.getLastUsedProfile'),
+        operation: 'getActiveProfile',
+        error: sanitizeApiError(error, 'getDestinationState.getActiveProfile'),
       });
       return null;
     });
+
     const entitlement = await service.getDestinationEntitlement().catch(error => {
       Logger.warn({
         action: 'getDestinationState',
@@ -205,9 +220,15 @@ export async function getDestinationState() {
       });
       return { maxProfiles: 1 };
     });
-    const selectedProfileId = profiles.some(profile => profile.id === selectedProfile?.id)
-      ? selectedProfile.id
-      : (profiles[0]?.id ?? null);
+
+    const allowedProfiles = profiles.slice(0, entitlement.maxProfiles);
+    const tempIsValid = allowedProfiles.some(profile => profile.id === tempProfileId);
+    let selectedProfileId = allowedProfiles[0]?.id ?? null;
+    if (tempIsValid) {
+      selectedProfileId = tempProfileId;
+    } else if (allowedProfiles.some(profile => profile.id === activeProfile?.id)) {
+      selectedProfileId = activeProfile.id;
+    }
 
     return {
       profiles,

--- a/pages/popup/popupActions.js
+++ b/pages/popup/popupActions.js
@@ -362,3 +362,17 @@ export async function openAccountManagement() {
     return { success: false, error: UI_MESSAGES.ACCOUNT.ACCOUNT_MANAGEMENT_OPEN_FAILED };
   }
 }
+
+/**
+ * 設定 popup 臨時選擇的保存目標，存入 session storage 中。
+ *
+ * @param {string} profileId - 臨時選取的保存目標 ID
+ * @returns {Promise<void>}
+ */
+export async function setPopupTempProfile(profileId) {
+  try {
+    await chrome.storage.session.set({ [POPUP_TEMP_PROFILE_SESSION_KEY]: profileId });
+  } catch (error) {
+    Logger.warn('Failed to persist popup temp profile selection:', error);
+  }
+}

--- a/pages/popup/popupActions.js
+++ b/pages/popup/popupActions.js
@@ -50,10 +50,25 @@ export async function checkSettings() {
     ]);
     const isOAuth = localResult.notionAuthMode === AuthMode.OAUTH && localResult.notionOAuthToken;
 
-    // Local 優先，sync 回退（向後兼容 v2.47.0 前僅存於 sync 的升級用戶）
-    const localDataSourceId = localResult.notionDataSourceId || localResult.notionDatabaseId;
-    const syncDataSourceId = syncResult.notionDataSourceId || syncResult.notionDatabaseId;
-    const dataSourceId = localDataSourceId || syncDataSourceId;
+    // SOT：activeProfileId 指向的 profile 為當前生效目標；legacy 頂層 key 僅作安全網
+    let activeProfileDataSourceId = null;
+    try {
+      const service = new ProfileManager({ repository: new LocalDestinationProfileRepository() });
+      const activeProfile = await service.getActiveProfile();
+      activeProfileDataSourceId = activeProfile?.notionDataSourceId || null;
+    } catch (error) {
+      Logger.warn('checkSettings: failed to resolve active profile', {
+        action: 'checkSettings',
+        error: sanitizeApiError(error, 'checkSettings.getActiveProfile'),
+      });
+    }
+
+    const legacyDataSourceId =
+      localResult.notionDataSourceId ||
+      localResult.notionDatabaseId ||
+      syncResult.notionDataSourceId ||
+      syncResult.notionDatabaseId;
+    const dataSourceId = activeProfileDataSourceId || legacyDataSourceId;
     const hasManualApiKey = Boolean(syncResult.notionApiKey);
     const hasAuth = Boolean(hasManualApiKey || isOAuth);
     const valid = Boolean(hasAuth && dataSourceId);

--- a/pages/popup/popupActions.js
+++ b/pages/popup/popupActions.js
@@ -26,6 +26,10 @@ import { ProfileManager } from '../../scripts/destinations/ProfileManager.js';
 
 const POPUP_TEMP_PROFILE_SESSION_KEY = 'popupTempDestinationProfileId';
 
+function getPopupSessionStorage() {
+  return globalThis.chrome?.storage?.session || null;
+}
+
 /**
  * 檢查設置是否完整
  *
@@ -340,8 +344,13 @@ async function readDestinationProfiles(service) {
  * @returns {Promise<string|null>}
  */
 async function readPopupTempProfileId() {
+  const sessionStorage = getPopupSessionStorage();
+  if (typeof sessionStorage?.get !== 'function') {
+    return null;
+  }
+
   try {
-    const tempResult = await chrome.storage.session.get(POPUP_TEMP_PROFILE_SESSION_KEY);
+    const tempResult = await sessionStorage.get(POPUP_TEMP_PROFILE_SESSION_KEY);
     return tempResult?.[POPUP_TEMP_PROFILE_SESSION_KEY] || null;
   } catch (error) {
     logDestinationStateWarning('getSessionTempProfile', error);
@@ -531,8 +540,13 @@ export async function openAccountManagement() {
  * @returns {Promise<void>}
  */
 export async function setPopupTempProfile(profileId) {
+  const sessionStorage = getPopupSessionStorage();
+  if (typeof sessionStorage?.set !== 'function') {
+    return;
+  }
+
   try {
-    await chrome.storage.session.set({ [POPUP_TEMP_PROFILE_SESSION_KEY]: profileId });
+    await sessionStorage.set({ [POPUP_TEMP_PROFILE_SESSION_KEY]: profileId });
   } catch (error) {
     Logger.warn('Failed to persist popup temp profile selection:', error);
   }

--- a/scripts/background/handlers/saveHandlers.js
+++ b/scripts/background/handlers/saveHandlers.js
@@ -710,23 +710,6 @@ export function createSaveHandlers(services) {
     }
   }
 
-  async function rememberLastUsedDestinationProfile(destinationProfile) {
-    if (
-      !destinationProfile?.id ||
-      typeof destinationProfileResolver?.setLastUsedProfile !== 'function'
-    ) {
-      return;
-    }
-
-    await destinationProfileResolver.setLastUsedProfile(destinationProfile.id).catch(error => {
-      Logger.warn('更新最後使用保存目的地失敗（不影響保存流程）', {
-        action: 'rememberLastUsedDestinationProfile',
-        profileId: destinationProfile.id,
-        error,
-      });
-    });
-  }
-
   /**
    * 驗證請求並獲取配置
    *
@@ -886,7 +869,6 @@ export function createSaveHandlers(services) {
       lastVerifiedAt: Date.now(),
       destinationProfileId: destinationProfile?.id ?? null,
     });
-    await rememberLastUsedDestinationProfile(destinationProfile);
   }
 
   async function recordUrlAlias(originalUrl, normUrl) {
@@ -958,7 +940,6 @@ export function createSaveHandlers(services) {
       lastUpdated: Date.now(),
       destinationProfileId: destinationProfile?.id ?? savedData.destinationProfileId ?? null,
     });
-    await rememberLastUsedDestinationProfile(destinationProfile);
   }
 
   async function handleHighlightOnlyUpdate(params) {

--- a/scripts/config/shared/messages.js
+++ b/scripts/config/shared/messages.js
@@ -92,6 +92,8 @@ const OPTIONS = {
     CREATE_LIMIT_REACHED: BACKGROUND_MESSAGES.DESTINATION_PROFILE.CREATE_LIMIT_REACHED,
     CREATE_FAILED: '新增保存目標失敗，請稍後再試。',
     APPLY_SUCCESS: profileName => `已套用 ${profileName} 到編輯欄位`,
+    ACTIVATED: profileName => `已啟用保存目標：${profileName}`,
+    AT_LEAST_ONE_REQUIRED: '必須至少啟用一個保存目標。',
     ACTION_FAILED: '保存目標操作失敗，請稍後再試。',
   },
   INTERFACE: {

--- a/scripts/destinations/ProfileManager.js
+++ b/scripts/destinations/ProfileManager.js
@@ -8,6 +8,7 @@ import {
   DESTINATION_PROFILE_ERROR_CODES,
   DESTINATION_PROFILE_ERRORS,
   ensureMigratedDefaultProfile,
+  resolveActiveProfile,
   LocalDestinationProfileRepository,
   createProfileId,
   normalizeProfile,
@@ -51,6 +52,16 @@ export class ProfileManager {
   async setLastUsedProfile(profileId) {
     const profile = await this.getProfile(profileId);
     await this.repository.setLastUsedProfileId(profile.id);
+    return profile;
+  }
+
+  async getActiveProfile() {
+    return await resolveActiveProfile(this.repository);
+  }
+
+  async setActiveProfile(profileId) {
+    const profile = await this.getProfile(profileId); // throws NOT_FOUND if invalid
+    await this.repository.setActiveProfileId(profile.id, profile);
     return profile;
   }
 

--- a/scripts/destinations/ProfileManager.js
+++ b/scripts/destinations/ProfileManager.js
@@ -37,24 +37,6 @@ export class ProfileManager {
     return await this.entitlementProvider.getDestinationEntitlement();
   }
 
-  async getLastUsedProfile() {
-    const profiles = await this.listProfiles();
-    const entitlement = await this.getDestinationEntitlement();
-    const allowedProfiles = profiles.slice(0, entitlement.maxProfiles);
-    if (allowedProfiles.length === 0) {
-      return null;
-    }
-
-    const lastUsedProfileId = await this.repository.getLastUsedProfileId();
-    return allowedProfiles.find(profile => profile.id === lastUsedProfileId) || allowedProfiles[0];
-  }
-
-  async setLastUsedProfile(profileId) {
-    const profile = await this.getProfile(profileId);
-    await this.repository.setLastUsedProfileId(profile.id);
-    return profile;
-  }
-
   async getActiveProfile() {
     return await resolveActiveProfile(this.repository);
   }
@@ -131,12 +113,13 @@ export class ProfileManager {
       throw new Error(DESTINATION_PROFILE_ERRORS.NOT_FOUND);
     }
 
-    const lastUsedProfileId = await this.repository.getLastUsedProfileId();
-    const nextLastUsedProfileId =
-      lastUsedProfileId === profileId ? nextProfiles[0].id : lastUsedProfileId;
-    await this.repository.writeProfiles(nextProfiles, {
-      lastUsedProfileId: nextLastUsedProfileId,
-    });
+    const activeProfileId = await this.repository.getActiveProfileId();
+    if (activeProfileId === profileId) {
+      const nextActiveProfile = nextProfiles[0];
+      await this.repository.setActiveProfileId(nextActiveProfile.id, nextActiveProfile);
+    }
+
+    await this.repository.writeProfiles(nextProfiles);
     return nextProfiles;
   }
 }

--- a/scripts/destinations/ProfileResolver.js
+++ b/scripts/destinations/ProfileResolver.js
@@ -59,10 +59,10 @@ export class ProfileResolver {
       return profiles[profileIndex];
     }
 
-    const lastUsedProfileId = await this.repository.getLastUsedProfileId();
-    const lastUsedProfile = allowedProfiles.find(profile => profile.id === lastUsedProfileId);
-    if (lastUsedProfile) {
-      return lastUsedProfile;
+    const activeProfileId = await this.repository.getActiveProfileId();
+    const activeProfile = allowedProfiles.find(profile => profile.id === activeProfileId);
+    if (activeProfile) {
+      return activeProfile;
     }
 
     return allowedProfiles[0];

--- a/scripts/destinations/ProfileResolver.js
+++ b/scripts/destinations/ProfileResolver.js
@@ -26,16 +26,6 @@ export class ProfileResolver {
     return await this.entitlementProvider.getDestinationEntitlement();
   }
 
-  async setLastUsedProfile(profileId) {
-    const profiles = await this.ensureMigratedDefaultProfile();
-    const profile = profiles.find(item => item.id === profileId);
-    if (!profile) {
-      throw new Error(DESTINATION_PROFILE_ERRORS.NOT_FOUND);
-    }
-    await this.repository.setLastUsedProfileId(profile.id);
-    return profile;
-  }
-
   async resolveProfileForSave(profileId) {
     const profiles = await this.ensureMigratedDefaultProfile();
     if (profiles.length === 0) {

--- a/scripts/destinations/ProfileStore.js
+++ b/scripts/destinations/ProfileStore.js
@@ -11,6 +11,7 @@ import Logger from '../utils/Logger.js';
 export const DESTINATION_PROFILE_STORAGE_KEYS = {
   PROFILES: 'destinationProfiles',
   LAST_USED_PROFILE_ID: 'destinationLastUsedProfileId',
+  ACTIVE_PROFILE_ID: 'destinationActiveProfileId',
   VERSION: 'destinationProfilesVersion',
 };
 
@@ -148,6 +149,7 @@ export class LocalDestinationProfileRepository {
     return await storageLocal.get([
       DESTINATION_PROFILE_STORAGE_KEYS.PROFILES,
       DESTINATION_PROFILE_STORAGE_KEYS.LAST_USED_PROFILE_ID,
+      DESTINATION_PROFILE_STORAGE_KEYS.ACTIVE_PROFILE_ID,
       DESTINATION_PROFILE_STORAGE_KEYS.VERSION,
       ...LEGACY_DATA_SOURCE_KEYS,
     ]);
@@ -156,6 +158,12 @@ export class LocalDestinationProfileRepository {
   async getLastUsedProfileId() {
     const state = await this.getRawState();
     const id = state[DESTINATION_PROFILE_STORAGE_KEYS.LAST_USED_PROFILE_ID];
+    return typeof id === 'string' && id.trim() ? id : null;
+  }
+
+  async getActiveProfileId() {
+    const state = await this.getRawState();
+    const id = state[DESTINATION_PROFILE_STORAGE_KEYS.ACTIVE_PROFILE_ID];
     return typeof id === 'string' && id.trim() ? id : null;
   }
 
@@ -171,6 +179,10 @@ export class LocalDestinationProfileRepository {
         options.lastUsedProfileId ?? null;
     }
 
+    if (options.activeProfileId !== undefined) {
+      values[DESTINATION_PROFILE_STORAGE_KEYS.ACTIVE_PROFILE_ID] = options.activeProfileId ?? null;
+    }
+
     await storageLocal.set(values);
   }
 
@@ -179,6 +191,16 @@ export class LocalDestinationProfileRepository {
     await storageLocal.set({
       [DESTINATION_PROFILE_STORAGE_KEYS.LAST_USED_PROFILE_ID]: profileId,
     });
+  }
+
+  async setActiveProfileId(profileId, legacyTargetProfile = null) {
+    const storageLocal = this._requireStorage();
+    await storageLocal.set({
+      [DESTINATION_PROFILE_STORAGE_KEYS.ACTIVE_PROFILE_ID]: profileId,
+    });
+    if (legacyTargetProfile) {
+      await this.writeLegacyTarget(legacyTargetProfile);
+    }
   }
 
   async writeLegacyTarget(profile) {

--- a/scripts/destinations/ProfileStore.js
+++ b/scripts/destinations/ProfileStore.js
@@ -229,6 +229,25 @@ export async function ensureMigratedDefaultProfile(repository) {
   return [defaultProfile];
 }
 
+export async function resolveActiveProfile(repository) {
+  const profiles = await ensureMigratedDefaultProfile(repository);
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  const activeId = await repository.getActiveProfileId();
+  const active = profiles.find(p => p.id === activeId);
+  if (active) {
+    return active;
+  }
+
+  // 一次性遷移：activeProfileId 缺失或失效 → 用 lastUsedProfileId，否則第一個 profile
+  const lastUsedId = await repository.getLastUsedProfileId();
+  const seed = profiles.find(p => p.id === lastUsedId) || profiles[0];
+  await repository.setActiveProfileId(seed.id, seed);
+  return seed;
+}
+
 export class AccountGatedDestinationEntitlementProvider {
   async getDestinationEntitlement() {
     try {

--- a/tests/helpers/optionsTestHarness.js
+++ b/tests/helpers/optionsTestHarness.js
@@ -17,8 +17,9 @@ export function appendSaveFormFields() {
 }
 
 export async function flushAsyncClick() {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
 }
 
 export async function waitForLoggerWarn(Logger, message) {
@@ -191,6 +192,8 @@ export function buildProfileManagerMock(overrides = {}) {
     }),
     updateProfile: jest.fn(),
     createProfile: jest.fn().mockResolvedValue({ id: 'profile-2' }),
+    getActiveProfile: jest.fn().mockResolvedValue(profiles[0]),
+    setActiveProfile: jest.fn().mockResolvedValue(profiles[0]),
     deleteProfile: jest.fn().mockResolvedValue(profiles),
     ...overrides,
   };

--- a/tests/helpers/saveHandlersTestHarness.js
+++ b/tests/helpers/saveHandlersTestHarness.js
@@ -126,7 +126,6 @@ export function createMockServices() {
         notionDataSourceId: 'db-123',
         notionDataSourceType: 'database',
       }),
-      setLastUsedProfile: jest.fn().mockResolvedValue(),
     },
   };
 }

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -103,6 +103,10 @@ const chrome = {
           });
         } else if (keys === null || keys === undefined) {
           Object.assign(result, syncStorageData);
+        } else if (typeof keys === 'object') {
+          Object.entries(keys).forEach(([key, defaultValue]) => {
+            result[key] = syncStorageData[key] === undefined ? defaultValue : syncStorageData[key];
+          });
         }
         if (callback) {
           callback(result);
@@ -151,6 +155,11 @@ const chrome = {
           });
         } else if (keys === null || keys === undefined) {
           Object.assign(result, sessionStorageData);
+        } else if (typeof keys === 'object') {
+          Object.entries(keys).forEach(([key, defaultValue]) => {
+            result[key] =
+              sessionStorageData[key] === undefined ? defaultValue : sessionStorageData[key];
+          });
         }
         if (callback) {
           callback(result);

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -26,6 +26,7 @@
 // ========== 內部狀態（跨測試共享）==========
 const localStorageData = {};
 const syncStorageData = {};
+const sessionStorageData = {};
 let mockTabIdCounter = 1000;
 
 /** @type {import('../').ChromeMock} */
@@ -128,6 +129,54 @@ const chrome = {
       clear: jest.fn(callback => {
         Object.keys(syncStorageData).forEach(key => {
           delete syncStorageData[key];
+        });
+        if (callback) {
+          callback();
+        }
+        return Promise.resolve();
+      }),
+    },
+    session: {
+      get: jest.fn((keys, callback) => {
+        const result = {};
+        if (typeof keys === 'string') {
+          if (sessionStorageData[keys] !== undefined) {
+            result[keys] = sessionStorageData[keys];
+          }
+        } else if (Array.isArray(keys)) {
+          keys.forEach(key => {
+            if (sessionStorageData[key] !== undefined) {
+              result[key] = sessionStorageData[key];
+            }
+          });
+        } else if (keys === null || keys === undefined) {
+          Object.assign(result, sessionStorageData);
+        }
+        if (callback) {
+          callback(result);
+        }
+        return Promise.resolve(result);
+      }),
+      set: jest.fn((items, callback) => {
+        Object.assign(sessionStorageData, items);
+        if (callback) {
+          callback();
+        }
+        return Promise.resolve();
+      }),
+      remove: jest.fn((keys, callback) => {
+        const keysArray = Array.isArray(keys) ? keys : [keys];
+        keysArray.forEach(key => {
+          delete sessionStorageData[key];
+        });
+        if (callback) {
+          callback();
+        }
+        return Promise.resolve();
+      }),
+      clear: jest.fn(callback => {
+        Object.keys(sessionStorageData).forEach(key => {
+          delete sessionStorageData[key];
         });
         if (callback) {
           callback();
@@ -309,14 +358,18 @@ const chrome = {
     Object.keys(syncStorageData).forEach(key => {
       delete syncStorageData[key];
     });
+    Object.keys(sessionStorageData).forEach(key => {
+      delete sessionStorageData[key];
+    });
     mockTabIdCounter = 1000;
   },
 
   /** 輔助方法：取得儲存資料（測試用） */
-  /** @returns {{local: object, sync: object}} */
+  /** @returns {{local: object, sync: object, session: object}} */
   _getStorage: () => ({
     local: { ...localStorageData },
     sync: { ...syncStorageData },
+    session: { ...sessionStorageData },
   }),
 };
 

--- a/tests/unit/background/handlers/actionHandlers.edge-cases.test.js
+++ b/tests/unit/background/handlers/actionHandlers.edge-cases.test.js
@@ -338,7 +338,6 @@ function createMigrationServiceMock() {
 function createDestinationProfileResolverMock() {
   return {
     resolveProfileForSave: jest.fn().mockResolvedValue(createDefaultProfile()),
-    setLastUsedProfile: jest.fn().mockResolvedValue(),
   };
 }
 

--- a/tests/unit/background/handlers/saveHandlers.savePage.test.js
+++ b/tests/unit/background/handlers/saveHandlers.savePage.test.js
@@ -52,9 +52,6 @@ describe('saveHandlers savePage', () => {
       'https://example.com',
       expect.objectContaining({ destinationProfileId: 'default' })
     );
-    expect(context.mockServices.destinationProfileResolver.setLastUsedProfile).toHaveBeenCalledWith(
-      'default'
-    );
   });
 
   test('savePage: payload 帶 profileId 時應使用該 profile 的 Notion target', async () => {

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -309,7 +309,7 @@ describe('Destination profile domain services', () => {
     );
   });
 
-  it('resolveProfileForSave 未明確指定 profile 時會忽略超出 entitlement 的 last-used profile', async () => {
+  it('resolveProfileForSave 未明確指定 profile 時會忽略超出 entitlement 的 active profile', async () => {
     entitlementProvider.getDestinationEntitlement.mockResolvedValue({
       maxProfiles: 1,
       source: 'test',
@@ -336,10 +336,40 @@ describe('Destination profile domain services', () => {
         updatedAt: 2,
       },
     ];
-    storageData.destinationLastUsedProfileId = 'second';
+    storageData.destinationActiveProfileId = 'second';
 
     await expect(resolver.resolveProfileForSave()).resolves.toEqual(
       expect.objectContaining({ id: 'default' })
+    );
+  });
+
+  it('resolveProfileForSave 未明確指定 profile 時會優先使用 activeProfileId 指向的 profile', async () => {
+    storageData.destinationProfiles = [
+      {
+        id: 'default',
+        name: 'Default',
+        icon: 'bookmark',
+        color: '#2563eb',
+        notionDataSourceId: 'source-1',
+        notionDataSourceType: 'database',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        id: 'second',
+        name: 'Second',
+        icon: 'bookmark',
+        color: '#16a34a',
+        notionDataSourceId: 'source-2',
+        notionDataSourceType: 'page',
+        createdAt: 2,
+        updatedAt: 2,
+      },
+    ];
+    storageData.destinationActiveProfileId = 'second';
+
+    await expect(resolver.resolveProfileForSave()).resolves.toEqual(
+      expect.objectContaining({ id: 'second' })
     );
   });
 

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -41,6 +41,30 @@ describe('Destination profile domain services', () => {
   let resolver = null;
   let entitlementProvider = null;
 
+  const buildProfile = (overrides = {}) => ({
+    id: 'default',
+    name: 'Default',
+    icon: 'bookmark',
+    color: '#2563eb',
+    notionDataSourceId: 'source-1',
+    notionDataSourceType: 'database',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  });
+
+  const buildSecondProfile = (overrides = {}) =>
+    buildProfile({
+      id: 'second',
+      name: 'Second',
+      color: '#16a34a',
+      notionDataSourceId: 'source-2',
+      notionDataSourceType: 'page',
+      createdAt: 2,
+      updatedAt: 2,
+      ...overrides,
+    });
+
   beforeEach(() => {
     storageData = {};
     chromeStorage = {
@@ -99,16 +123,11 @@ describe('Destination profile domain services', () => {
 
   it('已有 destinationProfiles 時不會重複建立 Default profile', async () => {
     storageData.destinationProfiles = [
-      {
+      buildProfile({
         id: 'existing',
         name: 'Existing',
-        icon: 'bookmark',
-        color: '#2563eb',
         notionDataSourceId: 'existing-source',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
+      }),
     ];
     storageData.notionDataSourceId = 'legacy-source';
 
@@ -169,18 +188,7 @@ describe('Destination profile domain services', () => {
       maxProfiles: 1,
       source: 'test',
     });
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile()];
 
     await expect(
       manager.createProfile({
@@ -195,18 +203,7 @@ describe('Destination profile domain services', () => {
   });
 
   it('createProfile 會拒絕 caller-provided duplicate id', async () => {
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile()];
 
     await expect(
       manager.createProfile({
@@ -219,18 +216,7 @@ describe('Destination profile domain services', () => {
   });
 
   it('createProfile 會將 caller-provided id trim 後檢查 duplicate', async () => {
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile()];
 
     await expect(
       manager.createProfile({
@@ -247,28 +233,7 @@ describe('Destination profile domain services', () => {
       maxProfiles: 1,
       source: 'test',
     });
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
-        id: 'second',
-        name: 'Second',
-        icon: 'bookmark',
-        color: '#16a34a',
-        notionDataSourceId: 'source-2',
-        notionDataSourceType: 'page',
-        createdAt: 2,
-        updatedAt: 2,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
 
     await expect(resolver.resolveProfileForSave('second')).rejects.toThrow(
       '此保存目標目前不可使用'
@@ -280,28 +245,7 @@ describe('Destination profile domain services', () => {
       maxProfiles: 1,
       source: 'test',
     });
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
-        id: 'second',
-        name: 'Second',
-        icon: 'bookmark',
-        color: '#16a34a',
-        notionDataSourceId: 'source-2',
-        notionDataSourceType: 'page',
-        createdAt: 2,
-        updatedAt: 2,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
     storageData.destinationActiveProfileId = 'second';
 
     await expect(resolver.resolveProfileForSave()).resolves.toEqual(
@@ -310,28 +254,7 @@ describe('Destination profile domain services', () => {
   });
 
   it('resolveProfileForSave 未明確指定 profile 時會優先使用 activeProfileId 指向的 profile', async () => {
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
-        id: 'second',
-        name: 'Second',
-        icon: 'bookmark',
-        color: '#16a34a',
-        notionDataSourceId: 'source-2',
-        notionDataSourceType: 'page',
-        createdAt: 2,
-        updatedAt: 2,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
     storageData.destinationActiveProfileId = 'second';
 
     await expect(resolver.resolveProfileForSave()).resolves.toEqual(
@@ -340,18 +263,7 @@ describe('Destination profile domain services', () => {
   });
 
   it('更新 Default profile 時會同步回寫舊保存目標 keys', async () => {
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile()];
 
     await manager.updateProfile('default', {
       notionDataSourceId: 'source-2',
@@ -364,18 +276,7 @@ describe('Destination profile domain services', () => {
   });
 
   it('updateProfile 會忽略 updates.id 並保留原始 profile id', async () => {
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile()];
 
     const updated = await manager.updateProfile('default', {
       id: 'mutated-id',
@@ -390,28 +291,7 @@ describe('Destination profile domain services', () => {
 
   it('刪除 active profile 時會把 active 指向剩餘第一個 profile', async () => {
     storageData.destinationActiveProfileId = 'second';
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
-        id: 'second',
-        name: 'Second',
-        icon: 'bookmark',
-        color: '#16a34a',
-        notionDataSourceId: 'source-2',
-        notionDataSourceType: 'page',
-        createdAt: 2,
-        updatedAt: 2,
-      },
-    ];
+    storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
 
     await manager.deleteProfile('second');
 
@@ -429,18 +309,6 @@ describe('Destination profile domain services', () => {
   });
 
   describe('ProfileManager error branches', () => {
-    const buildProfile = overrides => ({
-      id: 'default',
-      name: 'Default',
-      icon: 'bookmark',
-      color: '#2563eb',
-      notionDataSourceId: 'source-1',
-      notionDataSourceType: 'database',
-      createdAt: 1,
-      updatedAt: 1,
-      ...overrides,
-    });
-
     it('getProfile 找不到 id 時拋 NOT_FOUND', async () => {
       storageData.destinationProfiles = [buildProfile()];
 
@@ -503,15 +371,7 @@ describe('Destination profile domain services', () => {
     });
 
     it('deleteProfile 對不存在 id 拋 NOT_FOUND', async () => {
-      storageData.destinationProfiles = [
-        buildProfile(),
-        buildProfile({
-          id: 'second',
-          notionDataSourceId: 'source-2',
-          createdAt: 2,
-          updatedAt: 2,
-        }),
-      ];
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
 
       await expect(manager.deleteProfile('missing')).rejects.toThrow(
         DESTINATION_PROFILE_ERRORS.NOT_FOUND
@@ -520,15 +380,7 @@ describe('Destination profile domain services', () => {
 
     it('deleteProfile 刪除非 active profile 時保留原 activeProfileId', async () => {
       storageData.destinationActiveProfileId = 'default';
-      storageData.destinationProfiles = [
-        buildProfile(),
-        buildProfile({
-          id: 'second',
-          notionDataSourceId: 'source-2',
-          createdAt: 2,
-          updatedAt: 2,
-        }),
-      ];
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
 
       const remaining = await manager.deleteProfile('second');
 

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -309,6 +309,35 @@ describe('Destination profile domain services', () => {
   });
 
   describe('ProfileManager error branches', () => {
+    it('getProfile 找到 id 時回傳對應 profile', async () => {
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
+
+      await expect(manager.getProfile('second')).resolves.toEqual(
+        expect.objectContaining({
+          id: 'second',
+          notionDataSourceId: 'source-2',
+        })
+      );
+    });
+
+    it('getActiveProfile 會回傳 activeProfileId 指向的 profile', async () => {
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
+      storageData.destinationActiveProfileId = 'second';
+
+      await expect(manager.getActiveProfile()).resolves.toEqual(
+        expect.objectContaining({ id: 'second' })
+      );
+    });
+
+    it('setActiveProfile 會驗證 profile 並寫入 activeProfileId', async () => {
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
+
+      const activeProfile = await manager.setActiveProfile('second');
+
+      expect(activeProfile).toEqual(expect.objectContaining({ id: 'second' }));
+      expect(storageData.destinationActiveProfileId).toBe('second');
+    });
+
     it('getProfile 找不到 id 時拋 NOT_FOUND', async () => {
       storageData.destinationProfiles = [buildProfile()];
 

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -275,40 +275,6 @@ describe('Destination profile domain services', () => {
     );
   });
 
-  it('getLastUsedProfile 會忽略超出 entitlement 上限的 last-used profile', async () => {
-    entitlementProvider.getDestinationEntitlement.mockResolvedValue({
-      maxProfiles: 1,
-      source: 'test',
-    });
-    storageData.destinationProfiles = [
-      {
-        id: 'default',
-        name: 'Default',
-        icon: 'bookmark',
-        color: '#2563eb',
-        notionDataSourceId: 'source-1',
-        notionDataSourceType: 'database',
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      {
-        id: 'second',
-        name: 'Second',
-        icon: 'bookmark',
-        color: '#16a34a',
-        notionDataSourceId: 'source-2',
-        notionDataSourceType: 'page',
-        createdAt: 2,
-        updatedAt: 2,
-      },
-    ];
-    storageData.destinationLastUsedProfileId = 'second';
-
-    await expect(manager.getLastUsedProfile()).resolves.toEqual(
-      expect.objectContaining({ id: 'default' })
-    );
-  });
-
   it('resolveProfileForSave 未明確指定 profile 時會忽略超出 entitlement 的 active profile', async () => {
     entitlementProvider.getDestinationEntitlement.mockResolvedValue({
       maxProfiles: 1,
@@ -422,8 +388,8 @@ describe('Destination profile domain services', () => {
     expect(storageData.notionDataSourceId).toBe('source-2');
   });
 
-  it('刪除 last-used profile 時會把 last-used 指向剩餘第一個 profile', async () => {
-    storageData.destinationLastUsedProfileId = 'second';
+  it('刪除 active profile 時會把 active 指向剩餘第一個 profile', async () => {
+    storageData.destinationActiveProfileId = 'second';
     storageData.destinationProfiles = [
       {
         id: 'default',
@@ -450,7 +416,7 @@ describe('Destination profile domain services', () => {
     await manager.deleteProfile('second');
 
     expect(storageData.destinationProfiles.map(profile => profile.id)).toEqual(['default']);
-    expect(storageData.destinationLastUsedProfileId).toBe('default');
+    expect(storageData.destinationActiveProfileId).toBe('default');
   });
 
   it('repository 使用 canonical destination storage keys', () => {
@@ -479,43 +445,6 @@ describe('Destination profile domain services', () => {
       storageData.destinationProfiles = [buildProfile()];
 
       await expect(manager.getProfile('missing')).rejects.toThrow(
-        DESTINATION_PROFILE_ERRORS.NOT_FOUND
-      );
-    });
-
-    it('getLastUsedProfile 在 entitlement.maxProfiles 為 0 時回 null', async () => {
-      entitlementProvider.getDestinationEntitlement.mockResolvedValue({
-        maxProfiles: 0,
-        source: 'test',
-      });
-      storageData.destinationProfiles = [buildProfile()];
-
-      await expect(manager.getLastUsedProfile()).resolves.toBeNull();
-    });
-
-    it('setLastUsedProfile happy path 會寫入 lastUsedProfileId 並回傳 profile', async () => {
-      storageData.destinationProfiles = [
-        buildProfile(),
-        buildProfile({
-          id: 'second',
-          name: 'Second',
-          notionDataSourceId: 'source-2',
-          notionDataSourceType: 'page',
-          createdAt: 2,
-          updatedAt: 2,
-        }),
-      ];
-
-      const result = await manager.setLastUsedProfile('second');
-
-      expect(result.id).toBe('second');
-      expect(storageData.destinationLastUsedProfileId).toBe('second');
-    });
-
-    it('setLastUsedProfile 對不存在 id 拋 NOT_FOUND', async () => {
-      storageData.destinationProfiles = [buildProfile()];
-
-      await expect(manager.setLastUsedProfile('missing')).rejects.toThrow(
         DESTINATION_PROFILE_ERRORS.NOT_FOUND
       );
     });
@@ -589,8 +518,8 @@ describe('Destination profile domain services', () => {
       );
     });
 
-    it('deleteProfile 刪除非 last-used profile 時保留原 lastUsedProfileId', async () => {
-      storageData.destinationLastUsedProfileId = 'default';
+    it('deleteProfile 刪除非 active profile 時保留原 activeProfileId', async () => {
+      storageData.destinationActiveProfileId = 'default';
       storageData.destinationProfiles = [
         buildProfile(),
         buildProfile({
@@ -604,7 +533,7 @@ describe('Destination profile domain services', () => {
       const remaining = await manager.deleteProfile('second');
 
       expect(remaining.map(profile => profile.id)).toEqual(['default']);
-      expect(storageData.destinationLastUsedProfileId).toBe('default');
+      expect(storageData.destinationActiveProfileId).toBe('default');
     });
   });
 

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -5,6 +5,7 @@ import {
   DESTINATION_PROFILE_ERRORS,
   DESTINATION_PROFILE_STORAGE_KEYS,
   LocalDestinationProfileRepository,
+  resolveActiveProfile,
 } from '../../../scripts/destinations/ProfileStore.js';
 import { ProfileManager } from '../../../scripts/destinations/ProfileManager.js';
 import { ProfileResolver } from '../../../scripts/destinations/ProfileResolver.js';
@@ -585,6 +586,45 @@ describe('Destination profile domain services', () => {
 
     it('returns null when activeProfileId is absent or blank', async () => {
       expect(await repository.getActiveProfileId()).toBeNull();
+    });
+  });
+
+  describe('resolveActiveProfile', () => {
+    it('returns the profile pointed to by activeProfileId', async () => {
+      await repository.writeProfiles([
+        { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
+        { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+      ]);
+      await repository.setActiveProfileId('p2');
+      const profile = await resolveActiveProfile(repository);
+      expect(profile.id).toBe('p2');
+    });
+
+    it('migrates from lastUsedProfileId when activeProfileId is empty, then backfills', async () => {
+      await repository.writeProfiles(
+        [
+          { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
+          { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+        ],
+        { lastUsedProfileId: 'p2' }
+      );
+      const profile = await resolveActiveProfile(repository);
+      expect(profile.id).toBe('p2');
+      expect(await repository.getActiveProfileId()).toBe('p2'); // backfilled
+    });
+
+    it('falls back to first profile when both ids absent/invalid', async () => {
+      await repository.writeProfiles([
+        { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
+      ]);
+      await repository.setActiveProfileId('ghost');
+      const profile = await resolveActiveProfile(repository);
+      expect(profile.id).toBe('default');
+      expect(await repository.getActiveProfileId()).toBe('default'); // corrected
+    });
+
+    it('returns null when there are no profiles', async () => {
+      expect(await resolveActiveProfile(repository)).toBeNull();
     });
   });
 });

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -426,6 +426,7 @@ describe('Destination profile domain services', () => {
     expect(DESTINATION_PROFILE_STORAGE_KEYS).toEqual({
       PROFILES: 'destinationProfiles',
       LAST_USED_PROFILE_ID: 'destinationLastUsedProfileId',
+      ACTIVE_PROFILE_ID: 'destinationActiveProfileId',
       VERSION: 'destinationProfilesVersion',
     });
   });
@@ -573,6 +574,17 @@ describe('Destination profile domain services', () => {
 
       expect(remaining.map(profile => profile.id)).toEqual(['default']);
       expect(storageData.destinationLastUsedProfileId).toBe('default');
+    });
+  });
+
+  describe('activeProfileId repository', () => {
+    it('writes and reads activeProfileId from local storage', async () => {
+      await repository.setActiveProfileId('destination_abc');
+      expect(await repository.getActiveProfileId()).toBe('destination_abc');
+    });
+
+    it('returns null when activeProfileId is absent or blank', async () => {
+      expect(await repository.getActiveProfileId()).toBeNull();
     });
   });
 });

--- a/tests/unit/destinations/profile-domain.test.js
+++ b/tests/unit/destinations/profile-domain.test.js
@@ -387,6 +387,16 @@ describe('Destination profile domain services', () => {
       expect(remaining.map(profile => profile.id)).toEqual(['default']);
       expect(storageData.destinationActiveProfileId).toBe('default');
     });
+
+    it('deleteProfile 刪除 active profile 時改派為第一個剩餘 profile', async () => {
+      storageData.destinationActiveProfileId = 'second';
+      storageData.destinationProfiles = [buildProfile(), buildSecondProfile()];
+
+      const remaining = await manager.deleteProfile('second');
+
+      expect(remaining.map(profile => profile.id)).toEqual(['default']);
+      expect(storageData.destinationActiveProfileId).toBe('default');
+    });
   });
 
   describe('activeProfileId repository', () => {

--- a/tests/unit/options/optionsDestinationProfiles.test.js
+++ b/tests/unit/options/optionsDestinationProfiles.test.js
@@ -438,7 +438,7 @@ describe('Destination profile options UI', () => {
     expect(service.listProfiles).toHaveBeenCalledTimes(2);
   });
 
-  it('保存目標套用與刪除按鈕應呼叫對應 service flow', async () => {
+  it('保存目標啟用開關與刪除按鈕應呼叫對應 service flow', async () => {
     const profiles = [
       {
         id: 'default',
@@ -469,21 +469,22 @@ describe('Destination profile options UI', () => {
     initOptions();
     await flushAsyncClick();
 
-    document.querySelector('button[data-action="edit"]').click();
+    const input = document.querySelector('input[data-profile-id="profile-2"]');
+    input.checked = true;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
     await flushAsyncClick();
 
-    expect(document.querySelector('#database-id').value).toBe('target-page-id');
-    expect(document.querySelector('#database-type').value).toBe('page');
+    expect(service.setActiveProfile).toHaveBeenCalledWith('profile-2');
     expect(mockUiInstance.showStatus).toHaveBeenCalledWith(
-      UI_MESSAGES.OPTIONS.DESTINATION.APPLY_SUCCESS('Second'),
-      'info'
+      UI_MESSAGES.OPTIONS.DESTINATION.ACTIVATED('Second'),
+      'success'
     );
 
     document.querySelector('button[data-action="delete"][data-profile-id="profile-2"]').click();
     await flushAsyncClick();
 
     expect(service.deleteProfile).toHaveBeenCalledWith('profile-2');
-    expect(service.listProfiles).toHaveBeenCalledTimes(2);
+    expect(service.listProfiles).toHaveBeenCalledTimes(3);
   });
 
   it('刪除保存目標失敗時應顯示錯誤而不是留下 unhandled rejection', async () => {
@@ -546,6 +547,84 @@ describe('Destination profile options UI', () => {
     expect(Logger.warn).toHaveBeenCalledWith('保存目標操作失敗', {
       action: 'destinationProfileAction',
       error: sanitizeApiError(renameError, 'destinationProfileAction'),
+    });
+  });
+
+  describe('destination profile radio-as-switch', () => {
+    const twoProfiles = [
+      {
+        id: 'default',
+        name: 'Default',
+        color: '#2563eb',
+        notionDataSourceId: 'A',
+        notionDataSourceType: 'database',
+      },
+      {
+        id: 'p2',
+        name: 'Second',
+        color: '#16a34a',
+        notionDataSourceId: 'B',
+        notionDataSourceType: 'page',
+      },
+    ];
+
+    it('renders one radio input per profile inside role=radio rows', async () => {
+      const service = buildProfileManagerMock({ profiles: twoProfiles });
+      await renderDestinationProfilesWithService(service);
+      expect(document.querySelectorAll('input[name="active-destination"]')).toHaveLength(2);
+      expect(document.querySelectorAll('.destination-profile-row[role="radio"]')).toHaveLength(2);
+    });
+
+    it('checks the row matching activeProfileId', async () => {
+      const service = buildProfileManagerMock({ profiles: twoProfiles });
+      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
+      await renderDestinationProfilesWithService(service);
+      const checked = document.querySelector('input[name="active-destination"]:checked');
+      expect(checked.dataset.profileId).toBe('p2');
+    });
+
+    it('calls setActiveProfile when a non-active switch is toggled on', async () => {
+      const service = buildProfileManagerMock({ profiles: twoProfiles });
+      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
+      await renderDestinationProfilesWithService(service);
+      const input = document.querySelector('input[data-profile-id="default"]');
+      input.checked = true;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await flushAsyncClick();
+      expect(service.setActiveProfile).toHaveBeenCalledWith('default');
+    });
+
+    it('blocks turning off the currently active switch and restores it', async () => {
+      const service = buildProfileManagerMock({ profiles: twoProfiles });
+      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
+      await renderDestinationProfilesWithService(service);
+      const activeInput = document.querySelector('input[data-profile-id="p2"]');
+      activeInput.checked = false;
+      activeInput.dispatchEvent(new Event('change', { bubbles: true }));
+      await flushAsyncClick();
+      expect(activeInput.checked).toBe(true);
+      expect(service.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('reassigns activeProfileId to first remaining profile when active profile is deleted', async () => {
+      const profiles = [
+        {
+          id: 'default',
+          name: 'Default',
+          notionDataSourceId: 'A',
+          notionDataSourceType: 'database',
+        },
+        { id: 'p2', name: 'Second', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+      ];
+      const service = buildProfileManagerMock({ profiles });
+      service.getActiveProfile.mockResolvedValue(profiles[1]); // p2 active
+      service.deleteProfile.mockResolvedValue([profiles[0]]); // 刪 p2 後剩 default
+      await renderDestinationProfilesWithService(service);
+
+      document.querySelector('button[data-action="delete"][data-profile-id="p2"]').click();
+      await flushAsyncClick();
+
+      expect(service.setActiveProfile).toHaveBeenCalledWith('default');
     });
   });
 });

--- a/tests/unit/options/optionsDestinationProfiles.test.js
+++ b/tests/unit/options/optionsDestinationProfiles.test.js
@@ -623,7 +623,7 @@ describe('Destination profile options UI', () => {
       expect(service.setActiveProfile).not.toHaveBeenCalled();
     });
 
-    it('reassigns activeProfileId to first remaining profile when active profile is deleted', async () => {
+    it('delegates deletion to service.deleteProfile without reassigning at the UI layer', async () => {
       const profiles = [
         {
           id: 'default',
@@ -641,7 +641,8 @@ describe('Destination profile options UI', () => {
       document.querySelector('button[data-action="delete"][data-profile-id="p2"]').click();
       await flushAsyncClick();
 
-      expect(service.setActiveProfile).toHaveBeenCalledWith('default');
+      expect(service.deleteProfile).toHaveBeenCalledWith('p2');
+      expect(service.setActiveProfile).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/options/optionsDestinationProfiles.test.js
+++ b/tests/unit/options/optionsDestinationProfiles.test.js
@@ -614,10 +614,12 @@ describe('Destination profile options UI', () => {
       expect(service.setActiveProfile).toHaveBeenCalledWith('default');
     });
 
-    it('blocks turning off the currently active switch and restores it', async () => {
+    it('ignores clicks on the currently active switch', async () => {
       const service = await renderDestinationSwitchesWithSecondProfileActive();
+      const activeInput = document.querySelector('input[data-profile-id="p2"]');
 
-      const activeInput = await changeProfileSwitch('p2', false);
+      activeInput.click();
+      await flushAsyncClick();
 
       expect(activeInput.checked).toBe(true);
       expect(service.setActiveProfile).not.toHaveBeenCalled();

--- a/tests/unit/options/optionsDestinationProfiles.test.js
+++ b/tests/unit/options/optionsDestinationProfiles.test.js
@@ -113,6 +113,20 @@ describe('Destination profile options UI', () => {
     return document.querySelector('input[data-role="destination-profile-name-edit"]');
   }
 
+  async function renderDestinationProfilesWithReadFailure(methodName, error) {
+    const service = buildProfileManagerMock({
+      [methodName]: jest.fn().mockRejectedValue(error),
+    });
+    await renderDestinationProfilesWithService(service);
+  }
+
+  function expectDestinationProfileRenderWarning(message, error, context) {
+    expect(Logger.warn).toHaveBeenCalledWith(message, {
+      action: 'renderDestinationProfiles',
+      error: sanitizeApiError(error, context),
+    });
+  }
+
   it('未登入且已達上限時，新增保存目標按鈕應 disabled 並顯示原因', async () => {
     ProfileManager.mockImplementationOnce(() => ({
       ensureMigratedDefaultProfile: jest.fn().mockResolvedValue([{ id: 'default' }]),
@@ -154,32 +168,28 @@ describe('Destination profile options UI', () => {
 
   it('render 應在 entitlement 讀取失敗時仍渲染 profiles 並記錄警告', async () => {
     const entitlementError = new Error('entitlement failed');
-    const service = buildProfileManagerMock({
-      getDestinationEntitlement: jest.fn().mockRejectedValue(entitlementError),
-    });
 
-    await renderDestinationProfilesWithService(service);
+    await renderDestinationProfilesWithReadFailure('getDestinationEntitlement', entitlementError);
 
     expect(document.querySelector('.destination-profile-title').textContent).toBe('Default');
-    expect(Logger.warn).toHaveBeenCalledWith('讀取保存目標權限失敗', {
-      action: 'renderDestinationProfiles',
-      error: sanitizeApiError(entitlementError, 'destinationProfileEntitlement'),
-    });
+    expectDestinationProfileRenderWarning(
+      '讀取保存目標權限失敗',
+      entitlementError,
+      'destinationProfileEntitlement'
+    );
   });
 
   it('render 應在 profile list 讀取失敗時使用空列表並記錄警告', async () => {
     const listError = new Error('list failed');
-    const service = buildProfileManagerMock({
-      listProfiles: jest.fn().mockRejectedValue(listError),
-    });
 
-    await renderDestinationProfilesWithService(service);
+    await renderDestinationProfilesWithReadFailure('listProfiles', listError);
 
     expect(document.querySelector('.destination-profile-row')).toBeNull();
-    expect(Logger.warn).toHaveBeenCalledWith('讀取保存目標列表失敗', {
-      action: 'renderDestinationProfiles',
-      error: sanitizeApiError(listError, 'destinationProfileList'),
-    });
+    expectDestinationProfileRenderWarning(
+      '讀取保存目標列表失敗',
+      listError,
+      'destinationProfileList'
+    );
   });
 
   it('已達付費方案上限時應顯示付費方案提示', async () => {
@@ -568,6 +578,21 @@ describe('Destination profile options UI', () => {
       },
     ];
 
+    async function renderDestinationSwitchesWithSecondProfileActive() {
+      const service = buildProfileManagerMock({ profiles: twoProfiles });
+      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
+      await renderDestinationProfilesWithService(service);
+      return service;
+    }
+
+    async function changeProfileSwitch(profileId, checked) {
+      const input = document.querySelector(`input[data-profile-id="${profileId}"]`);
+      input.checked = checked;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await flushAsyncClick();
+      return input;
+    }
+
     it('renders one radio input per profile inside role=radio rows', async () => {
       const service = buildProfileManagerMock({ profiles: twoProfiles });
       await renderDestinationProfilesWithService(service);
@@ -576,32 +601,24 @@ describe('Destination profile options UI', () => {
     });
 
     it('checks the row matching activeProfileId', async () => {
-      const service = buildProfileManagerMock({ profiles: twoProfiles });
-      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
-      await renderDestinationProfilesWithService(service);
+      await renderDestinationSwitchesWithSecondProfileActive();
       const checked = document.querySelector('input[name="active-destination"]:checked');
       expect(checked.dataset.profileId).toBe('p2');
     });
 
     it('calls setActiveProfile when a non-active switch is toggled on', async () => {
-      const service = buildProfileManagerMock({ profiles: twoProfiles });
-      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
-      await renderDestinationProfilesWithService(service);
-      const input = document.querySelector('input[data-profile-id="default"]');
-      input.checked = true;
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-      await flushAsyncClick();
+      const service = await renderDestinationSwitchesWithSecondProfileActive();
+
+      await changeProfileSwitch('default', true);
+
       expect(service.setActiveProfile).toHaveBeenCalledWith('default');
     });
 
     it('blocks turning off the currently active switch and restores it', async () => {
-      const service = buildProfileManagerMock({ profiles: twoProfiles });
-      service.getActiveProfile.mockResolvedValue(twoProfiles[1]); // p2 active
-      await renderDestinationProfilesWithService(service);
-      const activeInput = document.querySelector('input[data-profile-id="p2"]');
-      activeInput.checked = false;
-      activeInput.dispatchEvent(new Event('change', { bubbles: true }));
-      await flushAsyncClick();
+      const service = await renderDestinationSwitchesWithSecondProfileActive();
+
+      const activeInput = await changeProfileSwitch('p2', false);
+
       expect(activeInput.checked).toBe(true);
       expect(service.setActiveProfile).not.toHaveBeenCalled();
     });

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -200,4 +200,16 @@ describe('options.html 結構', () => {
       /\.connection-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*auto;/
     );
   });
+
+  test('保存目標 profile row 應保留 switch、內容與 actions 三欄 layout', () => {
+    const cssPath = path.resolve(__dirname, '../../../pages/options/options.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+
+    expect(css).toMatch(
+      /\.destination-profile-row\s*\{[^}]*grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+auto;/
+    );
+    expect(css).toMatch(
+      /\.destination-profile-row\s*>\s*div:first-of-type\s*\{[^}]*min-width:\s*0;/
+    );
+  });
 });

--- a/tests/unit/popup/popupActions.test.js
+++ b/tests/unit/popup/popupActions.test.js
@@ -38,6 +38,96 @@ describe('popupActions.js', () => {
     isAccountSessionExpired,
   } = require('../../../scripts/auth/accountSession.js');
 
+  const TEST_API_KEY = 'test-key';
+
+  const setManualApiKey = (overrides = {}) =>
+    chrome.storage.sync.set({
+      notionApiKey: TEST_API_KEY,
+      ...overrides,
+    });
+
+  const mockDelayedLocalStorageSet = () => {
+    const originalSet = chrome.storage.local.set.bind(chrome.storage.local);
+    chrome.storage.local.set = jest.fn(
+      items =>
+        new Promise(resolve => {
+          setTimeout(async () => {
+            await originalSet(items);
+            resolve();
+          }, 0);
+        })
+    );
+
+    return () => {
+      chrome.storage.local.set = originalSet;
+    };
+  };
+
+  const expectMigratedDataSourceKeys = async expectedDataSourceId => {
+    const localData = await chrome.storage.local.get(['notionDataSourceId', 'notionDatabaseId']);
+
+    expect(localData.notionDataSourceId).toBe(expectedDataSourceId);
+    expect(localData.notionDatabaseId).toBe(expectedDataSourceId);
+  };
+
+  const mockRuntimeActionResponse = (action, response) => {
+    chrome.runtime.sendMessage.mockImplementation(msg => {
+      if (msg.action === action) {
+        return Promise.resolve(response);
+      }
+      return Promise.resolve({ success: true });
+    });
+  };
+
+  const mockRuntimeActionThrow = (action, error) => {
+    chrome.runtime.sendMessage.mockImplementation(msg => {
+      if (msg.action === action) {
+        throw error;
+      }
+      return Promise.resolve({ success: true });
+    });
+  };
+
+  const makeDestinationProfile = overrides => ({
+    id: 'default',
+    name: 'Default',
+    icon: 'bookmark',
+    color: '#2563eb',
+    notionDataSourceId: 'db-1',
+    notionDataSourceType: 'database',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  });
+
+  const makeResearchProfile = overrides =>
+    makeDestinationProfile({
+      id: 'profile-2',
+      name: 'Research',
+      icon: 'book-open',
+      color: '#16a34a',
+      notionDataSourceId: 'page-1',
+      notionDataSourceType: 'page',
+      createdAt: 2,
+      updatedAt: 2,
+      ...overrides,
+    });
+
+  const makeAccountProfile = () => ({
+    userId: 'u1',
+    email: 'user@example.com',
+    displayName: 'Test User',
+    avatarUrl: null,
+  });
+
+  const makePopupAccountState = overrides => ({
+    enabled: true,
+    isLoggedIn: false,
+    profile: null,
+    transientRefreshError: false,
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Logger, 'warn').mockImplementation(() => {});
@@ -55,9 +145,7 @@ describe('popupActions.js', () => {
 
   describe('checkSettings', () => {
     it('當設置完整時應該返回 valid: true', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-      });
+      await setManualApiKey();
       await chrome.storage.local.set({
         notionDataSourceId: 'test-db',
       });
@@ -78,9 +166,7 @@ describe('popupActions.js', () => {
     });
 
     it('當缺少 Data Source ID 時應該返回 valid: false', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-      });
+      await setManualApiKey();
 
       const result = await checkSettings();
       expect(result.valid).toBe(false);
@@ -117,119 +203,82 @@ describe('popupActions.js', () => {
       expect(result.missingReason).toBe('missing_auth');
     });
 
-    it('應該同時支持 notionDataSourceId 和 notionDatabaseId (兼容性檢查)', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-      });
-      await chrome.storage.local.set({
-        notionDatabaseId: 'old-db-id',
-      });
+    it.each([
+      {
+        name: '應該同時支持 notionDataSourceId 和 notionDatabaseId (兼容性檢查)',
+        syncData: {},
+        localData: { notionDatabaseId: 'old-db-id' },
+        expectedDataSourceId: 'old-db-id',
+      },
+      {
+        name: '當 local 無 dataSourceId 但 sync 有時，應回退讀取 sync 並返回 valid: true',
+        syncData: { notionDataSourceId: 'sync-db-id' },
+        localData: {},
+        expectedDataSourceId: 'sync-db-id',
+      },
+      {
+        name: '當 local 和 sync 都有 dataSourceId 時，應優先使用 local',
+        syncData: { notionDataSourceId: 'sync-db-id' },
+        localData: { notionDataSourceId: 'local-db-id' },
+        expectedDataSourceId: 'local-db-id',
+      },
+    ])('$name', async ({ syncData, localData, expectedDataSourceId }) => {
+      await setManualApiKey(syncData);
+      await chrome.storage.local.set(localData);
 
       const result = await checkSettings();
+
       expect(result.valid).toBe(true);
-      expect(result.dataSourceId).toBe('old-db-id');
+      expect(result.dataSourceId).toBe(expectedDataSourceId);
     });
 
-    it('當 local 無 dataSourceId 但 sync 有時，應回退讀取 sync 並返回 valid: true', async () => {
-      // 模擬 v2.47.0 前的升級用戶：dataSourceId 只在 sync
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-        notionDataSourceId: 'sync-db-id',
-      });
-      // local 中沒有 notionDataSourceId
+    it.each([
+      {
+        name: '當 sync 回退觸發時，應自動遷移 dataSourceId 至 local',
+        syncData: { notionDataSourceId: 'sync-db-id' },
+        expectedDataSourceId: 'sync-db-id',
+      },
+      {
+        name: '當 sync 僅有 notionDatabaseId (legacy key) 時，應回退並正確遷移',
+        syncData: { notionDatabaseId: 'legacy-sync-id' },
+        expectedDataSourceId: 'legacy-sync-id',
+      },
+    ])('$name', async ({ syncData, expectedDataSourceId }) => {
+      await setManualApiKey(syncData);
 
-      const result = await checkSettings();
-      expect(result.valid).toBe(true);
-      expect(result.dataSourceId).toBe('sync-db-id');
-    });
+      const restoreLocalSet = mockDelayedLocalStorageSet();
+      try {
+        const result = await checkSettings();
 
-    it('當 sync 回退觸發時，應自動遷移 dataSourceId 至 local', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-        notionDataSourceId: 'sync-db-id',
-      });
-
-      const originalSet = chrome.storage.local.set.bind(chrome.storage.local);
-      chrome.storage.local.set = jest.fn(
-        items =>
-          new Promise(resolve => {
-            setTimeout(async () => {
-              await originalSet(items);
-              resolve();
-            }, 0);
-          })
-      );
-
-      await checkSettings();
-
-      // 驗證自動遷移：local 應被寫入
-      const localData = await chrome.storage.local.get(['notionDataSourceId', 'notionDatabaseId']);
-      expect(localData.notionDataSourceId).toBe('sync-db-id');
-      expect(localData.notionDatabaseId).toBe('sync-db-id');
-    });
-
-    it('當 sync 僅有 notionDatabaseId (legacy key) 時，應回退並正確遷移', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-        notionDatabaseId: 'legacy-sync-id',
-      });
-
-      const originalSet = chrome.storage.local.set.bind(chrome.storage.local);
-      chrome.storage.local.set = jest.fn(
-        items =>
-          new Promise(resolve => {
-            setTimeout(async () => {
-              await originalSet(items);
-              resolve();
-            }, 0);
-          })
-      );
-
-      const result = await checkSettings();
-      expect(result.valid).toBe(true);
-      expect(result.dataSourceId).toBe('legacy-sync-id');
-
-      const localData = await chrome.storage.local.get(['notionDataSourceId', 'notionDatabaseId']);
-      expect(localData.notionDataSourceId).toBe('legacy-sync-id');
-      expect(localData.notionDatabaseId).toBe('legacy-sync-id');
+        expect(result.valid).toBe(true);
+        expect(result.dataSourceId).toBe(expectedDataSourceId);
+        await expectMigratedDataSourceKeys(expectedDataSourceId);
+      } finally {
+        restoreLocalSet();
+      }
     });
 
     it('當 chrome.storage.local.set 拋錯時，checkSettings 仍應正常回傳', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-        notionDataSourceId: 'sync-db-id',
-      });
+      await setManualApiKey({ notionDataSourceId: 'sync-db-id' });
 
       const originalSet = chrome.storage.local.set.bind(chrome.storage.local);
       chrome.storage.local.set = jest.fn().mockRejectedValueOnce(new Error('Quota exceeded'));
 
-      const result = await checkSettings();
-      expect(result.valid).toBe(true);
-      expect(result.dataSourceId).toBe('sync-db-id');
+      try {
+        const result = await checkSettings();
 
-      // 還原
-      chrome.storage.local.set = originalSet;
-    });
-
-    it('當 local 和 sync 都有 dataSourceId 時，應優先使用 local', async () => {
-      await chrome.storage.sync.set({
-        notionApiKey: 'test-key',
-        notionDataSourceId: 'sync-db-id',
-      });
-      await chrome.storage.local.set({
-        notionDataSourceId: 'local-db-id',
-      });
-
-      const result = await checkSettings();
-      expect(result.valid).toBe(true);
-      expect(result.dataSourceId).toBe('local-db-id');
+        expect(result.valid).toBe(true);
+        expect(result.dataSourceId).toBe('sync-db-id');
+      } finally {
+        chrome.storage.local.set = originalSet;
+      }
     });
 
     it('reports valid when a non-default active profile has a target but legacy top-level keys are absent', async () => {
       await chrome.storage.local.set({
         destinationProfiles: [
-          { id: 'default', notionDataSourceId: 'AAA', notionDataSourceType: 'database' },
-          { id: 'p2', notionDataSourceId: 'BBB', notionDataSourceType: 'page' },
+          makeDestinationProfile({ notionDataSourceId: 'AAA' }),
+          makeResearchProfile({ id: 'p2', notionDataSourceId: 'BBB' }),
         ],
         destinationActiveProfileId: 'p2',
         notionAuthMode: 'oauth',
@@ -245,13 +294,10 @@ describe('popupActions.js', () => {
 
   describe('checkPageStatus', () => {
     it('應該發送正確的訊息', async () => {
-      chrome.runtime.sendMessage.mockImplementation(msg => {
-        if (msg.action === 'checkPageStatus') {
-          return Promise.resolve({ success: true, isSaved: true });
-        }
-        return Promise.resolve({ success: true });
-      });
+      mockRuntimeActionResponse('checkPageStatus', { success: true, isSaved: true });
+
       const result = await checkPageStatus({ forceRefresh: true });
+
       expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'checkPageStatus',
@@ -262,26 +308,20 @@ describe('popupActions.js', () => {
     });
 
     it('當失敗時應該返回 success: false', async () => {
-      chrome.runtime.sendMessage.mockImplementation(msg => {
-        if (msg.action === 'checkPageStatus') {
-          throw new Error('Fail');
-        }
-        return Promise.resolve({ success: true });
-      });
+      mockRuntimeActionThrow('checkPageStatus', new Error('Fail'));
+
       const result = await checkPageStatus();
+
       expect(result.success).toBe(false);
     });
   });
 
   describe('savePage', () => {
     it('應該調用 savePage 動作', async () => {
-      chrome.runtime.sendMessage.mockImplementation(msg => {
-        if (msg.action === 'savePage') {
-          return Promise.resolve({ success: true });
-        }
-        return Promise.resolve({ success: true });
-      });
+      mockRuntimeActionResponse('savePage', { success: true });
+
       const result = await savePage();
+
       expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'savePage' })
       );
@@ -318,28 +358,7 @@ describe('popupActions.js', () => {
   describe('getDestinationState', () => {
     it('應從 destination profile service 讀取 profiles 並以 entitlement 內的 profile 作為選取值', async () => {
       await chrome.storage.local.set({
-        destinationProfiles: [
-          {
-            id: 'default',
-            name: 'Default',
-            icon: 'bookmark',
-            color: '#2563eb',
-            notionDataSourceId: 'db-1',
-            notionDataSourceType: 'database',
-            createdAt: 1,
-            updatedAt: 1,
-          },
-          {
-            id: 'profile-2',
-            name: 'Research',
-            icon: 'book-open',
-            color: '#16a34a',
-            notionDataSourceId: 'page-1',
-            notionDataSourceType: 'page',
-            createdAt: 2,
-            updatedAt: 2,
-          },
-        ],
+        destinationProfiles: [makeDestinationProfile(), makeResearchProfile()],
         destinationLastUsedProfileId: 'profile-2',
       });
 
@@ -352,18 +371,7 @@ describe('popupActions.js', () => {
 
     it('active 讀取失敗時仍應保留 profiles 並回退選第一個 profile', async () => {
       await chrome.storage.local.set({
-        destinationProfiles: [
-          {
-            id: 'default',
-            name: 'Default',
-            icon: 'bookmark',
-            color: '#2563eb',
-            notionDataSourceId: 'db-1',
-            notionDataSourceType: 'database',
-            createdAt: 1,
-            updatedAt: 1,
-          },
-        ],
+        destinationProfiles: [makeDestinationProfile()],
         destinationActiveProfileId: 'default',
       });
       const activeSpy = jest
@@ -390,18 +398,7 @@ describe('popupActions.js', () => {
 
     it('last-used 指向 profiles snapshot 外的 id 時應回退選第一個 profile', async () => {
       await chrome.storage.local.set({
-        destinationProfiles: [
-          {
-            id: 'default',
-            name: 'Default',
-            icon: 'bookmark',
-            color: '#2563eb',
-            notionDataSourceId: 'db-1',
-            notionDataSourceType: 'database',
-            createdAt: 1,
-            updatedAt: 1,
-          },
-        ],
+        destinationProfiles: [makeDestinationProfile()],
         destinationLastUsedProfileId: 'stale-profile',
       });
 
@@ -420,29 +417,33 @@ describe('popupActions.js', () => {
         isAccountSessionExpired.mockReturnValue(false);
       });
 
-      it('prefers session temp selection over activeProfileId', async () => {
+      it.each([
+        {
+          name: 'prefers session temp selection over activeProfileId',
+          activeProfileId: 'default',
+          sessionTempProfileId: 'p2',
+          expectedProfileId: 'p2',
+        },
+        {
+          name: 'falls back to activeProfileId when no session temp selection',
+          activeProfileId: 'p2',
+          sessionTempProfileId: null,
+          expectedProfileId: 'p2',
+        },
+      ])('$name', async ({ activeProfileId, sessionTempProfileId, expectedProfileId }) => {
         await chrome.storage.local.set({
           destinationProfiles: [
-            { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
-            { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+            makeDestinationProfile({ notionDataSourceId: 'A' }),
+            makeResearchProfile({ id: 'p2', notionDataSourceId: 'B' }),
           ],
-          destinationActiveProfileId: 'default',
+          destinationActiveProfileId: activeProfileId,
         });
-        await chrome.storage.session.set({ popupTempDestinationProfileId: 'p2' });
-        const state = await getDestinationState();
-        expect(state.selectedProfileId).toBe('p2');
-      });
+        if (sessionTempProfileId) {
+          await chrome.storage.session.set({ popupTempDestinationProfileId: sessionTempProfileId });
+        }
 
-      it('falls back to activeProfileId when no session temp selection', async () => {
-        await chrome.storage.local.set({
-          destinationProfiles: [
-            { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
-            { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
-          ],
-          destinationActiveProfileId: 'p2',
-        });
         const state = await getDestinationState();
-        expect(state.selectedProfileId).toBe('p2');
+        expect(state.selectedProfileId).toBe(expectedProfileId);
       });
     });
   });
@@ -457,12 +458,8 @@ describe('popupActions.js', () => {
 
   describe('startHighlight', () => {
     it('應該調用 startHighlight 動作', async () => {
-      chrome.runtime.sendMessage.mockImplementation(msg => {
-        if (msg.action === 'startHighlight') {
-          return Promise.resolve({ success: true });
-        }
-        return Promise.resolve({ success: true });
-      });
+      mockRuntimeActionResponse('startHighlight', { success: true });
+
       const result = await startHighlight();
 
       expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
@@ -558,52 +555,38 @@ describe('popupActions.js', () => {
 
       const result = await getPopupAccountState();
 
-      expect(result).toEqual({
-        enabled: true,
-        isLoggedIn: false,
-        profile: null,
-        transientRefreshError: false,
-      });
+      expect(result).toEqual(makePopupAccountState());
     });
 
-    it('已登入時應回傳 profile 與 logged in 狀態', async () => {
-      const profile = {
-        userId: 'u1',
-        email: 'user@example.com',
-        displayName: 'Test User',
-        avatarUrl: null,
-      };
-      getAccountProfile.mockResolvedValue(profile);
-      getAccountAccessToken.mockResolvedValue('token-123');
-
-      const result = await getPopupAccountState();
-
-      expect(result).toEqual({
-        enabled: true,
-        isLoggedIn: true,
-        profile,
+    it.each([
+      {
+        name: '已登入時應回傳 profile 與 logged in 狀態',
+        accessTokenError: null,
         transientRefreshError: false,
-      });
-    });
-
-    it('token 暫時刷新失敗時應保留 logged in 狀態並標記 transientRefreshError', async () => {
-      const profile = {
-        userId: 'u1',
-        email: 'user@example.com',
-        displayName: 'Test User',
-        avatarUrl: null,
-      };
-      getAccountProfile.mockResolvedValue(profile);
-      getAccountAccessToken.mockRejectedValue(new Error('transient refresh failure'));
-
-      const result = await getPopupAccountState();
-
-      expect(result).toEqual({
-        enabled: true,
-        isLoggedIn: true,
-        profile,
+      },
+      {
+        name: 'token 暫時刷新失敗時應保留 logged in 狀態並標記 transientRefreshError',
+        accessTokenError: new Error('transient refresh failure'),
         transientRefreshError: true,
-      });
+      },
+    ])('$name', async ({ accessTokenError, transientRefreshError }) => {
+      const profile = makeAccountProfile();
+      getAccountProfile.mockResolvedValue(profile);
+      if (accessTokenError) {
+        getAccountAccessToken.mockRejectedValue(accessTokenError);
+      } else {
+        getAccountAccessToken.mockResolvedValue('token-123');
+      }
+
+      const result = await getPopupAccountState();
+
+      expect(result).toEqual(
+        makePopupAccountState({
+          isLoggedIn: true,
+          profile,
+          transientRefreshError,
+        })
+      );
     });
 
     it('feature flag 關閉時應回傳 disabled account state', async () => {
@@ -611,12 +594,7 @@ describe('popupActions.js', () => {
 
       const result = await getPopupAccountState();
 
-      expect(result).toEqual({
-        enabled: false,
-        isLoggedIn: false,
-        profile: null,
-        transientRefreshError: false,
-      });
+      expect(result).toEqual(makePopupAccountState({ enabled: false }));
     });
 
     it('startAccountLogin 應以正確 query 開啟 Google start URL', async () => {
@@ -664,29 +642,33 @@ describe('popupActions.js', () => {
       });
     });
 
-    it('startAccountLogin 開啟 tab 失敗時應以 structured error context 記錄', async () => {
+    it.each([
+      {
+        name: 'startAccountLogin 開啟 tab 失敗時應以 structured error context 記錄',
+        actionFn: startAccountLogin,
+        logMessage: 'startAccountLogin failed',
+        logContext: {
+          action: 'startAccountLogin',
+          result: 'failed',
+        },
+      },
+      {
+        name: 'openAccountManagement 開啟 tab 失敗時應以 structured error context 記錄',
+        actionFn: openAccountManagement,
+        logMessage: 'openAccountManagement failed',
+        logContext: {
+          action: 'openAccountManagement',
+        },
+      },
+    ])('$name', async ({ actionFn, logMessage, logContext }) => {
       const error = new Error('tabs unavailable');
       chrome.tabs.create.mockRejectedValue(error);
 
-      const result = await startAccountLogin();
+      const result = await actionFn();
 
       expect(result.success).toBe(false);
-      expect(Logger.warn).toHaveBeenCalledWith('startAccountLogin failed', {
-        action: 'startAccountLogin',
-        result: 'failed',
-        error,
-      });
-    });
-
-    it('openAccountManagement 開啟 tab 失敗時應以 structured error context 記錄', async () => {
-      const error = new Error('tabs unavailable');
-      chrome.tabs.create.mockRejectedValue(error);
-
-      const result = await openAccountManagement();
-
-      expect(result.success).toBe(false);
-      expect(Logger.warn).toHaveBeenCalledWith('openAccountManagement failed', {
-        action: 'openAccountManagement',
+      expect(Logger.warn).toHaveBeenCalledWith(logMessage, {
+        ...logContext,
         error,
       });
     });

--- a/tests/unit/popup/popupActions.test.js
+++ b/tests/unit/popup/popupActions.test.js
@@ -445,6 +445,32 @@ describe('popupActions.js', () => {
         const state = await getDestinationState();
         expect(state.selectedProfileId).toBe(expectedProfileId);
       });
+
+      it('falls back to activeProfileId without warning when session storage is unavailable', async () => {
+        await chrome.storage.local.set({
+          destinationProfiles: [
+            makeDestinationProfile({ notionDataSourceId: 'A' }),
+            makeResearchProfile({ id: 'p2', notionDataSourceId: 'B' }),
+          ],
+          destinationActiveProfileId: 'p2',
+        });
+        const originalSessionStorage = chrome.storage.session;
+        try {
+          delete chrome.storage.session;
+
+          const state = await getDestinationState();
+
+          expect(state.selectedProfileId).toBe('p2');
+          expect(Logger.warn).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              action: 'getDestinationState',
+              operation: 'getSessionTempProfile',
+            })
+          );
+        } finally {
+          chrome.storage.session = originalSessionStorage;
+        }
+      });
     });
   });
 
@@ -453,6 +479,22 @@ describe('popupActions.js', () => {
       await setPopupTempProfile('p2');
       const result = await chrome.storage.session.get('popupTempDestinationProfileId');
       expect(result.popupTempDestinationProfileId).toBe('p2');
+    });
+
+    it('silently skips persistence when session storage is unavailable', async () => {
+      const originalSessionStorage = chrome.storage.session;
+      try {
+        delete chrome.storage.session;
+
+        await setPopupTempProfile('p2');
+
+        expect(Logger.warn).not.toHaveBeenCalledWith(
+          'Failed to persist popup temp profile selection:',
+          expect.anything()
+        );
+      } finally {
+        chrome.storage.session = originalSessionStorage;
+      }
     });
   });
 

--- a/tests/unit/popup/popupActions.test.js
+++ b/tests/unit/popup/popupActions.test.js
@@ -216,6 +216,23 @@ describe('popupActions.js', () => {
       expect(result.valid).toBe(true);
       expect(result.dataSourceId).toBe('local-db-id');
     });
+
+    it('reports valid when a non-default active profile has a target but legacy top-level keys are absent', async () => {
+      await chrome.storage.local.set({
+        destinationProfiles: [
+          { id: 'default', notionDataSourceId: 'AAA', notionDataSourceType: 'database' },
+          { id: 'p2', notionDataSourceId: 'BBB', notionDataSourceType: 'page' },
+        ],
+        destinationActiveProfileId: 'p2',
+        notionAuthMode: 'oauth',
+        notionOAuthToken: 'tok',
+      });
+      await chrome.storage.sync.set({ notionApiKey: '' });
+
+      const result = await checkSettings();
+      expect(result.valid).toBe(true);
+      expect(result.dataSourceId).toBe('BBB');
+    });
   });
 
   describe('checkPageStatus', () => {

--- a/tests/unit/popup/popupActions.test.js
+++ b/tests/unit/popup/popupActions.test.js
@@ -9,6 +9,7 @@ import {
   getPopupAccountState,
   startAccountLogin,
   openAccountManagement,
+  setPopupTempProfile,
 } from '../../../pages/popup/popupActions.js';
 import { ERROR_MESSAGES } from '../../../scripts/config/shared/messages.js';
 import { BUILD_ENV } from '../../../scripts/config/env/index.js';
@@ -443,6 +444,14 @@ describe('popupActions.js', () => {
         const state = await getDestinationState();
         expect(state.selectedProfileId).toBe('p2');
       });
+    });
+  });
+
+  describe('setPopupTempProfile', () => {
+    it('writes the temp profile id to session storage', async () => {
+      await setPopupTempProfile('p2');
+      const result = await chrome.storage.session.get('popupTempDestinationProfileId');
+      expect(result.popupTempDestinationProfileId).toBe('p2');
     });
   });
 

--- a/tests/unit/popup/popupActions.test.js
+++ b/tests/unit/popup/popupActions.test.js
@@ -13,6 +13,7 @@ import {
 import { ERROR_MESSAGES } from '../../../scripts/config/shared/messages.js';
 import { BUILD_ENV } from '../../../scripts/config/env/index.js';
 import Logger from '../../../scripts/utils/Logger.js';
+import { ProfileManager } from '../../../scripts/destinations/ProfileManager.js';
 
 jest.mock('../../../scripts/config/env/index.js', () => ({
   BUILD_ENV: {
@@ -24,17 +25,23 @@ jest.mock('../../../scripts/config/env/index.js', () => ({
 jest.mock('../../../scripts/auth/accountSession.js', () => ({
   getAccountProfile: jest.fn(),
   getAccountAccessToken: jest.fn(),
+  getAccountSession: jest.fn(),
+  isAccountSessionExpired: jest.fn(),
 }));
 
 describe('popupActions.js', () => {
   const {
     getAccountProfile,
     getAccountAccessToken,
+    getAccountSession,
+    isAccountSessionExpired,
   } = require('../../../scripts/auth/accountSession.js');
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Logger, 'warn').mockImplementation(() => {});
+    getAccountSession.mockResolvedValue(null);
+    isAccountSessionExpired.mockReturnValue(true);
     // 確保每次測試前 storage 是空的
     chrome._clearStorage();
     BUILD_ENV.ENABLE_ACCOUNT = true;
@@ -342,7 +349,7 @@ describe('popupActions.js', () => {
       expect(result.entitlement.maxProfiles).toBeGreaterThanOrEqual(1);
     });
 
-    it('last-used 讀取失敗時仍應保留 profiles 並回退選第一個 profile', async () => {
+    it('active 讀取失敗時仍應保留 profiles 並回退選第一個 profile', async () => {
       await chrome.storage.local.set({
         destinationProfiles: [
           {
@@ -356,18 +363,11 @@ describe('popupActions.js', () => {
             updatedAt: 1,
           },
         ],
-        destinationLastUsedProfileId: 'default',
+        destinationActiveProfileId: 'default',
       });
-      const originalGet = chrome.storage.local.get;
-      let getCallCount = 0;
-      chrome.storage.local.get = jest.fn(keys => {
-        getCallCount += 1;
-        const keyList = Array.isArray(keys) ? keys : [keys];
-        if (getCallCount >= 3 && keyList.includes('destinationLastUsedProfileId')) {
-          return Promise.reject(new Error('last-used failed'));
-        }
-        return originalGet.call(chrome.storage.local, keys);
-      });
+      const activeSpy = jest
+        .spyOn(ProfileManager.prototype, 'getActiveProfile')
+        .mockRejectedValueOnce(new Error('active failed'));
 
       try {
         const result = await getDestinationState();
@@ -378,12 +378,12 @@ describe('popupActions.js', () => {
         expect(Logger.warn).toHaveBeenCalledWith(
           expect.objectContaining({
             action: 'getDestinationState',
-            operation: 'getLastUsedProfile',
+            operation: 'getActiveProfile',
             error: expect.any(String),
           })
         );
       } finally {
-        chrome.storage.local.get = originalGet;
+        activeSpy.mockRestore();
       }
     });
 
@@ -408,6 +408,41 @@ describe('popupActions.js', () => {
 
       expect(result.profiles.map(profile => profile.id)).toEqual(['default']);
       expect(result.selectedProfileId).toBe('default');
+    });
+
+    describe('getDestinationState selection precedence', () => {
+      beforeEach(() => {
+        getAccountSession.mockResolvedValue({
+          accessToken: 'valid-token',
+          expiresAt: Date.now() + 100_000,
+        });
+        isAccountSessionExpired.mockReturnValue(false);
+      });
+
+      it('prefers session temp selection over activeProfileId', async () => {
+        await chrome.storage.local.set({
+          destinationProfiles: [
+            { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
+            { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+          ],
+          destinationActiveProfileId: 'default',
+        });
+        await chrome.storage.session.set({ popupTempDestinationProfileId: 'p2' });
+        const state = await getDestinationState();
+        expect(state.selectedProfileId).toBe('p2');
+      });
+
+      it('falls back to activeProfileId when no session temp selection', async () => {
+        await chrome.storage.local.set({
+          destinationProfiles: [
+            { id: 'default', notionDataSourceId: 'A', notionDataSourceType: 'database' },
+            { id: 'p2', notionDataSourceId: 'B', notionDataSourceType: 'page' },
+          ],
+          destinationActiveProfileId: 'p2',
+        });
+        const state = await getDestinationState();
+        expect(state.selectedProfileId).toBe('p2');
+      });
     });
   });
 

--- a/tests/unit/popup/popupController.test.js
+++ b/tests/unit/popup/popupController.test.js
@@ -30,6 +30,7 @@ import {
   getPopupAccountState,
   startAccountLogin,
   openAccountManagement,
+  setPopupTempProfile,
 } from '../../../pages/popup/popupActions.js';
 import Logger from '../../../scripts/utils/Logger.js';
 import { BUILD_ENV } from '../../../scripts/config/env/index.js';
@@ -61,6 +62,7 @@ jest.mock('../../../pages/popup/popupActions.js', () => ({
   getPopupAccountState: jest.fn(),
   startAccountLogin: jest.fn(),
   openAccountManagement: jest.fn(),
+  setPopupTempProfile: jest.fn().mockResolvedValue(),
 }));
 jest.mock('../../../scripts/utils/Logger.js');
 jest.mock('../../../scripts/config/env/index.js', () => ({
@@ -899,6 +901,7 @@ describe('popup.js Controller', () => {
         ],
         selectedProfileId: 'work',
       });
+      expect(setPopupTempProfile).toHaveBeenCalledWith('work');
 
       savePage.mockResolvedValue({ success: false, error: 'Save failed' });
       await triggerEvent(mockElements.saveButton);


### PR DESCRIPTION
### 摘要
新增主動配置檔管理功能，並支援會話儲存。

### 變更內容
- 新增 `activeProfileId` 的讀寫功能，取代舊有的 `lastUsedProfileId`。
- 在彈出視窗中，透過會話暫存選擇目的地配置檔。
- 儲存臨時配置檔選擇至會話儲存。
- 減少目的地配置檔的複雜性，並重構相關邏輯。
- 更新測試以涵蓋新的配置檔管理邏輯。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

