### PR TITLE
feat: convert options preference checkboxes to switch components

### DIFF
--- a/pages/options/AuthManager.js
+++ b/pages/options/AuthManager.js
@@ -122,6 +122,7 @@ export class AuthManager {
     this._bindAuthActionButtons();
     this._bindApiKeyDataSourceLoader();
     this._bindDebugToggle();
+    this._bindPreferenceSwitchAriaSync();
   }
 
   /**
@@ -256,6 +257,45 @@ export class AuthManager {
     }
 
     debugToggle.addEventListener('change', () => this._handleDebugToggleChange(debugToggle));
+  }
+
+  /**
+   * 綁定偏好設定 switch 的 ARIA state 同步。
+   *
+   * @private
+   */
+  _bindPreferenceSwitchAriaSync() {
+    [
+      this.elements.addSourceCheckbox,
+      this.elements.addTimestampCheckbox,
+      this.elements.floatingRailCheckbox,
+      this.elements.debugToggle,
+    ].forEach(input => this._bindSwitchAriaSync(input));
+  }
+
+  /**
+   * @private
+   * @param {HTMLInputElement|null} input
+   */
+  _bindSwitchAriaSync(input) {
+    if (!input) {
+      return;
+    }
+
+    this._syncSwitchAriaChecked(input);
+    input.addEventListener('change', () => this._syncSwitchAriaChecked(input));
+  }
+
+  /**
+   * @private
+   * @param {HTMLInputElement|null} input
+   */
+  _syncSwitchAriaChecked(input) {
+    if (!input) {
+      return;
+    }
+
+    input.setAttribute(AuthManager.ATTR_ARIA_CHECKED, input.checked ? 'true' : 'false');
   }
 
   /**
@@ -613,11 +653,15 @@ export class AuthManager {
       const rawVal = data[setting.prop];
       if (setting.type === 'value') {
         el.value = rawVal || setting.def;
-      } else if (setting.type === 'bool-true') {
+        continue;
+      }
+
+      if (setting.type === 'bool-true') {
         el.checked = rawVal !== false;
       } else {
         el.checked = Boolean(rawVal);
       }
+      this._syncSwitchAriaChecked(el);
     }
   }
 

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -50,6 +50,12 @@
   --text-muted: var(--color-text-muted);
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
@@ -58,7 +64,6 @@ body {
   color: var(--text-primary);
   margin: 0;
   padding: 0;
-  height: 100vh;
   display: flex;
 }
 
@@ -67,6 +72,7 @@ body {
   display: flex;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 /* Sidebar */
@@ -174,6 +180,8 @@ body {
 .content-area {
   flex: 1;
   overflow-y: auto;
+  min-height: 0;
+  overscroll-behavior: contain;
   padding: var(--spacing-lg) 40px;
 }
 
@@ -247,6 +255,11 @@ body {
   font-weight: 500;
   margin-bottom: var(--spacing-xs);
   color: var(--text-primary);
+}
+
+.form-group .switch-wrapper {
+  display: inline-flex;
+  align-items: center;
 }
 
 .input-wrapper {

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -402,6 +402,7 @@
                   role="switch"
                   class="switch-input"
                   checked
+                  aria-checked="true"
                 />
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-knob"></span>
@@ -850,7 +851,14 @@
 
             <div class="form-item-row">
               <label class="switch-wrapper" for="add-source">
-                <input type="checkbox" id="add-source" role="switch" class="switch-input" checked />
+                <input
+                  type="checkbox"
+                  id="add-source"
+                  role="switch"
+                  class="switch-input"
+                  checked
+                  aria-checked="true"
+                />
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-knob"></span>
                 </span>
@@ -868,6 +876,7 @@
                   role="switch"
                   class="switch-input"
                   checked
+                  aria-checked="true"
                 />
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-knob"></span>
@@ -1221,7 +1230,13 @@
           <div class="card">
             <div class="form-item-row">
               <label class="switch-wrapper" for="enable-debug-logs">
-                <input type="checkbox" id="enable-debug-logs" role="switch" class="switch-input" />
+                <input
+                  type="checkbox"
+                  id="enable-debug-logs"
+                  role="switch"
+                  class="switch-input"
+                  aria-checked="false"
+                />
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-knob"></span>
                 </span>

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -395,8 +395,17 @@
               <p class="help-text" data-ui-message="OPTIONS.INTERFACE.ZOOM_HELP"></p>
             </div>
             <div class="form-group">
-              <label class="toggle-label" for="floating-rail-enabled">
-                <input type="checkbox" id="floating-rail-enabled" checked />
+              <label class="switch-wrapper" for="floating-rail-enabled">
+                <input
+                  type="checkbox"
+                  id="floating-rail-enabled"
+                  role="switch"
+                  class="switch-input"
+                  checked
+                />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-knob"></span>
+                </span>
                 <span data-ui-message="OPTIONS.INTERFACE.FLOATING_RAIL_LABEL">顯示快捷工具列</span>
               </label>
               <p class="help-text" data-ui-message="OPTIONS.INTERFACE.FLOATING_RAIL_HELP"></p>
@@ -840,21 +849,33 @@
             </div>
 
             <div class="form-item-row">
-              <div class="checkbox-wrapper">
-                <input type="checkbox" id="add-source" checked />
-                <label for="add-source" data-ui-message="OPTIONS.TEMPLATES.ADD_SOURCE_LABEL"
-                  >在內容末尾添加來源連結</label
+              <label class="switch-wrapper" for="add-source">
+                <input type="checkbox" id="add-source" role="switch" class="switch-input" checked />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-knob"></span>
+                </span>
+                <span data-ui-message="OPTIONS.TEMPLATES.ADD_SOURCE_LABEL"
+                  >在內容末尾添加來源連結</span
                 >
-              </div>
+              </label>
             </div>
 
             <div class="form-item-row">
-              <div class="checkbox-wrapper">
-                <input type="checkbox" id="add-timestamp" checked />
-                <label for="add-timestamp" data-ui-message="OPTIONS.TEMPLATES.ADD_TIMESTAMP_LABEL"
-                  >在內容開頭添加保存時間</label
+              <label class="switch-wrapper" for="add-timestamp">
+                <input
+                  type="checkbox"
+                  id="add-timestamp"
+                  role="switch"
+                  class="switch-input"
+                  checked
+                />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-knob"></span>
+                </span>
+                <span data-ui-message="OPTIONS.TEMPLATES.ADD_TIMESTAMP_LABEL"
+                  >在內容開頭添加保存時間</span
                 >
-              </div>
+              </label>
             </div>
           </div>
 
@@ -1199,10 +1220,13 @@
 
           <div class="card">
             <div class="form-item-row">
-              <div class="checkbox-wrapper">
-                <input type="checkbox" id="enable-debug-logs" />
-                <label for="enable-debug-logs">啟用除錯日誌 (Debug Logs)</label>
-              </div>
+              <label class="switch-wrapper" for="enable-debug-logs">
+                <input type="checkbox" id="enable-debug-logs" role="switch" class="switch-input" />
+                <span class="switch-track" aria-hidden="true">
+                  <span class="switch-knob"></span>
+                </span>
+                <span>啟用除錯日誌 (Debug Logs)</span>
+              </label>
               <p class="help-text">將前端操作日誌轉發到背景頁面 console，僅供開發排查使用。</p>
             </div>
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -1240,7 +1240,9 @@
                 <span class="switch-track" aria-hidden="true">
                   <span class="switch-knob"></span>
                 </span>
-                <span>啟用除錯日誌 (Debug Logs)</span>
+                <span data-ui-message="OPTIONS.DIAGNOSTICS.ENABLE_DEBUG_LOGS_LABEL"
+                  >啟用除錯日誌 (Debug Logs)</span
+                >
               </label>
               <p class="help-text">將前端操作日誌轉發到背景頁面 console，僅供開發排查使用。</p>
             </div>

--- a/scripts/config/shared/messages.js
+++ b/scripts/config/shared/messages.js
@@ -115,6 +115,9 @@ const OPTIONS = {
   SETTINGS: {
     SAVE_BUTTON: '儲存設定',
   },
+  DIAGNOSTICS: {
+    ENABLE_DEBUG_LOGS_LABEL: '啟用除錯日誌 (Debug Logs)',
+  },
   ABOUT: {
     SECTION_TITLE: '關於作者',
     PROFILE_TITLE: '個人介紹',

--- a/styles/ui-primitives.css
+++ b/styles/ui-primitives.css
@@ -173,6 +173,7 @@ button.btn-icon:focus-visible {
 .switch-wrapper {
   display: inline-flex;
   align-items: center;
+  gap: var(--spacing-sm);
   cursor: pointer;
 }
 

--- a/tests/unit/options/AuthManager.test.js
+++ b/tests/unit/options/AuthManager.test.js
@@ -498,6 +498,28 @@ describe('AuthManager Extended', () => {
       expect(document.querySelector('#add-timestamp').checked).toBe(false);
       expect(document.querySelector('#highlight-style').value).toBe('underline');
       expect(document.querySelector('#enable-debug-logs').checked).toBe(true);
+      expect(document.querySelector('#add-source').getAttribute('aria-checked')).toBe('true');
+      expect(document.querySelector('#add-timestamp').getAttribute('aria-checked')).toBe('false');
+      expect(document.querySelector('#floating-rail-enabled').getAttribute('aria-checked')).toBe(
+        'true'
+      );
+      expect(document.querySelector('#enable-debug-logs').getAttribute('aria-checked')).toBe(
+        'true'
+      );
+    });
+
+    test('偏好設定 switch 變更時應同步 aria-checked', async () => {
+      renderExtendedAuthDom();
+      authManager = await createInitializedAuthManager(mockUiManager, mockLoadDatabases);
+
+      const addSource = document.querySelector('#add-source');
+      addSource.checked = true;
+      addSource.dispatchEvent(new Event('change'));
+      expect(addSource.getAttribute('aria-checked')).toBe('true');
+
+      addSource.checked = false;
+      addSource.dispatchEvent(new Event('change'));
+      expect(addSource.getAttribute('aria-checked')).toBe('false');
     });
 
     test('OAuth 模式缺 local 儲存時應備援至 sync 讀取保存目標', async () => {

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -38,6 +38,22 @@ const expectMissingElementAttribute = (doc, { selector, attribute }) => {
   expect(element.getAttribute(attribute)).toBeNull();
 };
 
+const expectSwitchControl = (doc, selector) => {
+  const input = queryRequiredElement(doc, selector);
+  const wrapper = input.closest('.switch-wrapper');
+  const track = input.nextElementSibling;
+
+  expect(input.tagName).toBe('INPUT');
+  expect(input.getAttribute('type')).toBe('checkbox');
+  expect(input.getAttribute('role')).toBe('switch');
+  expect(input.classList.contains('switch-input')).toBe(true);
+  expect(wrapper).not.toBeNull();
+  expect(track).not.toBeNull();
+  expect(track.classList.contains('switch-track')).toBe(true);
+  expect(track.getAttribute('aria-hidden')).toBe('true');
+  expect(track.querySelector('.switch-knob')).not.toBeNull();
+};
+
 describe('options.html 結構', () => {
   test('health-status 應為 polite live region 的 output 標籤', () => {
     const htmlPath = path.resolve(__dirname, '../../../pages/options/options.html');
@@ -211,5 +227,21 @@ describe('options.html 結構', () => {
     expect(css).toMatch(
       /\.destination-profile-row\s*>\s*div:first-of-type\s*\{[^}]*min-width:\s*0;/
     );
+  });
+
+  test('二元偏好設定應使用既有 switch primitive，並保留 migration checkbox 語意', () => {
+    const html = readOptionsHtml();
+    const doc = parseOptionsHtml(html);
+
+    ['#floating-rail-enabled', '#add-source', '#add-timestamp', '#enable-debug-logs'].forEach(
+      selector => {
+        expectSwitchControl(doc, selector);
+      }
+    );
+
+    const migrationSelectAll = queryRequiredElement(doc, '#migration-select-all');
+    expect(migrationSelectAll.getAttribute('type')).toBe('checkbox');
+    expect(migrationSelectAll.getAttribute('role')).toBeNull();
+    expect(migrationSelectAll.classList.contains('switch-input')).toBe(false);
   });
 });

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -46,6 +46,7 @@ const expectSwitchControl = (doc, selector) => {
   expect(input.tagName).toBe('INPUT');
   expect(input.getAttribute('type')).toBe('checkbox');
   expect(input.getAttribute('role')).toBe('switch');
+  expect(input.getAttribute('aria-checked')).toBe(input.checked ? 'true' : 'false');
   expect(input.classList.contains('switch-input')).toBe(true);
   expect(wrapper).not.toBeNull();
   expect(track).not.toBeNull();

--- a/tests/unit/options/optionsHtmlStructure.test.js
+++ b/tests/unit/options/optionsHtmlStructure.test.js
@@ -3,8 +3,14 @@ import path from 'node:path';
 import { UI_MESSAGES } from '../../../scripts/config/shared/messages.js';
 
 const OPTIONS_HTML_PATH = path.resolve(__dirname, '../../../pages/options/options.html');
+const OPTIONS_CSS_PATH = path.resolve(__dirname, '../../../pages/options/options.css');
+const UI_PRIMITIVES_CSS_PATH = path.resolve(__dirname, '../../../styles/ui-primitives.css');
 
 const readOptionsHtml = () => fs.readFileSync(OPTIONS_HTML_PATH, 'utf8');
+
+const readOptionsCss = () => fs.readFileSync(OPTIONS_CSS_PATH, 'utf8');
+
+const readUiPrimitivesCss = () => fs.readFileSync(UI_PRIMITIVES_CSS_PATH, 'utf8');
 
 const parseOptionsHtml = html => new DOMParser().parseFromString(html, 'text/html');
 
@@ -244,5 +250,27 @@ describe('options.html 結構', () => {
     expect(migrationSelectAll.getAttribute('type')).toBe('checkbox');
     expect(migrationSelectAll.getAttribute('role')).toBeNull();
     expect(migrationSelectAll.classList.contains('switch-input')).toBe(false);
+  });
+
+  test('Options layout 應限制 root overscroll，避免內容到底後拉出空白', () => {
+    const css = readOptionsCss();
+
+    expect(css).toMatch(/html,\s*body\s*\{[^}]*height:\s*100%;[^}]*overflow:\s*hidden;/);
+    expect(css).toMatch(/\.app-container\s*\{[^}]*height:\s*100%;[^}]*overflow:\s*hidden;/);
+    expect(css).toMatch(
+      /\.content-area\s*\{[^}]*overflow-y:\s*auto;[^}]*min-height:\s*0;[^}]*overscroll-behavior:\s*contain;/
+    );
+  });
+
+  test('Options switch row 應保留 primitive 間距並抵消 form label display 覆寫', () => {
+    const primitivesCss = readUiPrimitivesCss();
+    const optionsCss = readOptionsCss();
+
+    expect(primitivesCss).toMatch(
+      /\.switch-wrapper\s*\{[^}]*display:\s*inline-flex;[^}]*align-items:\s*center;[^}]*gap:\s*var\(--spacing-sm\);/
+    );
+    expect(optionsCss).toMatch(
+      /\.form-group\s+\.switch-wrapper\s*\{[^}]*display:\s*inline-flex;[^}]*align-items:\s*center;/
+    );
   });
 });

--- a/tests/unit/options/optionsStaticMessages.test.js
+++ b/tests/unit/options/optionsStaticMessages.test.js
@@ -155,6 +155,29 @@ describe('optionsStaticMessages', () => {
       expect(totalBindings).toBeGreaterThan(20);
     });
 
+    it('debug logs 開關標籤應透過 UI_MESSAGES 綁定', () => {
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const html = fs.readFileSync(
+        path.join(__dirname, '../../../pages/options/options.html'),
+        'utf8'
+      );
+      const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+      expect(bodyMatch).not.toBeNull();
+      document.body.innerHTML = bodyMatch[1];
+
+      const expectedKey = 'OPTIONS.DIAGNOSTICS.ENABLE_DEBUG_LOGS_LABEL';
+      const labelText = document.querySelector('label[for="enable-debug-logs"] > span:last-child');
+
+      expect(labelText).not.toBeNull();
+      expect(labelText.dataset.uiMessage).toBe(expectedKey);
+
+      applyStaticOptionMessages();
+
+      expect(labelText.textContent).toBe(resolveUiMessage(expectedKey));
+      expect(labelText.textContent).toBe(UI_MESSAGES.OPTIONS.DIAGNOSTICS.ENABLE_DEBUG_LOGS_LABEL);
+    });
+
     it('destination help link 應提供靜態 accessible name 並保留 runtime i18n 綁定', () => {
       const fs = require('node:fs');
       const path = require('node:path');


### PR DESCRIPTION
### 摘要
將選項偏好設定中的複選框轉換為開關元件，以提升用戶界面的可用性和一致性。

### 變更內容
- 將多個複選框替換為開關元件，包括顯示快捷工具列、在內容末尾添加來源連結、在內容開頭添加保存時間及啟用除錯日誌。
- 更新相關的 HTML 結構以符合開關元件的標準。
- 增加測試以驗證開關元件的正確性。

### 測試方式
已新增測試以驗證開關元件的結構和功能。

### 潛在風險
無顯著風險。

