### PR TITLE
refactor: deduplicate template status id and use native storage promise

### DIFF
--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -48,6 +48,7 @@ const NOTION_UUID_SEGMENT_LENGTH = 36;
 const NOTION_ID_SEGMENT_LENGTHS = new Set([NOTION_ID_LENGTH, NOTION_UUID_SEGMENT_LENGTH]);
 const NOTION_ID_HEX_DIGITS = new Set('0123456789abcdefABCDEF'.split(''));
 const ARIA_HIDDEN_ATTRIBUTE = 'aria-hidden';
+const TEMPLATE_STATUS_ID = 'template-status';
 let destinationProfilesUIController = null;
 
 function normalizeDestinationProfileName(value) {
@@ -395,7 +396,7 @@ function initializeAutosavePreferences(ui) {
     selector: '#add-source',
     storageKey: 'addSource',
     defaultValue: true,
-    statusId: 'template-status',
+    statusId: TEMPLATE_STATUS_ID,
   });
 
   // 6. Add Timestamp
@@ -404,7 +405,7 @@ function initializeAutosavePreferences(ui) {
     selector: '#add-timestamp',
     storageKey: 'addTimestamp',
     defaultValue: true,
-    statusId: 'template-status',
+    statusId: TEMPLATE_STATUS_ID,
   });
 
   // 7. Highlight Style
@@ -413,7 +414,7 @@ function initializeAutosavePreferences(ui) {
     selector: '#highlight-style',
     storageKey: 'highlightStyle',
     defaultValue: 'background',
-    statusId: 'template-status',
+    statusId: TEMPLATE_STATUS_ID,
     successMessage: UI_MESSAGES.OPTIONS.TEMPLATES.HIGHLIGHT_STYLE_SAVE_SUCCESS,
   });
 
@@ -423,7 +424,7 @@ function initializeAutosavePreferences(ui) {
     selector: '#highlight-content-style',
     storageKey: 'highlightContentStyle',
     defaultValue: 'COLOR_SYNC',
-    statusId: 'template-status',
+    statusId: TEMPLATE_STATUS_ID,
     successMessage: UI_MESSAGES.OPTIONS.TEMPLATES.HIGHLIGHT_CONTENT_STYLE_SAVE_SUCCESS,
   });
 }
@@ -439,10 +440,10 @@ function bindTitleTemplateSaveButton(ui) {
         ui.showStatus(
           UI_MESSAGES.OPTIONS.TEMPLATES.TITLE_TEMPLATE_SAVE_SUCCESS,
           'success',
-          'template-status'
+          TEMPLATE_STATUS_ID
         );
       } catch {
-        ui.showStatus(UI_MESSAGES.SETTINGS.PREFERENCE_SAVE_FAILED, 'error', 'template-status');
+        ui.showStatus(UI_MESSAGES.SETTINGS.PREFERENCE_SAVE_FAILED, 'error', TEMPLATE_STATUS_ID);
       }
     });
   }

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -250,21 +250,13 @@ function bindOptionsRuntimeMessages({ auth, ui }) {
   });
 }
 
-function getSyncStorage(keys) {
-  return new Promise(resolve => {
-    chrome.storage.sync.get(keys, result => {
-      resolve(result || {});
-    });
-  });
-}
-
 function setSwitchChecked(input, checked) {
   input.checked = Boolean(checked);
   input.setAttribute('aria-checked', input.checked ? 'true' : 'false');
 }
 
 async function restorePreferenceControl({ element, storageKey, defaultValue, applyValue }) {
-  const result = await getSyncStorage([storageKey]);
+  const result = (await chrome.storage.sync.get([storageKey])) || {};
   const storedValue = Object.hasOwn(result, storageKey) ? result[storageKey] : defaultValue;
   applyValue(element, storedValue);
 }

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -264,11 +264,12 @@ async function restorePreferenceControl({ element, storageKey, defaultValue, app
       storedValue = result[storageKey];
     }
   } catch (error) {
+    const safeError = sanitizeApiError(error, 'restorePreferenceControl');
     Logger.warn('讀取偏好設定失敗，套用預設值', {
       action: 'restorePreferenceControl',
       result: 'fallback',
       storageKey,
-      error,
+      error: safeError,
     });
   }
 

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -256,8 +256,22 @@ function setSwitchChecked(input, checked) {
 }
 
 async function restorePreferenceControl({ element, storageKey, defaultValue, applyValue }) {
-  const result = (await chrome.storage.sync.get([storageKey])) || {};
-  const storedValue = Object.hasOwn(result, storageKey) ? result[storageKey] : defaultValue;
+  let storedValue = defaultValue;
+
+  try {
+    const result = (await chrome.storage.sync.get([storageKey])) || {};
+    if (Object.hasOwn(result, storageKey)) {
+      storedValue = result[storageKey];
+    }
+  } catch (error) {
+    Logger.warn('讀取偏好設定失敗，套用預設值', {
+      action: 'restorePreferenceControl',
+      result: 'fallback',
+      storageKey,
+      error,
+    });
+  }
+
   applyValue(element, storedValue);
 }
 

--- a/tests/helpers/optionsTestHarness.js
+++ b/tests/helpers/optionsTestHarness.js
@@ -123,6 +123,12 @@ export function buildAccountCardDOM() {
 }
 
 export function buildChromeMock(overrides = {}) {
+  const getEmptySyncStorage = jest.fn((_keys, cb) => {
+    const result = {};
+    cb?.(result);
+    return Promise.resolve(result);
+  });
+
   return {
     runtime: {
       id: 'ext_id_123',
@@ -133,7 +139,7 @@ export function buildChromeMock(overrides = {}) {
     storage: {
       local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
       sync: {
-        get: jest.fn((keys, cb) => cb({})),
+        get: getEmptySyncStorage,
         set: jest.fn(),
         remove: jest.fn().mockResolvedValue(),
       },

--- a/tests/unit/options/optionsInitialization.test.js
+++ b/tests/unit/options/optionsInitialization.test.js
@@ -126,6 +126,25 @@ describe('optionsInitialization', () => {
       globalThis.history.replaceState({}, '', originalHref);
     });
 
+    const buildSidebarWarningDOM = navItemMarkup => {
+      document.body.innerHTML = `
+        <button id="save-button"></button>
+        <button id="save-templates-button"></button>
+        <div id="app-version"></div>
+        ${navItemMarkup}
+        <div id="section-general" class="settings-section"></div>
+      `;
+    };
+
+    const buildFailingAutosaveStorage = getPreferenceValue => ({
+      local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
+      sync: {
+        get: jest.fn(getPreferenceValue),
+        set: jest.fn().mockRejectedValue(new Error('storage failed')),
+        remove: jest.fn().mockResolvedValue(),
+      },
+    });
+
     it('should initialize all managers and check auth status', () => {
       initOptions();
 
@@ -345,46 +364,36 @@ describe('optionsInitialization', () => {
       expect(section.classList.contains('active')).toBe(true);
     });
 
-    it('導航項目缺少 data-section 時應記錄警告', () => {
-      document.body.innerHTML = `
-        <button id="save-button"></button>
-        <button id="save-templates-button"></button>
-        <div id="app-version"></div>
-        <div class="nav-item"></div>
-        <div id="section-general" class="settings-section"></div>
-      `;
+    it.each([
+      {
+        name: '導航項目缺少 data-section 時應記錄警告',
+        navItemMarkup: '<div class="nav-item"></div>',
+        expectedMessage: '缺少 data-section',
+        expectedContext: {
+          action: 'setupSidebarNavigation',
+          tagName: 'DIV',
+          targetId: null,
+          sectionName: null,
+        },
+      },
+      {
+        name: '導航目標區塊不存在時應記錄警告',
+        navItemMarkup: '<div class="nav-item" data-section="advanced"></div>',
+        expectedMessage: '找不到目標區塊',
+        expectedContext: expect.objectContaining({
+          action: 'setupSidebarNavigation',
+          targetId: 'section-advanced',
+        }),
+      },
+    ])('$name', ({ navItemMarkup, expectedMessage, expectedContext }) => {
+      buildSidebarWarningDOM(navItemMarkup);
 
       initOptions();
-
-      document.querySelector('.nav-item').click();
-
-      expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining('缺少 data-section'), {
-        action: 'setupSidebarNavigation',
-        tagName: 'DIV',
-        targetId: null,
-        sectionName: null,
-      });
-    });
-
-    it('導航目標區塊不存在時應記錄警告', () => {
-      document.body.innerHTML = `
-        <button id="save-button"></button>
-        <button id="save-templates-button"></button>
-        <div id="app-version"></div>
-        <div class="nav-item" data-section="advanced"></div>
-        <div id="section-general" class="settings-section"></div>
-      `;
-
-      initOptions();
-
       document.querySelector('.nav-item').click();
 
       expect(Logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('找不到目標區塊'),
-        expect.objectContaining({
-          action: 'setupSidebarNavigation',
-          targetId: 'section-advanced',
-        })
+        expect.stringContaining(expectedMessage),
+        expectedContext
       );
     });
 
@@ -509,56 +518,29 @@ describe('optionsInitialization', () => {
       );
     });
 
-    it('autosave 失敗時應顯示錯誤並回復 control 到 storage 值', async () => {
+    it.each([
+      {
+        name: 'autosave 失敗時應顯示錯誤並回復 control 到 storage 值',
+        getPreferenceValue: (_keys, cb) => {
+          const result = { addTimestamp: true };
+          cb?.(result);
+          return Promise.resolve(result);
+        },
+      },
+      {
+        name: 'autosave 回復讀取失敗時應套用 defaultValue 並顯示錯誤',
+        getPreferenceValue: (_keys, cb) => {
+          if (typeof cb === 'function') {
+            cb({});
+            return Promise.resolve({});
+          }
+          return Promise.reject(new Error('storage restore unavailable'));
+        },
+      },
+    ])('$name', async ({ getPreferenceValue }) => {
       buildOptionsPreferenceDOM();
       globalThis.chrome = buildChromeMock({
-        storage: {
-          local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
-          sync: {
-            get: jest.fn((_keys, cb) => {
-              const result = { addTimestamp: true };
-              cb?.(result);
-              return Promise.resolve(result);
-            }),
-            set: jest.fn().mockRejectedValue(new Error('storage failed')),
-            remove: jest.fn().mockResolvedValue(),
-          },
-        },
-      });
-
-      initOptions();
-
-      const addTimestamp = document.querySelector('#add-timestamp');
-      addTimestamp.checked = false;
-      addTimestamp.dispatchEvent(new Event('change'));
-      await flushAsyncClick();
-
-      expect(addTimestamp.checked).toBe(true);
-      expect(addTimestamp.getAttribute('aria-checked')).toBe('true');
-      expect(mockUiInstance.showStatus).toHaveBeenCalledWith(
-        UI_MESSAGES.SETTINGS.PREFERENCE_SAVE_FAILED,
-        'error',
-        'template-status'
-      );
-    });
-
-    it('autosave 回復讀取失敗時應套用 defaultValue 並顯示錯誤', async () => {
-      buildOptionsPreferenceDOM();
-      globalThis.chrome = buildChromeMock({
-        storage: {
-          local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
-          sync: {
-            get: jest.fn((_keys, cb) => {
-              if (typeof cb === 'function') {
-                cb({});
-                return Promise.resolve({});
-              }
-              return Promise.reject(new Error('storage restore unavailable'));
-            }),
-            set: jest.fn().mockRejectedValue(new Error('storage failed')),
-            remove: jest.fn().mockResolvedValue(),
-          },
-        },
+        storage: buildFailingAutosaveStorage(getPreferenceValue),
       });
 
       initOptions();

--- a/tests/unit/options/optionsInitialization.test.js
+++ b/tests/unit/options/optionsInitialization.test.js
@@ -542,6 +542,41 @@ describe('optionsInitialization', () => {
       );
     });
 
+    it('autosave 回復讀取失敗時應套用 defaultValue 並顯示錯誤', async () => {
+      buildOptionsPreferenceDOM();
+      globalThis.chrome = buildChromeMock({
+        storage: {
+          local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
+          sync: {
+            get: jest.fn((_keys, cb) => {
+              if (typeof cb === 'function') {
+                cb({});
+                return Promise.resolve({});
+              }
+              return Promise.reject(new Error('storage restore unavailable'));
+            }),
+            set: jest.fn().mockRejectedValue(new Error('storage failed')),
+            remove: jest.fn().mockResolvedValue(),
+          },
+        },
+      });
+
+      initOptions();
+
+      const addTimestamp = document.querySelector('#add-timestamp');
+      addTimestamp.checked = false;
+      addTimestamp.dispatchEvent(new Event('change'));
+      await flushAsyncClick();
+
+      expect(addTimestamp.checked).toBe(true);
+      expect(addTimestamp.getAttribute('aria-checked')).toBe('true');
+      expect(mockUiInstance.showStatus).toHaveBeenCalledWith(
+        UI_MESSAGES.SETTINGS.PREFERENCE_SAVE_FAILED,
+        'error',
+        'template-status'
+      );
+    });
+
     it('保存標題格式按鈕只應保存 titleTemplate', async () => {
       buildOptionsPreferenceDOM();
       globalThis.chrome = buildChromeMock();

--- a/tests/unit/options/optionsInitialization.test.js
+++ b/tests/unit/options/optionsInitialization.test.js
@@ -559,6 +559,42 @@ describe('optionsInitialization', () => {
       );
     });
 
+    it('autosave 回復讀取失敗時應只記錄脫敏後錯誤', async () => {
+      const restoreError = new Error('Storage unavailable with token secret_12345');
+      buildOptionsPreferenceDOM();
+      globalThis.chrome = buildChromeMock({
+        storage: buildFailingAutosaveStorage((_keys, cb) => {
+          if (typeof cb === 'function') {
+            cb({});
+            return Promise.resolve({});
+          }
+          return Promise.reject(restoreError);
+        }),
+      });
+
+      initOptions();
+
+      const addTimestamp = document.querySelector('#add-timestamp');
+      addTimestamp.checked = false;
+      addTimestamp.dispatchEvent(new Event('change'));
+      await flushAsyncClick();
+
+      const logCall = await waitForLoggerWarn(Logger, '讀取偏好設定失敗，套用預設值');
+      expect(logCall).toEqual([
+        '讀取偏好設定失敗，套用預設值',
+        {
+          action: 'restorePreferenceControl',
+          result: 'fallback',
+          storageKey: 'addTimestamp',
+          error: sanitizeApiError(restoreError, 'restorePreferenceControl'),
+        },
+      ]);
+      expect(Logger.warn).not.toHaveBeenCalledWith(
+        '讀取偏好設定失敗，套用預設值',
+        expect.objectContaining({ error: restoreError })
+      );
+    });
+
     it('保存標題格式按鈕只應保存 titleTemplate', async () => {
       buildOptionsPreferenceDOM();
       globalThis.chrome = buildChromeMock();

--- a/tests/unit/options/optionsInitialization.test.js
+++ b/tests/unit/options/optionsInitialization.test.js
@@ -515,7 +515,11 @@ describe('optionsInitialization', () => {
         storage: {
           local: { get: jest.fn().mockResolvedValue({}), remove: jest.fn().mockResolvedValue() },
           sync: {
-            get: jest.fn((keys, cb) => cb({ addTimestamp: true })),
+            get: jest.fn((_keys, cb) => {
+              const result = { addTimestamp: true };
+              cb?.(result);
+              return Promise.resolve(result);
+            }),
             set: jest.fn().mockRejectedValue(new Error('storage failed')),
             remove: jest.fn().mockResolvedValue(),
           },


### PR DESCRIPTION
### 摘要
重構代碼以消除模板狀態 ID 的重複定義，並在選項回滾中使用原生存儲 Promise。

### 變更內容
- 將模板狀態 ID 定義為常量，避免重複使用字串。
- 在恢復偏好控制的過程中，使用原生的 `chrome.storage.sync.get` 方法來獲取存儲值。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

