### PR TITLE
ci: update sonar scope for test debt governance

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,14 +3,14 @@ sonar.organization=cowcfj
 sonar.host.url=https://sonarcloud.io
 
 # 原始碼路徑
-sonar.sources=scripts,pages
+sonar.sources=scripts,pages,site
 # 語言特定設定
 sonar.javascript.file.suffixes=.js
 
 # 排除不需要分析的路徑
-sonar.exclusions=node_modules/**,dist/**,coverage/**,tests/**,**/*.test.js,**/*.spec.js,playwright-report/**,lib/Readability.js
+sonar.exclusions=node_modules/**,dist/**,coverage/**,playwright-report/**,lib/Readability.js
 
-# 測試代碼路徑（僅標註，不計入技術債）
+# 測試代碼路徑（此路徑將作為測試代碼分析以追蹤測試技術債，但不計入 source LOC 或覆蓋率核算）
 sonar.tests=tests
 sonar.test.inclusions=**/*.test.js,**/*.spec.js
 

--- a/tests/unit/config/coverageExclusionsContract.test.js
+++ b/tests/unit/config/coverageExclusionsContract.test.js
@@ -47,7 +47,7 @@ function readSonarPropertyValue(lines, propertyName) {
   const propertyPattern = new RegExp(
     String.raw`^${escapeRegExp(propertyName)}\s*=\s*([^#]*)(?:#.*)?$`
   );
-  const matchingLine = lines.find(line => propertyPattern.test(line.trim()));
+  const matchingLine = lines.findLast(line => propertyPattern.test(line.trim()));
   return matchingLine?.replace(propertyPattern, '$1').trim() ?? '';
 }
 
@@ -91,6 +91,15 @@ describe('coverage exclusion contract', () => {
       'scripts',
       'pages',
     ]);
+  });
+
+  test('Sonar property parser uses the last declaration for duplicate keys', () => {
+    const sonarProperties = [
+      'sonar.sources=scripts,pages',
+      'sonar.sources=site # override earlier declaration',
+    ];
+
+    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.sources')).toEqual(['site']);
   });
 
   test('Jest keeps production coverage exclusions explicit', () => {

--- a/tests/unit/config/coverageExclusionsContract.test.js
+++ b/tests/unit/config/coverageExclusionsContract.test.js
@@ -43,6 +43,19 @@ function hasSonarProperty(lines, propertyName) {
   return lines.some(line => propertyPattern.test(line.trim()));
 }
 
+function readSonarPropertyValue(lines, propertyName) {
+  const propertyPattern = new RegExp(String.raw`^${escapeRegExp(propertyName)}\s*=\s*(.*)$`);
+  const matchingLine = lines.find(line => propertyPattern.test(line.trim()));
+  return matchingLine?.replace(propertyPattern, '$1').trim() ?? '';
+}
+
+function readCommaSeparatedSonarProperty(lines, propertyName) {
+  return readSonarPropertyValue(lines, propertyName)
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+}
+
 describe('coverage exclusion contract', () => {
   test('Sonar property parser normalizes whitespace and ignores comments', () => {
     const readFileSync = jest.spyOn(fs, 'readFileSync').mockReturnValue(`
@@ -110,6 +123,42 @@ describe('coverage exclusion contract', () => {
     expect(readJestProjectCacheDirectories()).toEqual([
       '<rootDir>/.jest-cache',
       '<rootDir>/.jest-cache',
+    ]);
+  });
+
+  test('Sonar source scope includes production pages and site debt', () => {
+    const sonarProperties = readSonarProperties();
+
+    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.sources')).toEqual([
+      'scripts',
+      'pages',
+      'site',
+    ]);
+  });
+
+  test('Sonar source exclusions do not suppress test debt governance', () => {
+    const sonarProperties = readSonarProperties();
+    const sourceExclusions = readCommaSeparatedSonarProperty(sonarProperties, 'sonar.exclusions');
+
+    expect(sourceExclusions).toEqual([
+      'node_modules/**',
+      'dist/**',
+      'coverage/**',
+      'playwright-report/**',
+      'lib/Readability.js',
+    ]);
+    expect(sourceExclusions).not.toContain('tests/**');
+    expect(sourceExclusions).not.toContain('**/*.test.js');
+    expect(sourceExclusions).not.toContain('**/*.spec.js');
+  });
+
+  test('Sonar test scope remains explicit for test debt analysis', () => {
+    const sonarProperties = readSonarProperties();
+
+    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.tests')).toEqual(['tests']);
+    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.test.inclusions')).toEqual([
+      '**/*.test.js',
+      '**/*.spec.js',
     ]);
   });
 });

--- a/tests/unit/config/coverageExclusionsContract.test.js
+++ b/tests/unit/config/coverageExclusionsContract.test.js
@@ -44,7 +44,9 @@ function hasSonarProperty(lines, propertyName) {
 }
 
 function readSonarPropertyValue(lines, propertyName) {
-  const propertyPattern = new RegExp(String.raw`^${escapeRegExp(propertyName)}\s*=\s*(.*)$`);
+  const propertyPattern = new RegExp(
+    String.raw`^${escapeRegExp(propertyName)}\s*=\s*([^#]*)(?:#.*)?$`
+  );
   const matchingLine = lines.find(line => propertyPattern.test(line.trim()));
   return matchingLine?.replace(propertyPattern, '$1').trim() ?? '';
 }
@@ -80,6 +82,15 @@ describe('coverage exclusion contract', () => {
     const sonarProperties = ['sonar.coverage.exclusions = legacy/**'];
 
     expect(hasSonarProperty(sonarProperties, 'sonar.coverage.exclusions')).toBe(true);
+  });
+
+  test('Sonar property values stop before inline comments', () => {
+    const sonarProperties = ['sonar.sources=scripts,pages # keep source debt visible'];
+
+    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.sources')).toEqual([
+      'scripts',
+      'pages',
+    ]);
   });
 
   test('Jest keeps production coverage exclusions explicit', () => {
@@ -129,24 +140,24 @@ describe('coverage exclusion contract', () => {
   test('Sonar source scope includes production pages and site debt', () => {
     const sonarProperties = readSonarProperties();
 
-    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.sources')).toEqual([
-      'scripts',
-      'pages',
-      'site',
-    ]);
+    const sources = readCommaSeparatedSonarProperty(sonarProperties, 'sonar.sources');
+    expect(sources).toEqual(expect.arrayContaining(['scripts', 'pages', 'site']));
+    expect(sources).toHaveLength(3);
   });
 
   test('Sonar source exclusions do not suppress test debt governance', () => {
     const sonarProperties = readSonarProperties();
     const sourceExclusions = readCommaSeparatedSonarProperty(sonarProperties, 'sonar.exclusions');
 
-    expect(sourceExclusions).toEqual([
-      'node_modules/**',
-      'dist/**',
-      'coverage/**',
-      'playwright-report/**',
-      'lib/Readability.js',
-    ]);
+    expect(sourceExclusions).toEqual(
+      expect.arrayContaining([
+        'node_modules/**',
+        'dist/**',
+        'coverage/**',
+        'playwright-report/**',
+        'lib/Readability.js',
+      ])
+    );
     expect(sourceExclusions).not.toContain('tests/**');
     expect(sourceExclusions).not.toContain('**/*.test.js');
     expect(sourceExclusions).not.toContain('**/*.spec.js');
@@ -154,11 +165,15 @@ describe('coverage exclusion contract', () => {
 
   test('Sonar test scope remains explicit for test debt analysis', () => {
     const sonarProperties = readSonarProperties();
+    const testSources = readCommaSeparatedSonarProperty(sonarProperties, 'sonar.tests');
+    const testInclusions = readCommaSeparatedSonarProperty(
+      sonarProperties,
+      'sonar.test.inclusions'
+    );
 
-    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.tests')).toEqual(['tests']);
-    expect(readCommaSeparatedSonarProperty(sonarProperties, 'sonar.test.inclusions')).toEqual([
-      '**/*.test.js',
-      '**/*.spec.js',
-    ]);
+    expect(testSources).toEqual(expect.arrayContaining(['tests']));
+    expect(testSources).toHaveLength(1);
+    expect(testInclusions).toEqual(expect.arrayContaining(['**/*.test.js', '**/*.spec.js']));
+    expect(testInclusions).toHaveLength(2);
   });
 });


### PR DESCRIPTION
### 摘要
更新 Sonar 配置以包含網站目錄並改進測試技術債的治理。

### 變更內容
- 將 `sonar.sources` 更新為包含 `site` 目錄。
- 調整 `sonar.exclusions`，移除對測試文件的排除。
- 增加新的函數以讀取 Sonar 屬性值。
- 增加測試以驗證 Sonar 配置的正確性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

