### PR TITLE
test: deduplicate content index and auth error cases

### DIFF
--- a/tests/unit/auth/auth.test.js
+++ b/tests/unit/auth/auth.test.js
@@ -46,6 +46,70 @@ describe('auth.js', () => {
     }
   }
 
+  function buildSessionExchangePayload(overrides = {}) {
+    return {
+      access_token: 'access_123',
+      refresh_token: 'refresh_123',
+      expires_at: 1_700_000_000,
+      user_id: 'user_123',
+      ...overrides,
+    };
+  }
+
+  function buildAccountProfilePayload(overrides = {}) {
+    return {
+      user_id: 'user_123',
+      email: 'user@example.com',
+      display_name: 'Test User',
+      avatar_url: 'https://cdn.example.com/avatar.png',
+      ...overrides,
+    };
+  }
+
+  function mockJsonResponse(payload) {
+    return {
+      ok: true,
+      json: async () => payload,
+    };
+  }
+
+  function mockTextErrorResponse(status, body) {
+    return {
+      ok: false,
+      status,
+      text: async () => body,
+    };
+  }
+
+  async function runTicketExchangeFlow() {
+    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+
+    await loadAuthModule();
+    await dispatchDomReady();
+  }
+
+  function expectStatusError(message, detail) {
+    const statusArea = document.querySelector('#status-area');
+
+    expect(statusArea.className).toContain('status-error');
+    expect(statusArea.textContent).toContain(message);
+    if (detail) {
+      expect(statusArea.textContent).toContain(detail);
+    }
+    expect(globalThis.close).not.toHaveBeenCalled();
+  }
+
+  function expectNoSessionPersistence({ clearSession = false } = {}) {
+    expect(mockSetAccountSession).not.toHaveBeenCalled();
+    expect(mockSetAccountProfile).not.toHaveBeenCalled();
+    if (clearSession) {
+      expect(mockClearAccountSession).toHaveBeenCalled();
+      return;
+    }
+
+    expect(mockClearAccountSession).not.toHaveBeenCalled();
+  }
+
   beforeEach(() => {
     jest.resetModules();
     jest.useFakeTimers();
@@ -110,29 +174,10 @@ describe('auth.js', () => {
 
   it('成功交換 session 與 profile 後應寫入 storage、廣播並自動關閉', async () => {
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          user_id: 'user_123',
-          email: 'user@example.com',
-          display_name: 'Test User',
-          avatar_url: 'https://cdn.example.com/avatar.png',
-        }),
-      });
+      .mockResolvedValueOnce(mockJsonResponse(buildSessionExchangePayload()))
+      .mockResolvedValueOnce(mockJsonResponse(buildAccountProfilePayload()));
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       1,
@@ -182,15 +227,7 @@ describe('auth.js', () => {
     const { BUILD_ENV } = await import('../../../scripts/config/env/index.js');
     BUILD_ENV.OAUTH_SERVER_URL = 'https://worker.test/proxy';
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
+      .mockResolvedValueOnce(mockJsonResponse(buildSessionExchangePayload()))
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -200,10 +237,7 @@ describe('auth.js', () => {
           avatar_url: null,
         }),
       });
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       1,
@@ -219,24 +253,16 @@ describe('auth.js', () => {
 
   it('account/me 失敗時應清除 session 並顯示錯誤', async () => {
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockJsonResponse({
           access_token: 'access_123',
           refresh_token: 'refresh_123',
           expires_at: 1_700_000_000,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        text: async () => 'server error',
-      });
+        })
+      )
+      .mockResolvedValueOnce(mockTextErrorResponse(500, 'server error'));
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
     expect(mockClearAccountSession).toHaveBeenCalled();
     expect(document.querySelector('#status-area').className).toContain('status-error');
@@ -245,16 +271,16 @@ describe('auth.js', () => {
   });
 
   it('account/me 回 200 但缺 user_id 時應清除 session 並顯示錯誤', async () => {
+    expect.hasAssertions();
+
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_from_exchange',
-        }),
-      })
+      .mockResolvedValueOnce(
+        mockJsonResponse(
+          buildSessionExchangePayload({
+            user_id: 'user_from_exchange',
+          })
+        )
+      )
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -263,127 +289,46 @@ describe('auth.js', () => {
         }),
       });
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+    await runTicketExchangeFlow();
 
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockClearAccountSession).toHaveBeenCalled();
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
-    expect(document.querySelector('#status-area').textContent).toContain('user_id');
-    expect(globalThis.close).not.toHaveBeenCalled();
+    expectNoSessionPersistence({ clearSession: true });
+    expectStatusError('無法取得帳號資訊', 'user_id');
   });
 
   it('exchangeTicket 失敗時應顯示錯誤且不寫入 storage', async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      text: async () => 'invalid ticket',
-    });
+    expect.hasAssertions();
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+    globalThis.fetch.mockResolvedValueOnce(mockTextErrorResponse(400, 'invalid ticket'));
 
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(mockClearAccountSession).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
-    expect(globalThis.close).not.toHaveBeenCalled();
+    expectNoSessionPersistence();
+    expectStatusError('無法完成 Session 交換');
   });
 
-  it('exchangeTicket 回傳 null 時應顯示錯誤', async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => null,
-    });
+  it.each([
+    ['null', null],
+    ['primitive 值', 'invalid response'],
+    ['陣列', ['not', 'an', 'object']],
+  ])('exchangeTicket 回傳 %s 時應顯示錯誤', async (_label, exchangePayload) => {
+    expect.hasAssertions();
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+    globalThis.fetch.mockResolvedValueOnce(mockJsonResponse(exchangePayload));
 
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(mockClearAccountSession).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
-  });
-
-  it('exchangeTicket 回傳 primitive 值時應顯示錯誤', async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => 'invalid response',
-    });
-
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(mockClearAccountSession).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
-  });
-
-  it('exchangeTicket 回傳陣列時應顯示錯誤', async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ['not', 'an', 'object'],
-    });
-
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(mockClearAccountSession).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法完成 Session 交換');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
+    expectNoSessionPersistence();
+    expectStatusError('無法完成 Session 交換', 'not a valid object');
   });
 
   it('寫入 storage 失敗時應清除 session 並顯示錯誤', async () => {
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          user_id: 'user_123',
-          email: 'user@example.com',
-          display_name: 'Test User',
-          avatar_url: 'https://cdn.example.com/avatar.png',
-        }),
-      });
+      .mockResolvedValueOnce(mockJsonResponse(buildSessionExchangePayload()))
+      .mockResolvedValueOnce(mockJsonResponse(buildAccountProfilePayload()));
 
     mockSetAccountSession.mockRejectedValueOnce(new Error('storage quota exceeded'));
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
+    await runTicketExchangeFlow();
 
     expect(mockClearAccountSession).toHaveBeenCalled();
     expect(document.querySelector('#status-area').className).toContain('status-error');
@@ -391,93 +336,20 @@ describe('auth.js', () => {
     expect(globalThis.close).not.toHaveBeenCalled();
   });
 
-  it('account/me 回傳 null 時應清除 session 並顯示錯誤', async () => {
+  it.each([
+    ['null', null],
+    ['primitive 值', 42],
+    ['陣列', [{ email: 'user@example.com' }]],
+  ])('account/me 回傳 %s 時應清除 session 並顯示錯誤', async (_label, profilePayload) => {
+    expect.hasAssertions();
+
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => null,
-      });
+      .mockResolvedValueOnce(mockJsonResponse(buildSessionExchangePayload()))
+      .mockResolvedValueOnce(mockJsonResponse(profilePayload));
 
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
+    await runTicketExchangeFlow();
 
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockClearAccountSession).toHaveBeenCalled();
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
-  });
-
-  it('account/me 回傳 primitive 值時應清除 session 並顯示錯誤', async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => 42,
-      });
-
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockClearAccountSession).toHaveBeenCalled();
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
-  });
-
-  it('account/me 回傳陣列時應清除 session 並顯示錯誤', async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'access_123',
-          refresh_token: 'refresh_123',
-          expires_at: 1_700_000_000,
-          user_id: 'user_123',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ email: 'user@example.com' }],
-      });
-
-    globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
-
-    await loadAuthModule();
-    await dispatchDomReady();
-
-    expect(mockClearAccountSession).toHaveBeenCalled();
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    expect(document.querySelector('#status-area').className).toContain('status-error');
-    expect(document.querySelector('#status-area').textContent).toContain('無法取得帳號資訊');
-    expect(document.querySelector('#status-area').textContent).toContain('not a valid object');
-    expect(globalThis.close).not.toHaveBeenCalled();
+    expectNoSessionPersistence({ clearSession: true });
+    expectStatusError('無法取得帳號資訊', 'not a valid object');
   });
 });

--- a/tests/unit/auth/auth.test.js
+++ b/tests/unit/auth/auth.test.js
@@ -34,6 +34,63 @@ async function loadAuthModule() {
   await import('../../../scripts/auth/auth.js');
 }
 
+function buildSessionExchangePayload(overrides = {}) {
+  return {
+    access_token: 'access_123',
+    refresh_token: 'refresh_123',
+    expires_at: 1_700_000_000,
+    user_id: 'user_123',
+    ...overrides,
+  };
+}
+
+function buildAccountProfilePayload(overrides = {}) {
+  return {
+    user_id: 'user_123',
+    email: 'user@example.com',
+    display_name: 'Test User',
+    avatar_url: 'https://cdn.example.com/avatar.png',
+    ...overrides,
+  };
+}
+
+function mockJsonResponse(payload) {
+  return {
+    ok: true,
+    json: async () => payload,
+  };
+}
+
+function mockTextErrorResponse(status, body) {
+  return {
+    ok: false,
+    status,
+    text: async () => body,
+  };
+}
+
+function expectStatusError(message, detail) {
+  const statusArea = document.querySelector('#status-area');
+
+  expect(statusArea.className).toContain('status-error');
+  expect(statusArea.textContent).toContain(message);
+  if (detail) {
+    expect(statusArea.textContent).toContain(detail);
+  }
+  expect(globalThis.close).not.toHaveBeenCalled();
+}
+
+function expectNoSessionPersistence({ clearSession = false } = {}) {
+  expect(mockSetAccountSession).not.toHaveBeenCalled();
+  expect(mockSetAccountProfile).not.toHaveBeenCalled();
+  if (clearSession) {
+    expect(mockClearAccountSession).toHaveBeenCalled();
+    return;
+  }
+
+  expect(mockClearAccountSession).not.toHaveBeenCalled();
+}
+
 describe('auth.js', () => {
   let originalClose;
   let domReadyHandler;
@@ -46,68 +103,11 @@ describe('auth.js', () => {
     }
   }
 
-  function buildSessionExchangePayload(overrides = {}) {
-    return {
-      access_token: 'access_123',
-      refresh_token: 'refresh_123',
-      expires_at: 1_700_000_000,
-      user_id: 'user_123',
-      ...overrides,
-    };
-  }
-
-  function buildAccountProfilePayload(overrides = {}) {
-    return {
-      user_id: 'user_123',
-      email: 'user@example.com',
-      display_name: 'Test User',
-      avatar_url: 'https://cdn.example.com/avatar.png',
-      ...overrides,
-    };
-  }
-
-  function mockJsonResponse(payload) {
-    return {
-      ok: true,
-      json: async () => payload,
-    };
-  }
-
-  function mockTextErrorResponse(status, body) {
-    return {
-      ok: false,
-      status,
-      text: async () => body,
-    };
-  }
-
   async function runTicketExchangeFlow() {
     globalThis.history.replaceState({}, '', '/auth.html?account_ticket=ticket_123');
 
     await loadAuthModule();
     await dispatchDomReady();
-  }
-
-  function expectStatusError(message, detail) {
-    const statusArea = document.querySelector('#status-area');
-
-    expect(statusArea.className).toContain('status-error');
-    expect(statusArea.textContent).toContain(message);
-    if (detail) {
-      expect(statusArea.textContent).toContain(detail);
-    }
-    expect(globalThis.close).not.toHaveBeenCalled();
-  }
-
-  function expectNoSessionPersistence({ clearSession = false } = {}) {
-    expect(mockSetAccountSession).not.toHaveBeenCalled();
-    expect(mockSetAccountProfile).not.toHaveBeenCalled();
-    if (clearSession) {
-      expect(mockClearAccountSession).toHaveBeenCalled();
-      return;
-    }
-
-    expect(mockClearAccountSession).not.toHaveBeenCalled();
   }
 
   beforeEach(() => {

--- a/tests/unit/auth/auth.test.js
+++ b/tests/unit/auth/auth.test.js
@@ -228,15 +228,7 @@ describe('auth.js', () => {
     BUILD_ENV.OAUTH_SERVER_URL = 'https://worker.test/proxy';
     globalThis.fetch
       .mockResolvedValueOnce(mockJsonResponse(buildSessionExchangePayload()))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          user_id: 'user_123',
-          email: 'user@example.com',
-          display_name: 'Test User',
-          avatar_url: null,
-        }),
-      });
+      .mockResolvedValueOnce(mockJsonResponse(buildAccountProfilePayload({ avatar_url: null })));
     await runTicketExchangeFlow();
 
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
@@ -281,13 +273,12 @@ describe('auth.js', () => {
           })
         )
       )
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      .mockResolvedValueOnce(
+        mockJsonResponse({
           email: 'user@example.com',
           display_name: 'Test User',
-        }),
-      });
+        })
+      );
 
     await runTicketExchangeFlow();
 

--- a/tests/unit/content/content-index.test.js
+++ b/tests/unit/content/content-index.test.js
@@ -45,6 +45,34 @@ async function flushPromises() {
   }
 }
 
+function expectSendResponseFailure(sendResponse, error) {
+  expect(sendResponse).toHaveBeenCalledWith({
+    success: false,
+    error,
+  });
+}
+
+function mockReadabilityExtraction({
+  title = 'Test Title',
+  content = '<div>Test content</div>',
+  blocks = [],
+} = {}) {
+  ContentExtractor.extractAsync.mockResolvedValue({
+    content,
+    type: 'readability',
+    metadata: { title },
+    blocks,
+  });
+
+  const mockConverter = {
+    convert: jest.fn().mockReturnValue([{ object: 'block', type: 'paragraph' }]),
+    imageCount: 0,
+  };
+  ConverterFactory.getConverter.mockReturnValue(mockConverter);
+
+  return mockConverter;
+}
+
 describe('Content Script Entry (index.js)', () => {
   test('content default page title uses centralized zh-TW fallback copy', () => {
     expect(CONTENT_QUALITY.DEFAULT_PAGE_TITLE).toBe(DATA_SOURCE_MESSAGES.UNTITLED_PAGE);
@@ -149,13 +177,6 @@ describe('Content Script Entry (index.js)', () => {
 
     function dispatchAction(action, payload = {}) {
       return dispatchMessage({ action, ...payload });
-    }
-
-    function expectSendResponseFailure(sendResponse, error) {
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error,
-      });
     }
 
     function getReplayCallback() {
@@ -779,27 +800,6 @@ describe('Content Script Entry (index.js)', () => {
   });
 
   describe('extractPageContent', () => {
-    function mockReadabilityExtraction({
-      title = 'Test Title',
-      content = '<div>Test content</div>',
-      blocks = [],
-    } = {}) {
-      ContentExtractor.extractAsync.mockResolvedValue({
-        content,
-        type: 'readability',
-        metadata: { title },
-        blocks,
-      });
-
-      const mockConverter = {
-        convert: jest.fn().mockReturnValue([{ object: 'block', type: 'paragraph' }]),
-        imageCount: 0,
-      };
-      ConverterFactory.getConverter.mockReturnValue(mockConverter);
-
-      return mockConverter;
-    }
-
     test('應該成功提取並轉換內容', async () => {
       mockReadabilityExtraction();
 

--- a/tests/unit/content/content-index.test.js
+++ b/tests/unit/content/content-index.test.js
@@ -848,7 +848,6 @@ describe('Content Script Entry (index.js)', () => {
             new Error('Image collection failed')
           );
         },
-        expectDebugObject: true,
       },
       {
         title: '應該在 imageResult 無 metrics 時 imageMetrics 為 null',
@@ -859,18 +858,15 @@ describe('Content Script Entry (index.js)', () => {
           });
           mergeUniqueImages.mockReturnValue([]);
         },
-        expectDebugObject: false,
       },
-    ])('$title', async ({ arrangeImages, expectDebugObject }) => {
+    ])('$title', async ({ arrangeImages }) => {
       mockReadabilityExtraction();
       arrangeImages();
 
       const result = await extractPageContent();
 
       expect(result.extractionStatus).toBe('success');
-      if (expectDebugObject) {
-        expect(result.debug).toBeDefined();
-      }
+      expect(result.debug).toBeDefined();
       expect(result.debug.imageMetrics).toBeNull();
     });
 

--- a/tests/unit/content/content-index.test.js
+++ b/tests/unit/content/content-index.test.js
@@ -89,6 +89,21 @@ describe('Content Script Entry (index.js)', () => {
     let sendMessageMock;
     let preloaderHandler;
 
+    const showFloatingRailAction = 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL';
+    const activateFloatingRailAction = 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT';
+    const railOperationFailure = {
+      success: false,
+      error: '浮動側欄操作失敗',
+    };
+    const railInitializationFailure = {
+      success: false,
+      error: '浮動側欄初始化失敗',
+    };
+    const railNotInitializedFailure = {
+      success: false,
+      error: '浮動側欄尚未初始化',
+    };
+
     beforeEach(() => {
       sendMessageMock = jest.fn();
       globalThis.chrome.runtime.onMessage.addListener = jest.fn();
@@ -125,6 +140,33 @@ describe('Content Script Entry (index.js)', () => {
       document.removeEventListener('notion-preloader-request', preloaderHandler);
     });
 
+    function dispatchMessage(message) {
+      const sendResponse = jest.fn();
+      const result = messageHandler(message, {}, sendResponse);
+
+      return { result, sendResponse };
+    }
+
+    function dispatchAction(action, payload = {}) {
+      return dispatchMessage({ action, ...payload });
+    }
+
+    function expectSendResponseFailure(sendResponse, error) {
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error,
+      });
+    }
+
+    function getReplayCallback() {
+      const replayCall = sendMessageMock.mock.calls.find(
+        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
+      );
+
+      expect(replayCall).toBeDefined();
+      return replayCall[1];
+    }
+
     test('PING 應該返回正確的元數據', () => {
       const sendResponse = jest.fn();
       messageHandler({ action: 'PING' }, {}, sendResponse);
@@ -152,9 +194,8 @@ describe('Content Script Entry (index.js)', () => {
     test('showHighlighter 應優先調用 rail.show', () => {
       const showMock = jest.fn();
       globalThis.HighlighterV2 = { rail: { show: showMock } };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'showHighlighter' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction('showHighlighter');
 
       expect(showMock).toHaveBeenCalled();
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
@@ -169,70 +210,42 @@ describe('Content Script Entry (index.js)', () => {
           }),
         },
       };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'showHighlighter' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction('showHighlighter');
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railOperationFailure);
     });
 
     test('[REGRESSION] showHighlighter 不應在無 rail 時 fallback 到 notionHighlighter toolbar', async () => {
       delete globalThis.HighlighterV2;
       const showMock = jest.fn();
       globalThis.notionHighlighter = { show: showMock };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'showHighlighter' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction('showHighlighter');
       await Promise.resolve();
       await Promise.resolve();
 
       expect(showMock).not.toHaveBeenCalled();
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄尚未初始化',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railNotInitializedFailure);
       delete globalThis.notionHighlighter;
     });
 
-    test('[REGRESSION] showHighlighter 應等待 rail-ready 完成後才回應', async () => {
+    test.each([
+      {
+        title: '[REGRESSION] showHighlighter 應等待 rail-ready 完成後才回應',
+        action: 'showHighlighter',
+      },
+      {
+        title: '[REGRESSION] content bridge SHOW_FLOATING_RAIL 應等待 rail-ready 完成後才回應',
+        action: showFloatingRailAction,
+      },
+    ])('$title', async ({ action }) => {
       delete globalThis.HighlighterV2;
       const railReady = createDeferred();
       const showMock = jest.fn();
       globalThis.__NOTION_RAIL_READY__ = railReady.promise;
-      const sendResponse = jest.fn();
 
-      const result = messageHandler({ action: 'showHighlighter' }, {}, sendResponse);
-
-      expect(result).toBe(true);
-      expect(showMock).not.toHaveBeenCalled();
-      expect(sendResponse).not.toHaveBeenCalled();
-
-      railReady.resolve({
-        success: true,
-        rail: { show: showMock },
-      });
-      await flushPromises();
-
-      expect(showMock).toHaveBeenCalled();
-      expect(sendResponse).toHaveBeenCalledWith({ success: true });
-
-      delete globalThis.__NOTION_RAIL_READY__;
-    });
-
-    test('[REGRESSION] content bridge SHOW_FLOATING_RAIL 應等待 rail-ready 完成後才回應', async () => {
-      const railReady = createDeferred();
-      const showMock = jest.fn();
-      globalThis.__NOTION_RAIL_READY__ = railReady.promise;
-      const sendResponse = jest.fn();
-
-      const result = messageHandler(
-        { action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' },
-        {},
-        sendResponse
-      );
+      const { result, sendResponse } = dispatchAction(action);
 
       expect(result).toBe(true);
       expect(showMock).not.toHaveBeenCalled();
@@ -260,13 +273,8 @@ describe('Content Script Entry (index.js)', () => {
           show: showMock,
         },
       };
-      const sendResponse = jest.fn();
 
-      const result = messageHandler(
-        { action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' },
-        {},
-        sendResponse
-      );
+      const { result, sendResponse } = dispatchAction(showFloatingRailAction);
 
       expect(result).toBe(true);
       expect(undismissMock).toHaveBeenCalledWith();
@@ -280,75 +288,45 @@ describe('Content Script Entry (index.js)', () => {
         success: true,
         rail: { undismiss: undismissMock },
       });
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(showFloatingRailAction);
       await flushPromises();
 
       expect(undismissMock).not.toHaveBeenCalled();
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄缺少 show() 方法',
-      });
+      expectSendResponseFailure(sendResponse, '浮動側欄缺少 show() 方法');
       expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
       delete globalThis.__NOTION_RAIL_READY__;
     });
 
-    test('[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 顯示失敗時應返回安全 fallback 訊息', () => {
-      globalThis.HighlighterV2 = {
-        rail: {
-          show: jest.fn(() => {
-            throw new Error('rail show failed');
-          }),
-        },
-      };
-      const sendResponse = jest.fn();
+    test.each([
+      {
+        title: '[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 顯示失敗時應返回安全 fallback 訊息',
+        show: jest.fn(() => {
+          throw new Error('rail show failed');
+        }),
+      },
+      {
+        title:
+          '[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 的 async show reject 時應返回安全 fallback 訊息',
+        show: jest.fn().mockRejectedValue(new Error('async rail show failed')),
+      },
+      {
+        title:
+          '[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 拋出無 message 的 Error 時應回傳安全 fallback 訊息',
+        show: jest.fn(() => {
+          const railError = new Error('unused');
+          delete railError.message;
+          railError.reason = 'rail show failed';
+          throw railError;
+        }),
+      },
+    ])('$title', async ({ show }) => {
+      globalThis.HighlighterV2 = { rail: { show } };
 
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
-    });
-
-    test('[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 的 async show reject 時應返回安全 fallback 訊息', async () => {
-      globalThis.HighlighterV2 = {
-        rail: {
-          show: jest.fn().mockRejectedValue(new Error('async rail show failed')),
-        },
-      };
-      const sendResponse = jest.fn();
-
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(showFloatingRailAction);
       await flushPromises();
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
-    });
-
-    test('[REGRESSION] SHOW_FLOATING_RAIL 在現有 rail 拋出無 message 的 Error 時應回傳安全 fallback 訊息', () => {
-      const railError = new Error('unused');
-      delete railError.message;
-      railError.reason = 'rail show failed';
-
-      globalThis.HighlighterV2 = {
-        rail: {
-          show: jest.fn(() => {
-            throw railError;
-          }),
-        },
-      };
-      const sendResponse = jest.fn();
-
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railOperationFailure);
     });
 
     test('[REGRESSION] SHOW_FLOATING_RAIL 在 ready rail 缺少顯示方法時應返回明確錯誤', async () => {
@@ -356,43 +334,31 @@ describe('Content Script Entry (index.js)', () => {
         success: true,
         rail: {},
       });
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(showFloatingRailAction);
       await flushPromises();
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄缺少 show() 方法',
-      });
+      expectSendResponseFailure(sendResponse, '浮動側欄缺少 show() 方法');
       expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
     });
 
     test('SHOW_FLOATING_RAIL 在 readyResult 未帶 error 時應返回通用初始化錯誤', async () => {
       globalThis.__NOTION_RAIL_READY__ = Promise.resolve({ success: false });
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(showFloatingRailAction);
       await flushPromises();
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄初始化失敗',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railInitializationFailure);
       expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
     });
 
     test('SHOW_FLOATING_RAIL 在未初始化時應直接返回錯誤', () => {
       delete globalThis.HighlighterV2;
       delete globalThis.__NOTION_RAIL_READY__;
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'CONTENT_BRIDGE_SHOW_FLOATING_RAIL' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(showFloatingRailAction);
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄尚未初始化',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railNotInitializedFailure);
     });
 
     test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 應先喚回 dismissed 的 ready rail 再啟動標註', async () => {
@@ -401,13 +367,8 @@ describe('Content Script Entry (index.js)', () => {
       const undismissMock = jest.fn();
       const activateHighlightingMock = jest.fn();
       globalThis.__NOTION_RAIL_READY__ = railReady.promise;
-      const sendResponse = jest.fn();
 
-      const result = messageHandler(
-        { action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' },
-        {},
-        sendResponse
-      );
+      const { result, sendResponse } = dispatchAction(activateFloatingRailAction);
 
       expect(result).toBe(true);
       expect(showMock).not.toHaveBeenCalled();
@@ -445,9 +406,8 @@ describe('Content Script Entry (index.js)', () => {
           activateHighlighting: activateHighlightingMock,
         },
       };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(activateFloatingRailAction);
 
       expect(undismissMock).toHaveBeenCalledWith();
       expect(showMock).not.toHaveBeenCalled();
@@ -465,114 +425,88 @@ describe('Content Script Entry (index.js)', () => {
           activateHighlighting: activateHighlightingMock,
         },
       };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(activateFloatingRailAction);
 
       expect(activateHighlightingMock).toHaveBeenCalledWith();
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railOperationFailure);
     });
 
     test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在現有 rail 缺少 activateHighlighting 時應回傳明確錯誤', () => {
+      expect.hasAssertions();
       globalThis.HighlighterV2 = {
         rail: {
           show: jest.fn(),
         },
       };
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(activateFloatingRailAction);
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄缺少 activateHighlighting() 方法',
-      });
+      expectSendResponseFailure(sendResponse, '浮動側欄缺少 activateHighlighting() 方法');
     });
 
-    test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 初始化失敗時應回傳標準化初始化錯誤', async () => {
-      globalThis.__NOTION_RAIL_READY__ = Promise.resolve({
-        success: false,
-        error: 'ready failed',
-      });
-      const sendResponse = jest.fn();
-
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
-      await flushPromises();
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄初始化失敗',
-      });
-      expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
-    });
-
-    test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 缺少 activateHighlighting 時應回傳明確錯誤', async () => {
-      globalThis.__NOTION_RAIL_READY__ = Promise.resolve({
-        success: true,
-        rail: {
-          show: jest.fn(),
+    test.each([
+      {
+        title:
+          '[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 初始化失敗時應回傳標準化初始化錯誤',
+        createReadyPromise: () =>
+          Promise.resolve({
+            success: false,
+            error: 'ready failed',
+          }),
+        response: railInitializationFailure,
+      },
+      {
+        title:
+          '[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 缺少 activateHighlighting 時應回傳明確錯誤',
+        createReadyPromise: () =>
+          Promise.resolve({
+            success: true,
+            rail: {
+              show: jest.fn(),
+            },
+          }),
+        response: {
+          success: false,
+          error: '浮動側欄缺少 activateHighlighting() 方法',
         },
-      });
-      const sendResponse = jest.fn();
+      },
+      {
+        title:
+          '[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 的 async activateHighlighting reject 時應回傳安全 fallback 訊息',
+        createReadyPromise: () =>
+          Promise.resolve({
+            success: true,
+            rail: {
+              show: jest.fn(),
+              activateHighlighting: jest.fn().mockRejectedValue(new Error('async activate failed')),
+            },
+          }),
+        response: railOperationFailure,
+      },
+      {
+        title:
+          '[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready promise reject 時應回傳通用錯誤',
+        createReadyPromise: () => Promise.reject(new Error('boom')),
+        response: railInitializationFailure,
+      },
+    ])('$title', async ({ createReadyPromise, response }) => {
+      globalThis.__NOTION_RAIL_READY__ = createReadyPromise();
 
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(activateFloatingRailAction);
       await flushPromises();
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄缺少 activateHighlighting() 方法',
-      });
-      expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
-    });
-
-    test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready rail 的 async activateHighlighting reject 時應回傳安全 fallback 訊息', async () => {
-      globalThis.__NOTION_RAIL_READY__ = Promise.resolve({
-        success: true,
-        rail: {
-          show: jest.fn(),
-          activateHighlighting: jest.fn().mockRejectedValue(new Error('async activate failed')),
-        },
-      });
-      const sendResponse = jest.fn();
-
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
-      await flushPromises();
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄操作失敗',
-      });
-      expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
-    });
-
-    test('[REGRESSION] ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在 ready promise reject 時應回傳通用錯誤', async () => {
-      globalThis.__NOTION_RAIL_READY__ = Promise.reject(new Error('boom'));
-      const sendResponse = jest.fn();
-
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
-      await flushPromises();
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄初始化失敗',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(response);
       expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
     });
 
     test('ACTIVATE_FLOATING_RAIL_HIGHLIGHT 在未初始化時應直接返回錯誤', () => {
       delete globalThis.HighlighterV2;
       delete globalThis.__NOTION_RAIL_READY__;
-      const sendResponse = jest.fn();
 
-      messageHandler({ action: 'ACTIVATE_FLOATING_RAIL_HIGHLIGHT' }, {}, sendResponse);
+      const { sendResponse } = dispatchAction(activateFloatingRailAction);
 
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: '浮動側欄尚未初始化',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(railNotInitializedFailure);
     });
 
     test('REMOVE_HIGHLIGHT_DOM 應呼叫 manager.removeHighlight', () => {
@@ -655,10 +589,7 @@ describe('Content Script Entry (index.js)', () => {
     });
 
     test('REPLAY_BUFFERED_EVENTS callback 遇到 runtime.lastError 時應靜默忽略', () => {
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
       globalThis.chrome.runtime.lastError = { message: 'preloader missing' };
 
       replayCallback({ events: [{ type: 'shortcut' }] });
@@ -677,12 +608,7 @@ describe('Content Script Entry (index.js)', () => {
       };
       globalThis.HighlighterV2 = { rail };
 
-      // Simulate response to REPLAY_BUFFERED_EVENTS
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      expect(replayCall).toBeDefined();
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
 
       replayCallback({ events: [{ type: 'shortcut' }] });
       await flushPromises();
@@ -695,10 +621,7 @@ describe('Content Script Entry (index.js)', () => {
 
     test('重放 shortcut 事件時若 Highlighter 不可用應記錄警告', () => {
       delete globalThis.HighlighterV2;
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
 
       replayCallback({ events: [{ type: 'shortcut' }] });
 
@@ -717,10 +640,7 @@ describe('Content Script Entry (index.js)', () => {
       };
       globalThis.HighlighterV2 = { rail };
 
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
 
       replayCallback({ events: [{ type: 'shortcut' }] });
       await flushPromises();
@@ -741,10 +661,7 @@ describe('Content Script Entry (index.js)', () => {
       };
       globalThis.HighlighterV2 = { rail };
 
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
 
       replayCallback({ events: [{ type: 'shortcut' }] });
       await flushPromises();
@@ -770,10 +687,7 @@ describe('Content Script Entry (index.js)', () => {
         },
       };
 
-      const replayCall = sendMessageMock.mock.calls.find(
-        call => call[0].action === 'REPLAY_BUFFERED_EVENTS'
-      );
-      const replayCallback = replayCall[1];
+      const replayCallback = getReplayCallback();
 
       replayCallback({ events: [{ type: 'shortcut' }] });
       await flushPromises();
@@ -797,40 +711,31 @@ describe('Content Script Entry (index.js)', () => {
         delete globalThis.__NOTION_STABLE_URL__;
       });
 
-      test('應該接受帶有 query 參數的 URL', () => {
-        const sendResponse = jest.fn();
-        const result = messageHandler(
-          { action: 'SET_STABLE_URL', stableUrl: 'https://example.com/?p=123' },
-          {},
-          sendResponse
-        );
+      test.each([
+        ['應該接受帶有 query 參數的 URL', 'https://example.com/?p=123'],
+        ['應該接受帶有具體路徑的 URL', 'https://example.com/posts/123/'],
+      ])('%s', (_title, stableUrl) => {
+        const { result, sendResponse } = dispatchAction('SET_STABLE_URL', { stableUrl });
 
         expect(result).toBe(true);
-        expect(globalThis.__NOTION_STABLE_URL__).toBe('https://example.com/?p=123');
+        expect(globalThis.__NOTION_STABLE_URL__).toBe(stableUrl);
         expect(sendResponse).toHaveBeenCalledWith({ success: true });
       });
 
-      test('應該接受帶有具體路徑的 URL', () => {
-        const sendResponse = jest.fn();
-        const result = messageHandler(
-          { action: 'SET_STABLE_URL', stableUrl: 'https://example.com/posts/123/' },
-          {},
-          sendResponse
-        );
-
-        expect(result).toBe(true);
-        expect(globalThis.__NOTION_STABLE_URL__).toBe('https://example.com/posts/123/');
-        expect(sendResponse).toHaveBeenCalledWith({ success: true });
-      });
-
-      test('應該拒絕純首頁（無路徑無 query）', () => {
+      test.each([
+        {
+          title: '應該拒絕純首頁（無路徑無 query）',
+          stableUrl: 'https://example.com/',
+          logMessage: '拒絕設置首頁 URL 為穩定 URL',
+        },
+        {
+          title: '應該處理無效的 URL 字串',
+          stableUrl: 'not-a-valid-url',
+          logMessage: '拒絕設置無效 URL 為穩定 URL',
+        },
+      ])('$title', ({ stableUrl, logMessage }) => {
         globalThis.__NOTION_STABLE_URL__ = 'old-url';
-        const sendResponse = jest.fn();
-        const result = messageHandler(
-          { action: 'SET_STABLE_URL', stableUrl: 'https://example.com/' },
-          {},
-          sendResponse
-        );
+        const { result, sendResponse } = dispatchAction('SET_STABLE_URL', { stableUrl });
 
         expect(result).toBe(true);
         expect(globalThis.__NOTION_STABLE_URL__).toBe('old-url'); // Unchanged
@@ -838,38 +743,13 @@ describe('Content Script Entry (index.js)', () => {
           success: false,
           error: 'INVALID_STABLE_URL',
         });
-        expect(Logger.debug).toHaveBeenCalledWith(
-          '拒絕設置首頁 URL 為穩定 URL',
-          expect.any(Object)
-        );
-      });
-
-      test('應該處理無效的 URL 字串', () => {
-        globalThis.__NOTION_STABLE_URL__ = 'old-url';
-        const sendResponse = jest.fn();
-        const result = messageHandler(
-          { action: 'SET_STABLE_URL', stableUrl: 'not-a-valid-url' },
-          {},
-          sendResponse
-        );
-
-        expect(result).toBe(true);
-        expect(globalThis.__NOTION_STABLE_URL__).toBe('old-url'); // Unchanged
-        expect(sendResponse).toHaveBeenCalledWith({
-          success: false,
-          error: 'INVALID_STABLE_URL',
-        });
-        expect(Logger.debug).toHaveBeenCalledWith(
-          '拒絕設置無效 URL 為穩定 URL',
-          expect.any(Object)
-        );
+        expect(Logger.debug).toHaveBeenCalledWith(logMessage, expect.any(Object));
       });
 
       test('GET_STABLE_URL 應回傳目前 stableUrl', () => {
         globalThis.__NOTION_STABLE_URL__ = 'https://example.com/posts/123/';
-        const sendResponse = jest.fn();
 
-        const result = messageHandler({ action: 'GET_STABLE_URL' }, {}, sendResponse);
+        const { result, sendResponse } = dispatchAction('GET_STABLE_URL');
 
         expect(result).toBe(true);
         expect(sendResponse).toHaveBeenCalledWith({
@@ -878,9 +758,7 @@ describe('Content Script Entry (index.js)', () => {
       });
 
       test('INIT_BUNDLE 應回傳 bundle ready 狀態與 bufferedEvents', () => {
-        const sendResponse = jest.fn();
-
-        const result = messageHandler({ action: 'INIT_BUNDLE' }, {}, sendResponse);
+        const { result, sendResponse } = dispatchAction('INIT_BUNDLE');
 
         expect(result).toBe(true);
         expect(sendResponse).toHaveBeenCalledWith({
@@ -901,12 +779,16 @@ describe('Content Script Entry (index.js)', () => {
   });
 
   describe('extractPageContent', () => {
-    test('應該成功提取並轉換內容', async () => {
+    function mockReadabilityExtraction({
+      title = 'Test Title',
+      content = '<div>Test content</div>',
+      blocks = [],
+    } = {}) {
       ContentExtractor.extractAsync.mockResolvedValue({
-        content: '<div>Test content</div>',
+        content,
         type: 'readability',
-        metadata: { title: 'Test Title' },
-        blocks: [],
+        metadata: { title },
+        blocks,
       });
 
       const mockConverter = {
@@ -914,6 +796,12 @@ describe('Content Script Entry (index.js)', () => {
         imageCount: 0,
       };
       ConverterFactory.getConverter.mockReturnValue(mockConverter);
+
+      return mockConverter;
+    }
+
+    test('應該成功提取並轉換內容', async () => {
+      mockReadabilityExtraction();
 
       ImageCollector.collectAdditionalImages.mockResolvedValue({
         images: [{ type: 'image', image: { external: { url: 'img1' } } }],
@@ -952,72 +840,45 @@ describe('Content Script Entry (index.js)', () => {
       });
     });
 
-    test('應該在圖片收集失敗時仍返回成功結果且 imageMetrics 為 null', async () => {
-      ContentExtractor.extractAsync.mockResolvedValue({
-        content: '<div>Test content</div>',
-        type: 'readability',
-        metadata: { title: 'Test Title' },
-        blocks: [],
-      });
-
-      const mockConverter = {
-        convert: jest.fn().mockReturnValue([{ object: 'block', type: 'paragraph' }]),
-        imageCount: 0,
-      };
-      ConverterFactory.getConverter.mockReturnValue(mockConverter);
-
-      ImageCollector.collectAdditionalImages.mockRejectedValue(
-        new Error('Image collection failed')
-      );
-
-      const result = await extractPageContent();
-
-      expect(result.extractionStatus).toBe('success');
-      expect(result.debug).toBeDefined();
-      expect(result.debug.imageMetrics).toBeNull();
-    });
-
-    test('應該在 imageResult 無 metrics 時 imageMetrics 為 null', async () => {
-      ContentExtractor.extractAsync.mockResolvedValue({
-        content: '<div>Test content</div>',
-        type: 'readability',
-        metadata: { title: 'Test Title' },
-        blocks: [],
-      });
-
-      const mockConverter = {
-        convert: jest.fn().mockReturnValue([{ object: 'block', type: 'paragraph' }]),
-        imageCount: 0,
-      };
-      ConverterFactory.getConverter.mockReturnValue(mockConverter);
-
-      // 回傳舊格式（無 metrics）
-      ImageCollector.collectAdditionalImages.mockResolvedValue({
-        images: [],
-        coverImage: null,
-      });
-
-      mergeUniqueImages.mockReturnValue([]);
+    test.each([
+      {
+        title: '應該在圖片收集失敗時仍返回成功結果且 imageMetrics 為 null',
+        arrangeImages: () => {
+          ImageCollector.collectAdditionalImages.mockRejectedValue(
+            new Error('Image collection failed')
+          );
+        },
+        expectDebugObject: true,
+      },
+      {
+        title: '應該在 imageResult 無 metrics 時 imageMetrics 為 null',
+        arrangeImages: () => {
+          ImageCollector.collectAdditionalImages.mockResolvedValue({
+            images: [],
+            coverImage: null,
+          });
+          mergeUniqueImages.mockReturnValue([]);
+        },
+        expectDebugObject: false,
+      },
+    ])('$title', async ({ arrangeImages, expectDebugObject }) => {
+      mockReadabilityExtraction();
+      arrangeImages();
 
       const result = await extractPageContent();
 
       expect(result.extractionStatus).toBe('success');
+      if (expectDebugObject) {
+        expect(result.debug).toBeDefined();
+      }
       expect(result.debug.imageMetrics).toBeNull();
     });
 
     test('應該在正文無圖片時將首張額外圖片插入到開頭', async () => {
-      ContentExtractor.extractAsync.mockResolvedValue({
+      mockReadabilityExtraction({
         content: '<div>No image</div>',
-        type: 'readability',
-        metadata: { title: 'No Image' },
-        blocks: [],
+        title: 'No Image',
       });
-
-      const mockConverter = {
-        convert: jest.fn().mockReturnValue([{ object: 'block', type: 'paragraph' }]),
-        imageCount: 0,
-      };
-      ConverterFactory.getConverter.mockReturnValue(mockConverter);
 
       const leadImg = { type: 'image', image: { external: { url: 'lead-img' } } };
       ImageCollector.collectAdditionalImages.mockResolvedValue({

--- a/tests/unit/options/storageDataUtils.test.js
+++ b/tests/unit/options/storageDataUtils.test.js
@@ -327,15 +327,18 @@ describe('getStorageHealthReport', () => {
     delete globalThis.chrome;
   });
 
-  test('應回傳包含使用量、健康度、清理計劃的統一報告', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_example.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
-        notionApiKey: 'key',
-      })
-    );
+  const loadHealthReport = async snapshot => {
+    mockGet.mockImplementation((_keys, cb) => cb(snapshot));
+    return getStorageHealthReport();
+  };
 
-    const report = await getStorageHealthReport();
+  const hasCleanupItem = (report, key) => report.cleanupPlan.items.some(item => item.key === key);
+
+  test('應回傳包含使用量、健康度、清理計劃的統一報告', async () => {
+    const report = await loadHealthReport({
+      'page_example.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
+      notionApiKey: 'key',
+    });
 
     expect(report.pages).toBe(1);
     expect(report.highlights).toBe(1);
@@ -348,149 +351,111 @@ describe('getStorageHealthReport', () => {
   });
 
   test('有效頁面（有標注）不應進入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_valid.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
-      })
-    );
+    const report = await loadHealthReport({
+      'page_valid.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
+    });
 
-    const report = await getStorageHealthReport();
     expect(report.cleanupPlan.totalKeys).toBe(0);
   });
 
   test('空 page_*（無標注且無 Notion 綁定）應進入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_empty.com': { notion: null, highlights: [] },
-      })
-    );
+    const report = await loadHealthReport({
+      'page_empty.com': { notion: null, highlights: [] },
+    });
 
-    const report = await getStorageHealthReport();
     expect(report.cleanupPlan.summary.emptyRecords).toBe(1);
     expect(report.cleanupPlan.totalKeys).toBe(1);
     expect(report.cleanupPlan.items[0].key).toBe('page_empty.com');
   });
 
-  test('損壞的 page_*（highlights 非陣列）應加入 corruptedData 並進入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_bad.com': { highlights: 'not_an_array' },
-      })
-    );
+  test.each([
+    {
+      name: '損壞的 page_*（highlights 非陣列）應加入 corruptedData 並進入清理計劃',
+      key: 'page_bad.com',
+      value: { highlights: 'not_an_array' },
+    },
+    {
+      name: '缺少 highlights 的 page_* 應視為損壞資料',
+      key: 'page_missing_highlights.com',
+      value: { notion: { pageId: 'p1' } },
+    },
+  ])('$name', async ({ key, value }) => {
+    const report = await loadHealthReport({ [key]: value });
 
-    const report = await getStorageHealthReport();
-    expect(report.corruptedData).toContain('page_bad.com');
+    expect(report.corruptedData).toContain(key);
     expect(report.pages).toBe(0);
     expect(report.highlights).toBe(0);
     expect(report.cleanupPlan.summary.corruptedRecords).toBe(1);
   });
 
-  test('缺少 highlights 的 page_* 應視為損壞資料', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_missing_highlights.com': { notion: { pageId: 'p1' } },
-      })
-    );
+  test.each([
+    {
+      name: 'migration_* key 應計入 migrationKeys 並加入清理計劃',
+      key: 'migration_old_data',
+    },
+    {
+      name: 'migration_notion_* key 應優先視為 migration leftover 而非 config',
+      key: 'migration_notion_old_data',
+      expectedConfigs: 0,
+    },
+  ])('$name', async ({ key, expectedConfigs }) => {
+    const report = await loadHealthReport({ [key]: { someField: 'x' } });
 
-    const report = await getStorageHealthReport();
-
-    expect(report.corruptedData).toContain('page_missing_highlights.com');
-    expect(report.pages).toBe(0);
-    expect(report.highlights).toBe(0);
-    expect(report.cleanupPlan.summary.corruptedRecords).toBe(1);
-  });
-
-  test('migration_* key 應計入 migrationKeys 並加入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        migration_old_data: { someField: 'x' },
-      })
-    );
-
-    const report = await getStorageHealthReport();
     expect(report.migrationKeys).toBe(1);
-    expect(report.cleanupPlan.summary.migrationLeftovers).toBe(1);
-  });
-
-  test('migration_notion_* key 應優先視為 migration leftover 而非 config', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        migration_notion_old_data: { someField: 'x' },
-      })
-    );
-
-    const report = await getStorageHealthReport();
-    expect(report.migrationKeys).toBe(1);
-    expect(report.configs).toBe(0);
+    if (expectedConfigs !== undefined) {
+      expect(report.configs).toBe(expectedConfigs);
+    }
     expect(report.cleanupPlan.summary.migrationLeftovers).toBe(1);
   });
 
   test('saved_* key 應計入 legacySavedKeys（不影響清理計劃）', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'saved_example.com': { notionPageId: 'p1' },
-      })
-    );
+    const report = await loadHealthReport({
+      'saved_example.com': { notionPageId: 'p1' },
+    });
 
-    const report = await getStorageHealthReport();
     expect(report.legacySavedKeys).toBe(1);
     // saved_* 為舊格式殘留，不直接進入清理計劃（由升級機制處理）
     expect(report.cleanupPlan.totalKeys).toBe(0);
   });
 
   test('孤兒 highlights_*（無對應頁面且無標注）應加入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'highlights_orphan.com': [],
-      })
-    );
+    const report = await loadHealthReport({
+      'highlights_orphan.com': [],
+    });
 
-    const report = await getStorageHealthReport();
     expect(report.cleanupPlan.summary.orphanRecords).toBeGreaterThan(0);
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_orphan.com')).toBe(true);
+    expect(hasCleanupItem(report, 'highlights_orphan.com')).toBe(true);
   });
 
   test('有 saved_* 對應的 object-format highlights_* 應計入使用量但不視為孤兒', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'highlights_saved.com': { highlights: [{ id: '1' }, { id: '2' }] },
-        'saved_saved.com': { notionPageId: 'p1' },
-      })
-    );
-
-    const report = await getStorageHealthReport();
+    const report = await loadHealthReport({
+      'highlights_saved.com': { highlights: [{ id: '1' }, { id: '2' }] },
+      'saved_saved.com': { notionPageId: 'p1' },
+    });
 
     expect(report.pages).toBe(1);
     expect(report.highlights).toBe(2);
     expect(report.legacySavedKeys).toBe(1);
     expect(report.cleanupPlan.summary.orphanRecords).toBe(0);
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_saved.com')).toBe(false);
+    expect(hasCleanupItem(report, 'highlights_saved.com')).toBe(false);
   });
 
   test('損壞的 highlights_* 不應增加 pages 或 highlights，但仍應進入清理計劃', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'highlights_bad.com': { highlights: 'not_an_array' },
-      })
-    );
-
-    const report = await getStorageHealthReport();
+    const report = await loadHealthReport({
+      'highlights_bad.com': { highlights: 'not_an_array' },
+    });
 
     expect(report.pages).toBe(0);
     expect(report.highlights).toBe(0);
     expect(report.corruptedData).toContain('highlights_bad.com');
     expect(report.cleanupPlan.summary.corruptedRecords).toBe(1);
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_bad.com')).toBe(true);
+    expect(hasCleanupItem(report, 'highlights_bad.com')).toBe(true);
   });
 
   test('無效的 url_alias:* 應加入清理計劃並計入 orphanRecords', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'url_alias:https://example.com/bad': '',
-      })
-    );
-
-    const report = await getStorageHealthReport();
+    const report = await loadHealthReport({
+      'url_alias:https://example.com/bad': '',
+    });
 
     expect(report.corruptedData).toEqual([]);
     expect(report.cleanupPlan.summary.corruptedRecords).toBe(0);
@@ -504,47 +469,36 @@ describe('getStorageHealthReport', () => {
   });
 
   test('損壞的 page_* 不應遮蔽同 URL 的合法 highlights_* 計數', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_stable.com': { notion: { pageId: 'p1' } },
-        'highlights_stable.com': [{ id: '1' }, { id: '2' }],
-      })
-    );
-
-    const report = await getStorageHealthReport();
+    const report = await loadHealthReport({
+      'page_stable.com': { notion: { pageId: 'p1' } },
+      'highlights_stable.com': [{ id: '1' }, { id: '2' }],
+    });
 
     expect(report.corruptedData).toContain('page_stable.com');
     expect(report.pages).toBe(1);
     expect(report.highlights).toBe(2);
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_stable.com')).toBe(false);
+    expect(hasCleanupItem(report, 'highlights_stable.com')).toBe(false);
   });
 
   test('損壞的 page_* 不應阻止空 highlights_* 被判定為孤兒', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_orphan.com': { notion: { pageId: 'p1' } },
-        'highlights_orphan.com': [],
-      })
-    );
-
-    const report = await getStorageHealthReport();
+    const report = await loadHealthReport({
+      'page_orphan.com': { notion: { pageId: 'p1' } },
+      'highlights_orphan.com': [],
+    });
 
     expect(report.corruptedData).toContain('page_orphan.com');
     expect(report.cleanupPlan.summary.orphanRecords).toBe(1);
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_orphan.com')).toBe(true);
+    expect(hasCleanupItem(report, 'highlights_orphan.com')).toBe(true);
   });
 
   test('有對應 page_* 的 highlights_* 不應計入孤兒', async () => {
-    mockGet.mockImplementation((k, cb) =>
-      cb({
-        'page_example.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
-        'highlights_example.com': [{ id: '2' }],
-      })
-    );
+    const report = await loadHealthReport({
+      'page_example.com': { notion: { pageId: 'p1' }, highlights: [{ id: '1' }] },
+      'highlights_example.com': [{ id: '2' }],
+    });
 
-    const report = await getStorageHealthReport();
     // highlights_example.com 有對應的 page_example.com，不應視為孤兒
-    expect(report.cleanupPlan.items.some(i => i.key === 'highlights_example.com')).toBe(false);
+    expect(hasCleanupItem(report, 'highlights_example.com')).toBe(false);
     // 計數去重：只計 page_example.com 的 1 個頁面 + 1 個標注
     expect(report.pages).toBe(1);
     expect(report.highlights).toBe(1);

--- a/tests/unit/options/storageDataUtils.test.js
+++ b/tests/unit/options/storageDataUtils.test.js
@@ -396,15 +396,12 @@ describe('getStorageHealthReport', () => {
     {
       name: 'migration_notion_* key 應優先視為 migration leftover 而非 config',
       key: 'migration_notion_old_data',
-      expectedConfigs: 0,
     },
-  ])('$name', async ({ key, expectedConfigs }) => {
+  ])('$name', async ({ key }) => {
     const report = await loadHealthReport({ [key]: { someField: 'x' } });
 
     expect(report.migrationKeys).toBe(1);
-    if (expectedConfigs !== undefined) {
-      expect(report.configs).toBe(expectedConfigs);
-    }
+    expect(report.configs).toBe(0);
     expect(report.cleanupPlan.summary.migrationLeftovers).toBe(1);
   });
 


### PR DESCRIPTION
### 摘要
重構測試以減少重複代碼，提升測試可讀性和維護性。

### 變更內容
- 整合內容索引測試案例，消除重複的測試邏輯。
- 將身份驗證相關的測試輔助函數移出測試套件，提升結構清晰度。
- 簡化存儲健康報告的測試案例，減少重複代碼。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

