### PR TITLE
test: expand native esm diagnostics coverage

### DIFF
--- a/jest.native-esm.config.cjs
+++ b/jest.native-esm.config.cjs
@@ -11,6 +11,8 @@ module.exports = {
   coverageReporters: ['json', 'text'],
   collectCoverageFrom: [
     '<rootDir>/scripts/background/utils/BlockBuilder.js',
+    '<rootDir>/scripts/background/utils/highlightStyleMerger.js',
+    '<rootDir>/scripts/background/utils/migrationMetadataUtils.js',
     '<rootDir>/scripts/config/messages/highlighterMessages.js',
     '<rootDir>/scripts/config/runtimeActions/highlighterActions.js',
     '<rootDir>/scripts/config/shared/content.js',
@@ -18,6 +20,9 @@ module.exports = {
     '<rootDir>/scripts/config/shared/saveStatus.js',
     '<rootDir>/scripts/config/shared/storage.js',
     '<rootDir>/scripts/highlighter/autoInit/initializationInputs.js',
+    '<rootDir>/scripts/highlighter/utils/color.js',
+    '<rootDir>/scripts/highlighter/utils/safeIcon.js',
+    '<rootDir>/scripts/highlighter/utils/validation.js',
   ],
   coverageThreshold: {
     global: {

--- a/jest.native-esm.config.cjs
+++ b/jest.native-esm.config.cjs
@@ -21,7 +21,11 @@ module.exports = {
     '<rootDir>/scripts/config/shared/storage.js',
     '<rootDir>/scripts/highlighter/autoInit/initializationInputs.js',
     '<rootDir>/scripts/highlighter/utils/color.js',
+    '<rootDir>/scripts/highlighter/utils/dom.js',
+    '<rootDir>/scripts/highlighter/utils/domStability.js',
+    '<rootDir>/scripts/highlighter/utils/path.js',
     '<rootDir>/scripts/highlighter/utils/safeIcon.js',
+    '<rootDir>/scripts/highlighter/utils/textSearch.js',
     '<rootDir>/scripts/highlighter/utils/validation.js',
   ],
   coverageThreshold: {

--- a/jest.native-esm.config.cjs
+++ b/jest.native-esm.config.cjs
@@ -27,6 +27,16 @@ module.exports = {
     '<rootDir>/scripts/highlighter/utils/safeIcon.js',
     '<rootDir>/scripts/highlighter/utils/textSearch.js',
     '<rootDir>/scripts/highlighter/utils/validation.js',
+    '<rootDir>/scripts/utils/image/imageAttributeSource.js',
+    '<rootDir>/scripts/utils/image/imageBackgroundSource.js',
+    '<rootDir>/scripts/utils/image/imageBlockMerge.js',
+    '<rootDir>/scripts/utils/image/imageNoscriptSource.js',
+    '<rootDir>/scripts/utils/image/imagePictureSource.js',
+    '<rootDir>/scripts/utils/image/imageUrl.js',
+    '<rootDir>/scripts/utils/image/srcsetCandidateParser.js',
+    '<rootDir>/scripts/utils/image/srcsetExtractor.js',
+    '<rootDir>/scripts/utils/image/srcsetParserAdapter.js',
+    '<rootDir>/scripts/utils/image/srcsetUrlValidator.js',
   ],
   coverageThreshold: {
     global: {

--- a/jest.native-esm.config.cjs
+++ b/jest.native-esm.config.cjs
@@ -11,6 +11,12 @@ module.exports = {
   coverageReporters: ['json', 'text'],
   collectCoverageFrom: [
     '<rootDir>/scripts/background/utils/BlockBuilder.js',
+    '<rootDir>/scripts/config/messages/highlighterMessages.js',
+    '<rootDir>/scripts/config/runtimeActions/highlighterActions.js',
+    '<rootDir>/scripts/config/shared/content.js',
+    '<rootDir>/scripts/config/shared/deepFreeze.js',
+    '<rootDir>/scripts/config/shared/saveStatus.js',
+    '<rootDir>/scripts/config/shared/storage.js',
     '<rootDir>/scripts/highlighter/autoInit/initializationInputs.js',
   ],
   coverageThreshold: {

--- a/scripts/utils/image/package.json
+++ b/scripts/utils/image/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/native-esm/background/utils/backgroundUtils.native-esm.test.mjs
+++ b/tests/native-esm/background/utils/backgroundUtils.native-esm.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  hasNotionData,
+  isSameNotionPage,
+} from '../../../../scripts/background/utils/migrationMetadataUtils.js';
+import {
+  HIGHLIGHT_STYLE_OPTIONS,
+  mergeHighlightsWithStyle,
+  resolveStyle,
+} from '../../../../scripts/background/utils/highlightStyleMerger.js';
+
+function makeRichText(content, annotations = {}) {
+  return { type: 'text', text: { content }, annotations };
+}
+
+function makeParagraphBlock(richTextArray) {
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: { rich_text: richTextArray },
+  };
+}
+
+describe('background utility native ESM diagnostics', () => {
+  test('mergeHighlightsWithStyle applies color across rich_text segment boundaries', () => {
+    const blocks = [
+      makeParagraphBlock([makeRichText('前文重'), makeRichText('要概'), makeRichText('念後文')]),
+    ];
+    const highlights = [{ id: 'hl-native', text: '重要概念', color: 'blue', rangeInfo: {} }];
+
+    const result = mergeHighlightsWithStyle(blocks, highlights, HIGHLIGHT_STYLE_OPTIONS.COLOR_SYNC);
+    const highlightedText = result[0].paragraph.rich_text
+      .filter((part) => part.annotations?.color === 'blue_background')
+      .map((part) => part.text.content)
+      .join('');
+
+    expect(highlightedText).toBe('重要概念');
+    expect(result[0].paragraph.rich_text.map((part) => part.text.content).join('')).toBe(
+      '前文重要概念後文'
+    );
+    expect(resolveStyle(HIGHLIGHT_STYLE_OPTIONS.COLOR_TEXT, { color: 'purple' })).toEqual({
+      color: 'yellow',
+    });
+  });
+
+  test('migration metadata helpers compare ids before canonicalized Notion urls', () => {
+    expect(hasNotionData({ notion: { pageId: ' nested-page ' } })).toBe(true);
+    expect(hasNotionData({ notion: { pageId: ' ', url: ' ' } })).toBe(false);
+
+    expect(
+      isSameNotionPage(
+        { notionPageId: 'same-id', notionUrl: 'https://notion.so/a' },
+        { notion: { pageId: 'same-id', url: 'https://notion.so/b' } }
+      )
+    ).toBe(true);
+    expect(
+      isSameNotionPage(
+        { notionUrl: 'https://NOTION.SO/%7Eworkspace/page?ref=abc#section' },
+        { notionUrl: 'https://notion.so/~workspace/page' }
+      )
+    ).toBe(true);
+    expect(
+      isSameNotionPage(
+        { notionUrl: 'https://notion.so/native-page///?ref=abc#section' },
+        { notionUrl: 'https://notion.so/native-page' }
+      )
+    ).toBe(true);
+    expect(isSameNotionPage({ title: 'a' }, { title: 'b' })).toBeNull();
+  });
+});

--- a/tests/native-esm/config/configConstants.native-esm.test.mjs
+++ b/tests/native-esm/config/configConstants.native-esm.test.mjs
@@ -85,39 +85,47 @@ describe('config native ESM diagnostics', () => {
   });
 
   test('save status helpers normalize state and preserve canonical fields', () => {
+    const hadLogger = Object.hasOwn(globalThis, 'Logger');
+    const originalLogger = globalThis.Logger;
     const warn = jest.fn();
     globalThis.Logger = { warn };
 
-    expect(isSavedStatusResponse({ deletionPending: true, wasDeleted: true })).toBe(true);
-    expect(isSavedStatusResponse({ wasDeleted: true })).toBe(false);
-    expect(isSavedStatusResponse({ statusKind: SAVE_STATUS_KINDS.SAVED })).toBe(true);
-    expect(isSavedStatusResponse({ isSaved: 1 })).toBe(true);
+    try {
+      expect(isSavedStatusResponse({ deletionPending: true, wasDeleted: true })).toBe(true);
+      expect(isSavedStatusResponse({ wasDeleted: true })).toBe(false);
+      expect(isSavedStatusResponse({ statusKind: SAVE_STATUS_KINDS.SAVED })).toBe(true);
+      expect(isSavedStatusResponse({ isSaved: 1 })).toBe(true);
 
-    const response = createSaveStatusResponse({
-      statusKind: 'unknown_kind',
-      stableUrl: 'https://example.com',
-      extra: { customFlag: 'preserved', statusKind: 'saved' },
-    });
-
-    expect(response).toEqual(
-      expect.objectContaining({
-        success: false,
-        statusKind: SAVE_STATUS_KINDS.ERROR,
-        isSaved: false,
-        canSave: false,
-        canSyncHighlights: false,
+      const response = createSaveStatusResponse({
+        statusKind: 'unknown_kind',
         stableUrl: 'https://example.com',
-        error: 'unknown_status_kind',
-        customFlag: 'preserved',
-      })
-    );
-    expect(warn).toHaveBeenCalledWith('unknown status kind', {
-      operation: 'createSaveStatusResponse',
-      reason: 'unknown_status_kind',
-      statusKind: 'unknown_kind',
-    });
+        extra: { customFlag: 'preserved', statusKind: 'saved' },
+      });
 
-    delete globalThis.Logger;
+      expect(response).toEqual(
+        expect.objectContaining({
+          success: false,
+          statusKind: SAVE_STATUS_KINDS.ERROR,
+          isSaved: false,
+          canSave: false,
+          canSyncHighlights: false,
+          stableUrl: 'https://example.com',
+          error: 'unknown_status_kind',
+          customFlag: 'preserved',
+        })
+      );
+      expect(warn).toHaveBeenCalledWith('unknown status kind', {
+        operation: 'createSaveStatusResponse',
+        reason: 'unknown_status_kind',
+        statusKind: 'unknown_kind',
+      });
+    } finally {
+      if (hadLogger) {
+        globalThis.Logger = originalLogger;
+      } else {
+        delete globalThis.Logger;
+      }
+    }
   });
 
   test('content extraction constants expose stable selector and limit cohorts', () => {

--- a/tests/native-esm/config/configConstants.native-esm.test.mjs
+++ b/tests/native-esm/config/configConstants.native-esm.test.mjs
@@ -1,0 +1,136 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { HIGHLIGHTER_MESSAGES } from '../../../scripts/config/messages/highlighterMessages.js';
+import { HIGHLIGHTER_ACTIONS } from '../../../scripts/config/runtimeActions/highlighterActions.js';
+import {
+  ARTICLE_SELECTORS,
+  CONTENT_QUALITY,
+  DOM_STABILITY,
+  FEATURED_IMAGE_SELECTORS,
+  IMAGE_LIMITS,
+  IMAGE_SRC_ATTRIBUTES,
+  IMAGE_VALIDATION_CONFIG,
+  NEXTJS_CONFIG,
+  TEXT_PROCESSING,
+} from '../../../scripts/config/shared/content.js';
+import { deepFreeze } from '../../../scripts/config/shared/deepFreeze.js';
+import {
+  createSaveStatusResponse,
+  isSavedStatusResponse,
+  SAVE_STATUS_KINDS,
+} from '../../../scripts/config/shared/saveStatus.js';
+import {
+  AUTH_LOCAL_KEYS,
+  HIGHLIGHTS_PREFIX,
+  mergeDataSourceConfig,
+  SAVED_PREFIX,
+  SYNC_CONFIG_KEYS,
+} from '../../../scripts/config/shared/storage.js';
+
+describe('config native ESM diagnostics', () => {
+  test('deepFreeze recursively freezes objects and function metadata', () => {
+    const formatter = () => 'ok';
+    formatter.meta = { label: 'format' };
+    const target = {
+      nested: { enabled: true },
+      formatter,
+    };
+
+    const frozen = deepFreeze(target);
+
+    expect(frozen).toBe(target);
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.nested)).toBe(true);
+    expect(Object.isFrozen(frozen.formatter)).toBe(true);
+    expect(Object.isFrozen(frozen.formatter.meta)).toBe(true);
+    expect(deepFreeze('copy')).toBe('copy');
+  });
+
+  test('highlighter messages remain frozen and keep function-valued builders', () => {
+    expect(Object.isFrozen(HIGHLIGHTER_MESSAGES)).toBe(true);
+    expect(Object.isFrozen(HIGHLIGHTER_MESSAGES.FLOATING_RAIL)).toBe(true);
+    expect(HIGHLIGHTER_MESSAGES.FLOATING_RAIL.SAVE_LABEL).toBe('保存網頁');
+    expect(HIGHLIGHTER_MESSAGES.TOOLBAR.COLOR_PICKER_TITLE('黃')).toBe('黃色標註');
+    expect(HIGHLIGHTER_MESSAGES.TOOLBAR.COLOR_PICKER_ARIA_LABEL('藍')).toBe('選擇藍色標註');
+  });
+
+  test('highlighter actions expose stable frozen runtime values', () => {
+    expect(Object.isFrozen(HIGHLIGHTER_ACTIONS)).toBe(true);
+    expect(HIGHLIGHTER_ACTIONS.SYNC_HIGHLIGHTS).toBe('syncHighlights');
+    expect(HIGHLIGHTER_ACTIONS.UPDATE_HIGHLIGHTS).toBe('UPDATE_HIGHLIGHTS');
+    expect(HIGHLIGHTER_ACTIONS.ACTIVATE_FLOATING_RAIL_HIGHLIGHT).toBe(
+      'ACTIVATE_FLOATING_RAIL_HIGHLIGHT'
+    );
+  });
+
+  test('storage keys and data source merge semantics stay stable', () => {
+    expect(SYNC_CONFIG_KEYS).toContain('floatingRailEnabled');
+    expect(AUTH_LOCAL_KEYS).toContain('notionOAuthToken');
+    expect(SAVED_PREFIX).toBe('saved_');
+    expect(HIGHLIGHTS_PREFIX).toBe('highlights_');
+
+    expect(
+      mergeDataSourceConfig(
+        { notionDataSourceId: 'local-id' },
+        {
+          notionDataSourceId: 'sync-id',
+          notionDatabaseId: 'sync-db',
+          notionDataSourceType: 'database',
+        }
+      )
+    ).toEqual({
+      notionDataSourceId: 'local-id',
+      notionDatabaseId: 'sync-db',
+      notionDataSourceType: 'database',
+    });
+  });
+
+  test('save status helpers normalize state and preserve canonical fields', () => {
+    const warn = jest.fn();
+    globalThis.Logger = { warn };
+
+    expect(isSavedStatusResponse({ deletionPending: true, wasDeleted: true })).toBe(true);
+    expect(isSavedStatusResponse({ wasDeleted: true })).toBe(false);
+    expect(isSavedStatusResponse({ statusKind: SAVE_STATUS_KINDS.SAVED })).toBe(true);
+    expect(isSavedStatusResponse({ isSaved: 1 })).toBe(true);
+
+    const response = createSaveStatusResponse({
+      statusKind: 'unknown_kind',
+      stableUrl: 'https://example.com',
+      extra: { customFlag: 'preserved', statusKind: 'saved' },
+    });
+
+    expect(response).toEqual(
+      expect.objectContaining({
+        success: false,
+        statusKind: SAVE_STATUS_KINDS.ERROR,
+        isSaved: false,
+        canSave: false,
+        canSyncHighlights: false,
+        stableUrl: 'https://example.com',
+        error: 'unknown_status_kind',
+        customFlag: 'preserved',
+      })
+    );
+    expect(warn).toHaveBeenCalledWith('unknown status kind', {
+      operation: 'createSaveStatusResponse',
+      reason: 'unknown_status_kind',
+      statusKind: 'unknown_kind',
+    });
+
+    delete globalThis.Logger;
+  });
+
+  test('content extraction constants expose stable selector and limit cohorts', () => {
+    expect(NEXTJS_CONFIG.MAX_JSON_SIZE).toBe(2 * 1024 * 1024);
+    expect(FEATURED_IMAGE_SELECTORS).toContain('article img:first-of-type');
+    expect(IMAGE_SRC_ATTRIBUTES).toEqual(
+      expect.arrayContaining(['src', 'data-src', 'data-lazy-src'])
+    );
+    expect(ARTICLE_SELECTORS).toContain('article');
+    expect(IMAGE_VALIDATION_CONFIG.SUPPORTED_PROTOCOLS).toContain('https:');
+    expect(IMAGE_LIMITS.MAX_MAIN_CONTENT_IMAGES).toBe(6);
+    expect(DOM_STABILITY.THRESHOLD_MS).toBe(150);
+    expect(CONTENT_QUALITY.DEFAULT_PAGE_TITLE).toBe('未命名頁面');
+    expect(TEXT_PROCESSING.MAX_RICH_TEXT_LENGTH).toBe(2000);
+  });
+});

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -5,6 +5,36 @@
     "rationale": "createRichText body lines must not be mapped to 0 by V8 source-line conversion."
   },
   {
+    "fileSuffix": "scripts/config/shared/deepFreeze.js",
+    "lines": [8, 16, 18, 22],
+    "rationale": "deepFreeze primitive, recursive object, and freeze-return paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/config/messages/highlighterMessages.js",
+    "lines": [27, 28],
+    "rationale": "function-valued highlighter message builders must retain source-line hits under native ESM."
+  },
+  {
+    "fileSuffix": "scripts/config/runtimeActions/highlighterActions.js",
+    "lines": [6, 15, 23],
+    "rationale": "highlighter runtime action registry must be covered through the formal config ESM boundary."
+  },
+  {
+    "fileSuffix": "scripts/config/shared/storage.js",
+    "lines": [68, 69, 70, 72, 73, 74],
+    "rationale": "mergeDataSourceConfig local-first and sync-fallback lines must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/config/shared/saveStatus.js",
+    "lines": [77, 81, 85, 89, 100, 113, 115, 119],
+    "rationale": "save status normalization, capability resolution, and response construction must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/config/shared/content.js",
+    "lines": [42, 72, 101, 386, 397, 408, 413, 436],
+    "rationale": "content extraction selector and limit registries must be covered through formal config source paths."
+  },
+  {
     "fileSuffix": "scripts/highlighter/autoInit/initializationInputs.js",
     "lines": [38, 39, 40, 41],
     "rationale": "mock-dependent native ESM branch must retain source-line hits."

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -5,6 +5,16 @@
     "rationale": "createRichText body lines must not be mapped to 0 by V8 source-line conversion."
   },
   {
+    "fileSuffix": "scripts/background/utils/highlightStyleMerger.js",
+    "lines": [121, 123, 124, 532, 537, 546, 609, 678, 680, 687],
+    "rationale": "highlight style merge must retain source-line hits across style resolution, rich_text splitting, and entrypoint mapping."
+  },
+  {
+    "fileSuffix": "scripts/background/utils/migrationMetadataUtils.js",
+    "lines": [8, 10, 12, 43, 49, 54, 56, 69, 76, 87, 91, 98, 100],
+    "rationale": "Notion metadata id extraction and canonical URL comparison must retain source-line hits."
+  },
+  {
     "fileSuffix": "scripts/config/shared/deepFreeze.js",
     "lines": [8, 16, 18, 22],
     "rationale": "deepFreeze primitive, recursive object, and freeze-return paths must retain source-line hits."
@@ -38,5 +48,20 @@
     "fileSuffix": "scripts/highlighter/autoInit/initializationInputs.js",
     "lines": [38, 39, 40, 41],
     "rationale": "mock-dependent native ESM branch must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/color.js",
+    "lines": [47, 48, 61, 72, 73],
+    "rationale": "color conversion and CSS variable helpers must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/validation.js",
+    "lines": [18, 19, 32, 53, 68, 81, 82, 86, 99, 111, 112, 116],
+    "rationale": "validation helper branches for strings, ranges, colors, URLs, ids, and highlight data must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/safeIcon.js",
+    "lines": [12, 17, 79, 80, 83, 88, 97, 101, 120, 122],
+    "rationale": "safeIcon sanitization, text fallback, namespace normalization, and DOM append paths must retain source-line hits."
   }
 ]

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -86,5 +86,58 @@
     "fileSuffix": "scripts/highlighter/utils/safeIcon.js",
     "lines": [12, 17, 79, 80, 83, 88, 97, 101, 120, 122],
     "rationale": "safeIcon sanitization, text fallback, namespace normalization, and DOM append paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imageUrl.js",
+    "lines": [
+      75, 77, 112, 116, 119, 129, 137, 190, 193, 205, 223, 226, 236, 238, 242, 255, 256, 270, 275,
+      375, 380, 381, 460, 465, 469, 484, 493, 502, 507, 518, 526
+    ],
+    "rationale": "image URL normalization, protocol rejection, validation guards, and pattern checks must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/srcsetCandidateParser.js",
+    "lines": [103, 107, 108, 112, 115, 119],
+    "rationale": "manual srcset candidate parsing and best-candidate selection must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/srcsetExtractor.js",
+    "lines": [17, 18, 22, 27, 28, 37, 42, 45, 46, 48, 60, 61],
+    "rationale": "srcset extraction fallback and DOM attribute paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/srcsetParserAdapter.js",
+    "lines": [26, 27, 28, 29, 33, 34],
+    "rationale": "SrcsetParser adapter missing-parser and parser-success paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/srcsetUrlValidator.js",
+    "lines": [29, 30, 34, 35, 38, 42],
+    "rationale": "srcset URL validation success and unsafe-protocol rejection paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imageAttributeSource.js",
+    "lines": [39, 40, 50, 51, 55, 56, 58, 61, 70, 75, 76, 77, 79, 91, 96, 101],
+    "rationale": "image attribute source extraction, srcset attributes, unsafe guards, and cache key generation must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imagePictureSource.js",
+    "lines": [14, 15, 20, 21, 27, 28, 30],
+    "rationale": "picture/source srcset extraction and validation paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imageNoscriptSource.js",
+    "lines": [9, 10, 12, 13, 16, 19, 32, 34, 35, 41, 47, 49],
+    "rationale": "noscript image regex extraction and safe protocol checks must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imageBackgroundSource.js",
+    "lines": [8, 9, 10, 21, 22, 26, 27, 47, 48, 49, 51, 55, 64, 66, 70, 72, 75, 77],
+    "rationale": "background-image computed-style extraction and parent fallback paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/utils/image/imageBlockMerge.js",
+    "lines": [28, 29, 32, 36, 39, 40, 50, 51, 55, 57, 58, 59, 61, 66],
+    "rationale": "image block merge duplicate filtering and non-image preservation paths must retain source-line hits."
   }
 ]

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -55,6 +55,29 @@
     "rationale": "color conversion and CSS variable helpers must retain source-line hits."
   },
   {
+    "fileSuffix": "scripts/highlighter/utils/dom.js",
+    "lines": [29, 30, 42, 47, 48, 52, 65, 66, 70, 71, 89, 90, 94],
+    "rationale": "DOM validation, visibility, viewport, and attribute fallback branches must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/path.js",
+    "lines": [59, 64, 67, 68, 73, 78, 90, 95, 108, 117, 120, 254, 257, 261, 265, 277, 289],
+    "rationale": "DOM path serialization, parsing, resolution, and invalid-path branches must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/domStability.js",
+    "lines": [34, 42, 52, 54, 68, 72, 95, 96, 115, 120, 144, 147, 153, 159],
+    "rationale": "DOM stability container lookup, timer scheduling, observer setup, and cleanup paths must retain source-line hits."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/utils/textSearch.js",
+    "lines": [
+      155, 158, 161, 169, 213, 218, 239, 240, 310, 313, 395, 400, 403, 409, 587, 589, 594, 715, 727,
+      730, 736, 747
+    ],
+    "rationale": "TreeWalker, cross-node, fuzzy whitespace, and findTextInPage fallback paths must retain source-line hits."
+  },
+  {
     "fileSuffix": "scripts/highlighter/utils/validation.js",
     "lines": [18, 19, 32, 53, 68, 81, 82, 86, 99, 111, 112, 116],
     "rationale": "validation helper branches for strings, ranges, colors, URLs, ids, and highlight data must retain source-line hits."

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -1,0 +1,12 @@
+[
+  {
+    "fileSuffix": "scripts/background/utils/BlockBuilder.js",
+    "lines": [54, 55, 56, 57],
+    "rationale": "createRichText body lines must not be mapped to 0 by V8 source-line conversion."
+  },
+  {
+    "fileSuffix": "scripts/highlighter/autoInit/initializationInputs.js",
+    "lines": [38, 39, 40, 41],
+    "rationale": "mock-dependent native ESM branch must retain source-line hits."
+  }
+]

--- a/tests/native-esm/highlighter/utils/domText.native-esm.test.mjs
+++ b/tests/native-esm/highlighter/utils/domText.native-esm.test.mjs
@@ -88,7 +88,7 @@ describe('DOM/text native ESM diagnostics', () => {
       maxWaitMs: 100,
       initialGracePeriodMs: 0,
     });
-    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(10);
     await expect(stable).resolves.toBe(true);
 
     await expect(waitForDOMStability({ containerSelector: '#missing' })).resolves.toBe(false);

--- a/tests/native-esm/highlighter/utils/domText.native-esm.test.mjs
+++ b/tests/native-esm/highlighter/utils/domText.native-esm.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import {
+  getAttribute,
+  getVisibleText,
+  isInViewport,
+  isValidElement,
+} from '../../../../scripts/highlighter/utils/dom.js';
+import { waitForDOMStability } from '../../../../scripts/highlighter/utils/domStability.js';
+import {
+  getNodeByPath,
+  getNodePath,
+  isValidPathString,
+  parsePathFromString,
+} from '../../../../scripts/highlighter/utils/path.js';
+import {
+  findTextFuzzy,
+  findTextInPage,
+  findTextWithTreeWalker,
+} from '../../../../scripts/highlighter/utils/textSearch.js';
+
+afterEach(() => {
+  jest.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+describe('DOM/text native ESM diagnostics', () => {
+  test('native ESM jsdom environment is available', () => {
+    document.body.innerHTML = '<main><p>Hello</p></main>';
+    expect(document.querySelector('p').textContent).toBe('Hello');
+  });
+
+  test('dom helpers validate elements, visible text, viewport, and attributes', () => {
+    document.body.innerHTML = `
+      <main>
+        <p id="visible" data-id="p1">Hello <span>World</span></p>
+        <p id="hidden" style="display: none">Hidden</p>
+      </main>
+    `;
+    const visible = document.querySelector('#visible');
+    const hidden = document.querySelector('#hidden');
+    visible.getBoundingClientRect = () => ({
+      top: 0,
+      left: 0,
+      bottom: 10,
+      right: 10,
+    });
+
+    expect(isValidElement(visible)).toBe(true);
+    expect(isValidElement(null)).toBe(false);
+    expect(getVisibleText(visible)).toBe('Hello World');
+    expect(getVisibleText(hidden)).toBe('');
+    expect(isInViewport(visible)).toBe(true);
+    expect(isInViewport(null)).toBe(false);
+    expect(getAttribute(visible, 'data-id')).toBe('p1');
+    expect(getAttribute(null, 'data-id', 'fallback')).toBe('fallback');
+  });
+
+  test('path helpers serialize text nodes, resolve paths, and reject invalid input', () => {
+    document.body.innerHTML = '<main><p>Alpha <span>Beta</span></p></main>';
+    const textNode = document.querySelector('span').firstChild;
+    const path = getNodePath(textNode);
+
+    expect(path).toBe('main[0]/p[0]/span[0]/text[0]');
+    expect(getNodeByPath(path)).toBe(textNode);
+    expect(getNodeByPath('main[0]/missing')).toBeNull();
+    expect(parsePathFromString(path)).toEqual([
+      { type: 'element', tag: 'main', index: 0 },
+      { type: 'element', tag: 'p', index: 0 },
+      { type: 'element', tag: 'span', index: 0 },
+      { type: 'text', index: 0 },
+    ]);
+    expect(parsePathFromString('main[0]/bad-step')).toBeNull();
+    expect(isValidPathString(path)).toBe(true);
+    expect(isValidPathString('main[0]/bad-step')).toBe(false);
+  });
+
+  test('domStability resolves true for stable containers and false for missing containers', async () => {
+    document.body.innerHTML = '<main id="root"><p>Stable</p></main>';
+    jest.useFakeTimers();
+
+    const stable = waitForDOMStability({
+      containerSelector: '#root',
+      stabilityThresholdMs: 10,
+      maxWaitMs: 100,
+      initialGracePeriodMs: 0,
+    });
+    await jest.advanceTimersByTimeAsync(0);
+    await expect(stable).resolves.toBe(true);
+
+    await expect(waitForDOMStability({ containerSelector: '#missing' })).resolves.toBe(false);
+  });
+
+  test('text search finds exact, cross-node, and fuzzy whitespace matches', () => {
+    document.body.innerHTML = `
+      <main>
+        <p>Alpha exact target.</p>
+        <p>split <span>cross</span> nodes</p>
+        <p>Fuzzy   spacing target</p>
+        <p>first target here</p>
+        <p>matching target chosen</p>
+      </main>
+    `;
+
+    expect(findTextWithTreeWalker('exact target').toString()).toBe('exact target');
+    expect(findTextWithTreeWalker('split cross nodes').toString().trim()).toBe('split cross nodes');
+    expect(findTextFuzzy('Fuzzy spacing target').toString()).toBe('Fuzzy   spacing target');
+    expect(findTextInPage('missing text')).toBeNull();
+    expect(findTextInPage('Fuzzy spacing target', { prefix: 'Alpha', suffix: '' }).toString()).toBe(
+      'Fuzzy   spacing target'
+    );
+    expect(findTextFuzzy('target', { prefix: 'matching ' }).toString()).toBe('target');
+  });
+});

--- a/tests/native-esm/highlighter/utils/pureUtils.native-esm.test.mjs
+++ b/tests/native-esm/highlighter/utils/pureUtils.native-esm.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+  convertBgColorToName,
+  COLORS,
+  getColorCSSVar,
+} from '../../../../scripts/highlighter/utils/color.js';
+import {
+  isCollapsedRange,
+  isNonEmptyString,
+  isValidColor,
+  isValidHighlightData,
+  isValidRange,
+  isValidUrl,
+} from '../../../../scripts/highlighter/utils/validation.js';
+
+await jest.unstable_mockModule('../../../../scripts/utils/Logger.js', () => ({
+  default: {
+    warn: jest.fn(),
+  },
+}));
+
+const { createSafeIcon, sanitizeSvgIcon } = await import(
+  '../../../../scripts/highlighter/utils/safeIcon.js'
+);
+
+describe('highlighter pure utility native ESM diagnostics', () => {
+  test('color helpers expose stable constants and conversion fallbacks', () => {
+    expect(COLORS.blue).toBe('#cce7ff');
+    expect(convertBgColorToName('rgb(255, 243, 205)')).toBe('yellow');
+    expect(convertBgColorToName('#f8d7da')).toBe('red');
+    expect(convertBgColorToName('unknown')).toBe('yellow');
+    expect(getColorCSSVar('green')).toBe('--highlight-green');
+  });
+
+  test('validation helpers cover url, range, color, and highlight data branches', () => {
+    const textNode = document.createTextNode('hello world');
+    document.body.append(textNode);
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5);
+
+    expect(isNonEmptyString(' value ')).toBe(true);
+    expect(isNonEmptyString('   ')).toBe(false);
+    expect(isValidRange(range)).toBe(true);
+    expect(isCollapsedRange(range)).toBe(false);
+    expect(isValidColor('yellow')).toBe(true);
+    expect(isValidColor('purple')).toBe(false);
+    expect(isValidUrl('https://example.com/path')).toBe(true);
+    expect(isValidUrl('not a url')).toBe(false);
+    expect(isValidHighlightData({ id: 'h1', text: 'text', color: 'yellow' })).toBe(true);
+    expect(isValidHighlightData({ id: 'bad', text: 'text', color: 'yellow' })).toBe(false);
+
+    textNode.remove();
+  });
+
+  test('safeIcon sanitizes SVG input and falls back to text spans', () => {
+    const sanitized = sanitizeSvgIcon(
+      '<svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M1" /></svg>'
+    );
+    expect(sanitized).toContain('<svg');
+    expect(sanitized).not.toContain('<script>');
+
+    const textIcon = createSafeIcon('Save');
+    expect(textIcon.tagName).toBe('SPAN');
+    expect(textIcon.textContent).toBe('Save');
+    expect(textIcon.querySelector('svg')).toBeNull();
+
+    const svgIcon = createSafeIcon('<svg viewBox="0 0 24 24"><path d="M1" /></svg>');
+    const svg = svgIcon.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg.classList.contains('icon-svg')).toBe(true);
+    expect(svg.getAttribute('xmlns')).toBe('http://www.w3.org/2000/svg');
+  });
+});

--- a/tests/native-esm/utils/image/imagePipeline.native-esm.test.mjs
+++ b/tests/native-esm/utils/image/imagePipeline.native-esm.test.mjs
@@ -13,9 +13,9 @@ await jest.unstable_mockModule('../../../../scripts/utils/Logger.js', () => ({
 
 await jest.unstable_mockModule('../../../../scripts/utils/LogSanitizer.js', () => ({
   LogSanitizer: {
-    _sanitizeString: (value) => String(value),
+    _sanitizeString: String,
   },
-  sanitizeUrlForLogging: (url) => String(url),
+  sanitizeUrlForLogging: String,
 }));
 
 const imageUrl = await import('../../../../scripts/utils/image/imageUrl.js');

--- a/tests/native-esm/utils/image/imagePipeline.native-esm.test.mjs
+++ b/tests/native-esm/utils/image/imagePipeline.native-esm.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../../../../scripts/utils/Logger.js', () => ({
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+await jest.unstable_mockModule('../../../../scripts/utils/LogSanitizer.js', () => ({
+  LogSanitizer: {
+    _sanitizeString: (value) => String(value),
+  },
+  sanitizeUrlForLogging: (url) => String(url),
+}));
+
+const imageUrl = await import('../../../../scripts/utils/image/imageUrl.js');
+const { parseBestCandidateSrcsetUrl } = await import(
+  '../../../../scripts/utils/image/srcsetCandidateParser.js'
+);
+const srcsetExtractor = await import('../../../../scripts/utils/image/srcsetExtractor.js');
+const { parseWithSrcsetParser } = await import(
+  '../../../../scripts/utils/image/srcsetParserAdapter.js'
+);
+const { validateSrcsetUrl } = await import('../../../../scripts/utils/image/srcsetUrlValidator.js');
+const attributeSource = await import('../../../../scripts/utils/image/imageAttributeSource.js');
+const { extractFromPicture } = await import('../../../../scripts/utils/image/imagePictureSource.js');
+const { extractFromNoscript } = await import('../../../../scripts/utils/image/imageNoscriptSource.js');
+const { extractFromBackgroundImage } = await import(
+  '../../../../scripts/utils/image/imageBackgroundSource.js'
+);
+const { mergeUniqueImages } = await import('../../../../scripts/utils/image/imageBlockMerge.js');
+
+function makeImageBlock(url) {
+  return {
+    type: 'image',
+    image: {
+      external: { url },
+    },
+  };
+}
+
+afterEach(() => {
+  delete globalThis.SrcsetParser;
+  document.body.innerHTML = '';
+});
+
+describe('image pipeline native ESM diagnostics', () => {
+  test('imageUrl normalizes valid URLs and rejects unsafe inputs', () => {
+    expect(imageUrl.cleanImageUrl('http://example.com/images/photo(1).jpg?x=1&x=2')).toBe(
+      'https://example.com/images/photo%281%29.jpg?x=1'
+    );
+    expect(imageUrl.cleanImageUrl('/images/photo.jpg')).toBe('/images/photo.jpg');
+    expect(imageUrl.isValidImageUrl('https://example.com/images/photo.jpg')).toBe(true);
+    expect(imageUrl.isValidImageUrl('javascript:alert(1)')).toBe(false);
+    expect(imageUrl.isValidCleanedImageUrl('/images/photo.jpg')).toBe(true);
+    expect(imageUrl.hasRejectedImageProtocol('blob:https://example.com/id')).toBe(true);
+  });
+
+  test('srcset helpers choose best candidates and validate safe protocols', () => {
+    expect(parseBestCandidateSrcsetUrl(['small.jpg 320w', 'large.jpg 1200w'])).toBe('large.jpg');
+    expect(srcsetExtractor.extractBestUrlFromSrcset('small.jpg 1x, retina.jpg 2x')).toBe(
+      'retina.jpg'
+    );
+    const srcsetImg = document.createElement('img');
+    srcsetImg.setAttribute(
+      'srcset',
+      'https://example.com/images/srcset-small.jpg 400w, https://example.com/images/srcset-large.jpg 1200w'
+    );
+    expect(srcsetExtractor.extractFromSrcset(srcsetImg)).toBe(
+      'https://example.com/images/srcset-large.jpg'
+    );
+    expect(srcsetExtractor.extractValidatedSrcsetUrl(srcsetImg)).toBe(
+      'https://example.com/images/srcset-large.jpg'
+    );
+
+    globalThis.SrcsetParser = {
+      parse: jest.fn(() => 'https://example.com/images/parser.jpg'),
+    };
+    expect(parseWithSrcsetParser('ignored.jpg 1x')).toBe('https://example.com/images/parser.jpg');
+    expect(validateSrcsetUrl('https://example.com/images/parser.jpg')).toBe(
+      'https://example.com/images/parser.jpg'
+    );
+    expect(validateSrcsetUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  test('attribute and picture extractors read stable DOM image sources', () => {
+    document.body.innerHTML = `
+      <picture>
+        <source srcset="https://example.com/images/small.jpg 400w, https://example.com/images/large.jpg 1200w">
+        <img id="picture-img" alt="">
+      </picture>
+      <img id="data-img" data-srcset="https://example.com/images/a.jpg 1x, https://example.com/images/b.jpg 2x" class="hero">
+    `;
+
+    const pictureImg = document.querySelector('#picture-img');
+    const dataImg = document.querySelector('#data-img');
+    const directImg = document.createElement('img');
+    directImg.setAttribute('src', 'https://example.com/images/direct.jpg');
+
+    expect(extractFromPicture(pictureImg)).toBe('https://example.com/images/large.jpg');
+    expect(attributeSource.extractFromAttributes(dataImg)).toBe('https://example.com/images/b.jpg');
+    expect(attributeSource.extractFromAttributes(directImg)).toBe(
+      'https://example.com/images/direct.jpg'
+    );
+    expect(attributeSource.generateImageCacheKey(dataImg)).toBe('||hero|data-img');
+  });
+
+  test('noscript and background extractors return safe image URLs', () => {
+    document.body.innerHTML = `
+      <div id="noscript-host"><img id="noscript-img"></div>
+      <div id="background-host"><img id="background-img"></div>
+      <div id="parent-background-host"><img id="parent-background-img"></div>
+    `;
+    const noscript = document.createElement('noscript');
+    noscript.textContent = '<img src="https://example.com/images/noscript.jpg">';
+    document.querySelector('#noscript-host').append(noscript);
+    document.querySelector('#background-img').style.backgroundImage =
+      'url("https://example.com/images/self-bg.jpg")';
+    document.querySelector('#background-host').style.backgroundImage =
+      'url("https://example.com/images/bg.jpg")';
+    document.querySelector('#parent-background-host').style.backgroundImage =
+      'url("https://example.com/images/parent-bg.jpg")';
+
+    expect(extractFromNoscript(document.querySelector('#noscript-img'))).toBe(
+      'https://example.com/images/noscript.jpg'
+    );
+    expect(extractFromBackgroundImage(document.querySelector('#background-img'))).toBe(
+      'https://example.com/images/self-bg.jpg'
+    );
+    expect(extractFromBackgroundImage(document.querySelector('#parent-background-img'))).toBe(
+      'https://example.com/images/parent-bg.jpg'
+    );
+  });
+
+  test('mergeUniqueImages removes duplicate image blocks and keeps non-image blocks', () => {
+    const existing = [makeImageBlock('https://example.com/images/existing.jpg')];
+    const textBlock = { type: 'paragraph', paragraph: { rich_text: [] } };
+    const merged = mergeUniqueImages(existing, [
+      makeImageBlock('https://example.com/images/existing.jpg'),
+      makeImageBlock('https://example.com/images/new.jpg'),
+      textBlock,
+    ]);
+
+    expect(merged).toEqual([makeImageBlock('https://example.com/images/new.jpg'), textBlock]);
+    expect(mergeUniqueImages(existing, [])).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/assert-native-esm-line-hits.test.js
+++ b/tests/unit/scripts/assert-native-esm-line-hits.test.js
@@ -90,6 +90,25 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
     expect(result.stdout).not.toContain('Native ESM 行命中檢查通過');
   });
 
+  test('[SECURITY] repo 內 manifest symlink 指向 repo 外檔案時應被拒絕', () => {
+    const externalTempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'native-esm-line-hits-'));
+    const externalManifestPath = path.join(externalTempRoot, 'coverage-line-hits.json');
+    const linkedManifestPath = path.join(tempRoot, 'linked-coverage-line-hits.json');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(externalManifestPath, JSON.stringify(createPassingManifest()), 'utf8');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.symlinkSync(externalManifestPath, linkedManifestPath);
+
+    const coveragePath = writeCoverageFile(createPassingCoverage());
+    const result = runCli(coveragePath, linkedManifestPath);
+
+    fs.rmSync(externalTempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('manifest 路徑必須位於 repo root 底下');
+    expect(result.stdout).not.toContain('Native ESM 行命中檢查通過');
+  });
+
   test('缺少必要 source coverage entry 時輸出繁中錯誤', () => {
     const coveragePath = writeCoverageFile({
       [path.join(projectRoot, 'scripts/background/utils/BlockBuilder.js')]: {

--- a/tests/unit/scripts/assert-native-esm-line-hits.test.js
+++ b/tests/unit/scripts/assert-native-esm-line-hits.test.js
@@ -35,8 +35,19 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
     },
   });
 
-  const runCli = coveragePath =>
-    spawnSync('node', [scriptPath, coveragePath], {
+  const createPassingManifest = () => [
+    {
+      fileSuffix: 'scripts/background/utils/BlockBuilder.js',
+      lines: [54, 55, 56, 57],
+    },
+    {
+      fileSuffix: 'scripts/highlighter/autoInit/initializationInputs.js',
+      lines: [38, 39, 40, 41],
+    },
+  ];
+
+  const runCli = (coveragePath, manifestPath) =>
+    spawnSync('node', [scriptPath, coveragePath, manifestPath].filter(Boolean), {
       cwd: projectRoot,
       encoding: 'utf8',
     });
@@ -46,6 +57,13 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     fs.writeFileSync(coveragePath, JSON.stringify(coverage), 'utf8');
     return coveragePath;
+  };
+
+  const writeManifestFile = manifest => {
+    const manifestPath = path.join(tempRoot, 'coverage-line-hits.json');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest), 'utf8');
+    return manifestPath;
   };
 
   beforeEach(() => {
@@ -84,8 +102,9 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
         s: { 0: 1 },
       },
     });
+    const manifestPath = writeManifestFile(createPassingManifest());
 
-    const result = runCli(coveragePath);
+    const result = runCli(coveragePath, manifestPath);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
@@ -97,8 +116,14 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
     const coverage = createPassingCoverage();
     coverage[path.join(projectRoot, 'scripts/background/utils/BlockBuilder.js')].s[0] = 0;
     const coveragePath = writeCoverageFile(coverage);
+    const manifestPath = writeManifestFile([
+      {
+        fileSuffix: 'scripts/background/utils/BlockBuilder.js',
+        lines: [54],
+      },
+    ]);
 
-    const result = runCli(coveragePath);
+    const result = runCli(coveragePath, manifestPath);
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
@@ -108,10 +133,53 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
 
   test('必要 line 都命中時輸出繁中成功訊息', () => {
     const coveragePath = writeCoverageFile(createPassingCoverage());
+    const manifestPath = writeManifestFile(createPassingManifest());
 
-    const result = runCli(coveragePath);
+    const result = runCli(coveragePath, manifestPath);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Native ESM 行命中檢查通過');
+    expect(result.stdout).toContain('Native ESM 行命中檢查通過：2 files, 8 lines');
+  });
+
+  test('[SECURITY] coverage entry 不可來自 copy-slice spike path', () => {
+    const coveragePath = writeCoverageFile({
+      [path.join(projectRoot, '.tmp/coverage-spike/scripts/background/utils/BlockBuilder.js')]: {
+        statementMap: {
+          0: {
+            start: { line: 54 },
+            end: { line: 57 },
+          },
+        },
+        s: { 0: 1 },
+      },
+    });
+    const manifestPath = writeManifestFile([
+      {
+        fileSuffix: 'scripts/background/utils/BlockBuilder.js',
+        lines: [54],
+      },
+    ]);
+
+    const result = runCli(coveragePath, manifestPath);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('coverage entry 不可來自 .tmp/coverage-spike');
+  });
+
+  test('[SECURITY] manifest fileSuffix 必須位於 native ESM allowlist', () => {
+    const coveragePath = writeCoverageFile(createPassingCoverage());
+    const manifestPath = writeManifestFile([
+      {
+        fileSuffix: 'scripts/utils/RetryManager.js',
+        lines: [1],
+      },
+    ]);
+
+    const result = runCli(coveragePath, manifestPath);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'manifest fileSuffix 不在 native ESM diagnostic allowlist: scripts/utils/RetryManager.js'
+    );
   });
 });

--- a/tests/unit/scripts/assert-native-esm-line-hits.test.js
+++ b/tests/unit/scripts/assert-native-esm-line-hits.test.js
@@ -138,7 +138,41 @@ describe('tools/assert-native-esm-line-hits.mjs', () => {
     const result = runCli(coveragePath, manifestPath);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Native ESM 行命中檢查通過：2 files, 8 lines');
+    expect(result.stdout).toContain('Native ESM 行命中檢查通過：2 個檔案, 8 行');
+  });
+
+  test('coverage lookup 必須精準匹配 manifest 指定檔案', () => {
+    const coveragePath = writeCoverageFile({
+      [path.join(projectRoot, 'fixtures/scripts/background/utils/BlockBuilder.js')]: {
+        statementMap: {
+          0: {
+            start: { line: 54 },
+            end: { line: 57 },
+          },
+        },
+        s: { 0: 0 },
+      },
+      [path.join(projectRoot, 'scripts/background/utils/BlockBuilder.js')]: {
+        statementMap: {
+          0: {
+            start: { line: 54 },
+            end: { line: 57 },
+          },
+        },
+        s: { 0: 1 },
+      },
+    });
+    const manifestPath = writeManifestFile([
+      {
+        fileSuffix: 'scripts/background/utils/BlockBuilder.js',
+        lines: [54],
+      },
+    ]);
+
+    const result = runCli(coveragePath, manifestPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Native ESM 行命中檢查通過：1 個檔案, 1 行');
   });
 
   test('[SECURITY] coverage entry 不可來自 copy-slice spike path', () => {

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -43,9 +43,13 @@ const absoluteManifestPath = path.resolve(projectRoot, manifestPath);
 assertPathInsideDirectory(
   absoluteCoveragePath,
   allowedCoverageRoot,
-  '覆蓋率檔案路徑必須位於 coverage/native-esm 底下',
+  '覆蓋率檔案路徑必須位於 coverage/native-esm 底下'
 );
-assertPathInsideDirectory(absoluteManifestPath, projectRoot, 'manifest 路徑必須位於 repo root 底下');
+assertPathInsideDirectory(
+  absoluteManifestPath,
+  projectRoot,
+  'manifest 路徑必須位於 repo root 底下'
+);
 const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
 const requiredHits = JSON.parse(fs.readFileSync(absoluteManifestPath, 'utf8'));
 
@@ -66,12 +70,12 @@ function assertFormalCoveragePath(filePath) {
   assertPathInsideDirectory(
     resolveCoverageKeyPath(filePath),
     projectRoot,
-    `coverage entry 必須位於 repo root 底下: ${filePath}`,
+    `coverage entry 必須位於 repo root 底下: ${filePath}`
   );
 }
 
 function assertAllowedSourceSuffix(fileSuffix) {
-  if (allowedSourcePrefixes.some((prefix) => fileSuffix.startsWith(prefix))) {
+  if (allowedSourcePrefixes.some(prefix => fileSuffix.startsWith(prefix))) {
     return;
   }
 
@@ -111,9 +115,15 @@ function assertValidRequirement(requirement) {
   assertRequirementLines(fileSuffix, requirement.lines);
 }
 
+function normalizeCoverageLookupPath(filePath) {
+  return normalizeToPosixPath(resolveCoverageKeyPath(filePath));
+}
+
 function findFileCoverage(fileSuffix) {
-  const normalizedSuffix = fileSuffix.split('/').join(path.sep);
-  const entry = Object.entries(coverage).find(([filePath]) => filePath.endsWith(normalizedSuffix));
+  const normalizedFilePath = normalizeCoverageLookupPath(fileSuffix.split('/').join(path.sep));
+  const entry = Object.entries(coverage).find(
+    ([filePath]) => normalizeCoverageLookupPath(filePath) === normalizedFilePath
+  );
   if (!entry) {
     throw new Error(`找不到 ${fileSuffix} 的覆蓋率資料`);
   }
@@ -136,6 +146,10 @@ const failures = [];
 const checkedFiles = new Set();
 let checkedLineCount = 0;
 
+for (const filePath of Object.keys(coverage)) {
+  assertFormalCoveragePath(filePath);
+}
+
 for (const requirement of requiredHits) {
   assertValidRequirement(requirement);
   const fileCoverage = findFileCoverage(requirement.fileSuffix);
@@ -155,4 +169,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`Native ESM 行命中檢查通過：${checkedFiles.size} files, ${checkedLineCount} lines`);
+console.log(`Native ESM 行命中檢查通過：${checkedFiles.size} 個檔案, ${checkedLineCount} 行`);

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -2,7 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const [, , coveragePath = 'coverage/native-esm/coverage-final.json'] = process.argv;
+const [
+  ,
+  ,
+  coveragePath = 'coverage/native-esm/coverage-final.json',
+  manifestPath = 'tests/native-esm/coverage-line-hits.json',
+] = process.argv;
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const allowedCoverageRoot = path.join(projectRoot, 'coverage', 'native-esm');
 
@@ -14,7 +19,7 @@ function isDescendantPath(relativePath) {
   return !path.isAbsolute(relativePath);
 }
 
-function assertPathInsideDirectory(filePath, directoryPath) {
+function assertPathInsideDirectory(filePath, directoryPath, message) {
   const relativePath = path.relative(directoryPath, filePath);
   if (relativePath === '') {
     return;
@@ -24,23 +29,34 @@ function assertPathInsideDirectory(filePath, directoryPath) {
     return;
   }
 
-  throw new Error('覆蓋率檔案路徑必須位於 coverage/native-esm 底下');
+  throw new Error(message);
 }
 
 const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
-assertPathInsideDirectory(absoluteCoveragePath, allowedCoverageRoot);
+const absoluteManifestPath = path.resolve(projectRoot, manifestPath);
+assertPathInsideDirectory(
+  absoluteCoveragePath,
+  allowedCoverageRoot,
+  '覆蓋率檔案路徑必須位於 coverage/native-esm 底下',
+);
+assertPathInsideDirectory(absoluteManifestPath, projectRoot, 'manifest 路徑必須位於 repo root 底下');
 const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+const requiredHits = JSON.parse(fs.readFileSync(absoluteManifestPath, 'utf8'));
 
-const requiredHits = [
-  {
-    fileSuffix: 'scripts/background/utils/BlockBuilder.js',
-    lines: [54, 55, 56, 57],
-  },
-  {
-    fileSuffix: 'scripts/highlighter/autoInit/initializationInputs.js',
-    lines: [38, 39, 40, 41],
-  },
-];
+function assertValidRequirement(requirement) {
+  if (!requirement || typeof requirement.fileSuffix !== 'string') {
+    throw new Error('manifest entry 必須包含 fileSuffix 字串');
+  }
+
+  if (!Array.isArray(requirement.lines) || requirement.lines.length === 0) {
+    throw new Error(`${requirement.fileSuffix} 必須包含至少一個 line number`);
+  }
+
+  const invalidLine = requirement.lines.find((line) => !Number.isInteger(line) || line <= 0);
+  if (invalidLine !== undefined) {
+    throw new Error(`${requirement.fileSuffix} 包含無效 line number: ${invalidLine}`);
+  }
+}
 
 function findFileCoverage(fileSuffix) {
   const normalizedSuffix = fileSuffix.split('/').join(path.sep);
@@ -65,6 +81,7 @@ function getLineHits(fileCoverage) {
 const failures = [];
 
 for (const requirement of requiredHits) {
+  assertValidRequirement(requirement);
   const fileCoverage = findFileCoverage(requirement.fileSuffix);
   const lineHits = getLineHits(fileCoverage);
   for (const line of requirement.lines) {

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -38,20 +38,28 @@ function assertPathInsideDirectory(filePath, directoryPath, message) {
   throw new Error(message);
 }
 
-const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
-const absoluteManifestPath = path.resolve(projectRoot, manifestPath);
-assertPathInsideDirectory(
-  absoluteCoveragePath,
+function resolveAllowedFilePath(filePath, directoryPath, message) {
+  const absolutePath = path.resolve(projectRoot, filePath);
+  assertPathInsideDirectory(absolutePath, directoryPath, message);
+
+  const canonicalPath = fs.realpathSync.native(absolutePath);
+  const canonicalDirectoryPath = fs.realpathSync.native(directoryPath);
+  assertPathInsideDirectory(canonicalPath, canonicalDirectoryPath, message);
+  return canonicalPath;
+}
+
+const validatedCoveragePath = resolveAllowedFilePath(
+  coveragePath,
   allowedCoverageRoot,
   '覆蓋率檔案路徑必須位於 coverage/native-esm 底下'
 );
-assertPathInsideDirectory(
-  absoluteManifestPath,
+const validatedManifestPath = resolveAllowedFilePath(
+  manifestPath,
   projectRoot,
   'manifest 路徑必須位於 repo root 底下'
 );
-const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
-const requiredHits = JSON.parse(fs.readFileSync(absoluteManifestPath, 'utf8'));
+const coverage = JSON.parse(fs.readFileSync(validatedCoveragePath, 'utf8'));
+const requiredHits = JSON.parse(fs.readFileSync(validatedManifestPath, 'utf8'));
 
 function normalizeToPosixPath(filePath) {
   return filePath.split(path.sep).join('/');

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -10,6 +10,12 @@ const [
 ] = process.argv;
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const allowedCoverageRoot = path.join(projectRoot, 'coverage', 'native-esm');
+const allowedSourcePrefixes = [
+  'scripts/config/',
+  'scripts/background/utils/',
+  'scripts/highlighter/',
+  'scripts/utils/image/',
+];
 
 function isDescendantPath(relativePath) {
   if (relativePath.startsWith('..')) {
@@ -43,10 +49,41 @@ assertPathInsideDirectory(absoluteManifestPath, projectRoot, 'manifest 路徑必
 const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
 const requiredHits = JSON.parse(fs.readFileSync(absoluteManifestPath, 'utf8'));
 
+function normalizeToPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function resolveCoverageKeyPath(filePath) {
+  return path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(projectRoot, filePath);
+}
+
+function assertFormalCoveragePath(filePath) {
+  const normalizedPath = normalizeToPosixPath(filePath);
+  if (normalizedPath.includes('/.tmp/coverage-spike/')) {
+    throw new Error(`coverage entry 不可來自 .tmp/coverage-spike: ${filePath}`);
+  }
+
+  assertPathInsideDirectory(
+    resolveCoverageKeyPath(filePath),
+    projectRoot,
+    `coverage entry 必須位於 repo root 底下: ${filePath}`,
+  );
+}
+
+function assertAllowedSourceSuffix(fileSuffix) {
+  if (allowedSourcePrefixes.some((prefix) => fileSuffix.startsWith(prefix))) {
+    return;
+  }
+
+  throw new Error(`manifest fileSuffix 不在 native ESM diagnostic allowlist: ${fileSuffix}`);
+}
+
 function assertValidRequirement(requirement) {
   if (!requirement || typeof requirement.fileSuffix !== 'string') {
     throw new Error('manifest entry 必須包含 fileSuffix 字串');
   }
+
+  assertAllowedSourceSuffix(requirement.fileSuffix);
 
   if (!Array.isArray(requirement.lines) || requirement.lines.length === 0) {
     throw new Error(`${requirement.fileSuffix} 必須包含至少一個 line number`);
@@ -64,6 +101,7 @@ function findFileCoverage(fileSuffix) {
   if (!entry) {
     throw new Error(`找不到 ${fileSuffix} 的覆蓋率資料`);
   }
+  assertFormalCoveragePath(entry[0]);
   return entry[1];
 }
 
@@ -79,12 +117,16 @@ function getLineHits(fileCoverage) {
 }
 
 const failures = [];
+const checkedFiles = new Set();
+let checkedLineCount = 0;
 
 for (const requirement of requiredHits) {
   assertValidRequirement(requirement);
   const fileCoverage = findFileCoverage(requirement.fileSuffix);
+  checkedFiles.add(requirement.fileSuffix);
   const lineHits = getLineHits(fileCoverage);
   for (const line of requirement.lines) {
+    checkedLineCount += 1;
     const count = lineHits.get(line) || 0;
     if (count <= 0) {
       failures.push(`${requirement.fileSuffix}:${line} 預期命中次數 > 0，實際為 ${count}`);
@@ -97,4 +139,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Native ESM 行命中檢查通過');
+console.log(`Native ESM 行命中檢查通過：${checkedFiles.size} files, ${checkedLineCount} lines`);

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -78,21 +78,37 @@ function assertAllowedSourceSuffix(fileSuffix) {
   throw new Error(`manifest fileSuffix 不在 native ESM diagnostic allowlist: ${fileSuffix}`);
 }
 
-function assertValidRequirement(requirement) {
+function assertRequirementFileSuffix(requirement) {
   if (!requirement || typeof requirement.fileSuffix !== 'string') {
     throw new Error('manifest entry 必須包含 fileSuffix 字串');
   }
 
   assertAllowedSourceSuffix(requirement.fileSuffix);
+  return requirement.fileSuffix;
+}
 
-  if (!Array.isArray(requirement.lines) || requirement.lines.length === 0) {
-    throw new Error(`${requirement.fileSuffix} 必須包含至少一個 line number`);
+function hasRequiredLineList(lines) {
+  return Array.isArray(lines) && lines.length > 0;
+}
+
+function isInvalidLineNumber(line) {
+  return !Number.isInteger(line) || line <= 0;
+}
+
+function assertRequirementLines(fileSuffix, lines) {
+  if (!hasRequiredLineList(lines)) {
+    throw new Error(`${fileSuffix} 必須包含至少一個 line number`);
   }
 
-  const invalidLine = requirement.lines.find((line) => !Number.isInteger(line) || line <= 0);
+  const invalidLine = lines.find(isInvalidLineNumber);
   if (invalidLine !== undefined) {
-    throw new Error(`${requirement.fileSuffix} 包含無效 line number: ${invalidLine}`);
+    throw new Error(`${fileSuffix} 包含無效 line number: ${invalidLine}`);
   }
+}
+
+function assertValidRequirement(requirement) {
+  const fileSuffix = assertRequirementFileSuffix(requirement);
+  assertRequirementLines(fileSuffix, requirement.lines);
 }
 
 function findFileCoverage(fileSuffix) {


### PR DESCRIPTION
### 摘要
擴展了原生 ESM 診斷的測試覆蓋範圍，增強了對各種工具和實用程序的測試。

### 變更內容
- 增加了對原生 ESM 配置的診斷測試。
- 增加了對背景實用程序的測試，包括合併高亮樣式和遷移元數據的幫助函數。
- 增加了高亮工具的測試，包括顏色和驗證幫助函數。
- 強化了原生 ESM 覆蓋合約檢查，確保測試的穩定性和準確性。
- 減少了診斷警告，提升了測試的可讀性。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

