### PR TITLE
fix(native esm): address sonar findings and refactor cli parsing

### DIFF
--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -30,18 +30,22 @@ function parseCliArgs(argv) {
   };
   const errors = [];
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
+  let skipNextArg = false;
+  for (const [index, arg] of argv.entries()) {
+    if (skipNextArg) {
+      skipNextArg = false;
+      continue;
+    }
     if (arg === '--summary-json') {
       const result = readFlagValue(argv, index, arg, errors);
       options.summaryJsonPath = result.value;
-      index = result.nextIndex;
+      skipNextArg = result.nextIndex > index;
       continue;
     }
     if (arg === '--summary-md') {
       const result = readFlagValue(argv, index, arg, errors);
       options.summaryMarkdownPath = result.value;
-      index = result.nextIndex;
+      skipNextArg = result.nextIndex > index;
       continue;
     }
 
@@ -49,7 +53,7 @@ function parseCliArgs(argv) {
   }
 
   if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
+    throw new Error(errors.join('\n') || 'CLI arguments are invalid');
   }
 
   return {
@@ -166,7 +170,7 @@ function assertValidRequirement(requirement) {
 
 function assertUniqueRequirements(requirements) {
   if (!Array.isArray(requirements)) {
-    throw new Error('manifest 必須是陣列');
+    throw new TypeError('manifest 必須是陣列');
   }
 
   const seen = new Set();
@@ -288,7 +292,7 @@ function formatGateName(gate) {
 }
 
 function escapeMarkdownTableCell(value) {
-  return String(value).replace(/\r?\n/g, ' ').replaceAll('|', '\\|');
+  return String(value).replace(/\r?\n/g, ' ').replaceAll('|', String.raw`\|`);
 }
 
 function renderMarkdownSummary(summary) {

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -34,25 +34,23 @@ function parseCliArgs(argv) {
   };
   const errors = [];
 
-  let skipNextArg = false;
-  for (const [index, arg] of argv.entries()) {
-    if (skipNextArg) {
-      skipNextArg = false;
-      continue;
-    }
+  let index = 0;
+  while (index < argv.length) {
+    const arg = argv[index];
     const optionName = summaryFlagOptionNames.get(arg);
     if (optionName) {
       const result = readFlagValue(argv, index, arg, errors);
       options[optionName] = result.value;
-      skipNextArg = result.nextIndex > index;
+      index = result.nextIndex + 1;
       continue;
     }
 
     positional.push(arg);
+    index += 1;
   }
 
   if (errors.length > 0) {
-    throw new Error(errors.join('\n') || 'CLI arguments are invalid');
+    throw new Error(errors.join('\n') || 'CLI 參數無效');
   }
 
   return {

--- a/tools/assert-native-esm-line-hits.mjs
+++ b/tools/assert-native-esm-line-hits.mjs
@@ -11,6 +11,10 @@ const allowedSourcePrefixes = [
   'scripts/highlighter/',
   'scripts/utils/image/',
 ];
+const summaryFlagOptionNames = new Map([
+  ['--summary-json', 'summaryJsonPath'],
+  ['--summary-md', 'summaryMarkdownPath'],
+]);
 
 function readFlagValue(argv, index, flagName, errors) {
   const nextArg = argv[index + 1];
@@ -36,15 +40,10 @@ function parseCliArgs(argv) {
       skipNextArg = false;
       continue;
     }
-    if (arg === '--summary-json') {
+    const optionName = summaryFlagOptionNames.get(arg);
+    if (optionName) {
       const result = readFlagValue(argv, index, arg, errors);
-      options.summaryJsonPath = result.value;
-      skipNextArg = result.nextIndex > index;
-      continue;
-    }
-    if (arg === '--summary-md') {
-      const result = readFlagValue(argv, index, arg, errors);
-      options.summaryMarkdownPath = result.value;
+      options[optionName] = result.value;
       skipNextArg = result.nextIndex > index;
       continue;
     }


### PR DESCRIPTION
### 摘要
修正原生 ESM 的 Sonar 發現並簡化 CLI 解析邏輯。

### 變更內容
- 修正 CLI 參數解析中的錯誤處理，確保錯誤信息更清晰。
- 簡化 CLI 參數的處理邏輯，使用映射來管理選項名稱。

### 測試方式
尚未測試

### 潛在風險
無顯著風險.

