### PR TITLE
refactor: reduce service complexity

### DIFF
--- a/rollup/background.config.mjs
+++ b/rollup/background.config.mjs
@@ -25,6 +25,7 @@ export default {
     json(),
     !isDev &&
       createTerserPlugin({
+        passes: 2,
         pureFuncs: ['console.debug', 'console.info'],
       }),
     createVisualizerPlugin('background-bundle', 'Background Bundle Analysis'),

--- a/scripts/background/services/ImageService.js
+++ b/scripts/background/services/ImageService.js
@@ -185,6 +185,21 @@ class ImageService {
     this.validator = validator;
   }
 
+  static _normalizeImageUrlInput(url) {
+    if (typeof url !== 'string') {
+      return null;
+    }
+
+    const trimmedUrl = url.trim();
+    return trimmedUrl || null;
+  }
+
+  static _hasSupportedImageSource(pathname) {
+    return (
+      IMAGE_EXTENSIONS.test(pathname) || IMAGE_PATH_PATTERNS.some(pattern => pattern.test(pathname))
+    );
+  }
+
   /**
    * 本地輕量級驗證器（回退方案）
    *
@@ -193,27 +208,22 @@ class ImageService {
    * @private
    */
   static _validateLocally(url) {
-    if (!url || typeof url !== 'string' || url.trim().length === 0) {
+    const trimmedUrl = ImageService._normalizeImageUrlInput(url);
+    if (!trimmedUrl) {
       return false;
     }
 
     try {
-      const urlObj = new URL(url);
+      const urlObj = new URL(trimmedUrl);
 
       // 驗證協議是 http 或 https
-      if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+      const isHttpUrl = urlObj.protocol === 'http:' || urlObj.protocol === 'https:';
+      if (!isHttpUrl) {
         return false;
       }
 
-      // 檢查常見圖片擴展名
       const pathname = urlObj.pathname.toLowerCase();
-      const hasImageExtension = IMAGE_EXTENSIONS.test(pathname);
-
-      // 檢查路徑是否包含圖片關鍵詞
-      const hasImageKeyword = IMAGE_PATH_PATTERNS.some(pattern => pattern.test(pathname));
-
-      // 至少滿足一個條件
-      return hasImageExtension || hasImageKeyword;
+      return ImageService._hasSupportedImageSource(pathname);
     } catch {
       return false;
     }
@@ -227,11 +237,7 @@ class ImageService {
    */
   isValidImageUrl(url) {
     // 輸入驗證
-    if (!url || typeof url !== 'string') {
-      return false;
-    }
-
-    const trimmedUrl = url.trim();
+    const trimmedUrl = ImageService._normalizeImageUrlInput(url);
     if (!trimmedUrl) {
       return false;
     }

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -41,11 +41,26 @@ async function activateFloatingRailInPage() {
   const startTime = Date.now();
 
   /* eslint-disable unicorn/consistent-function-scoping -- chrome.scripting.executeScript 序列化限制：func 無法捕獲外部閉包，必須內聯定義 */
+  const notReady = () => ({ initialized: false, highlightCount: 0 });
+
   function activateRail(rail) {
     rail.show?.();
     rail.activateHighlighting?.();
     const count = globalThis.HighlighterV2?.manager?.getCount() || 0;
     return { initialized: true, highlightCount: count };
+  }
+
+  async function waitForRailReady(remainingMs) {
+    const readyResult = await Promise.race([
+      globalThis.__NOTION_RAIL_READY__.catch(() => null),
+      delay(Math.max(0, remainingMs)).then(() => null),
+    ]);
+
+    if (readyResult?.success && readyResult.rail) {
+      return activateRail(readyResult.rail);
+    }
+
+    return notReady();
   }
 
   function delay(ms) {
@@ -60,20 +75,13 @@ async function activateFloatingRailInPage() {
     }
 
     if (globalThis.__NOTION_RAIL_READY__) {
-      const readyResult = await Promise.race([
-        globalThis.__NOTION_RAIL_READY__.catch(() => null),
-        delay(Math.max(0, timeout - (Date.now() - startTime))).then(() => null),
-      ]);
-      if (readyResult?.success && readyResult.rail) {
-        return activateRail(readyResult.rail);
-      }
-      return { initialized: false, highlightCount: 0 };
+      return waitForRailReady(timeout - (Date.now() - startTime));
     }
 
     await delay(interval);
   }
 
-  return { initialized: false, highlightCount: 0 };
+  return notReady();
 }
 
 /**

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -35,6 +35,27 @@ const ERROR_NOTION_TOKEN_PATTERN = /secret_[\dA-Za-z]+/g;
 const ERROR_SENSITIVE_ASSIGNMENT_PATTERN =
   /\b([\w.-]*(?:token|secret|password|credential|authorization|session|api[_-]?key)[\w.-]*)=(?:[^\s&"',)]+)/gi;
 
+const BLOCKED_INJECTION_HOSTS = [
+  { host: 'chrome.google.com', pathPrefix: '/webstore' },
+  { host: 'chromewebstore.google.com' },
+  { host: 'microsoftedge.microsoft.com', pathPrefix: '/addons' },
+  { host: 'addons.mozilla.org' },
+];
+const NOTION_DOMAINS = ['notion.so', 'notion.com', 'notion.site'];
+
+function isBlockedInjectionHost(urlObj) {
+  return BLOCKED_INJECTION_HOSTS.some(({ host, pathPrefix }) => {
+    if (urlObj.host !== host) {
+      return false;
+    }
+    return !pathPrefix || urlObj.pathname.startsWith(pathPrefix);
+  });
+}
+
+function isNotionInjectionHost(host) {
+  return NOTION_DOMAINS.some(domain => host === domain || host.endsWith(`.${domain}`));
+}
+
 async function activateFloatingRailInPage() {
   const timeout = 2000;
   const interval = 100;
@@ -43,11 +64,28 @@ async function activateFloatingRailInPage() {
   /* eslint-disable unicorn/consistent-function-scoping -- chrome.scripting.executeScript 序列化限制：func 無法捕獲外部閉包，必須內聯定義 */
   const notReady = () => ({ initialized: false, highlightCount: 0 });
 
+  function getRail() {
+    try {
+      return globalThis.HighlighterV2.rail;
+    } catch {
+      return null;
+    }
+  }
+
+  function getHighlightCount() {
+    try {
+      return globalThis.HighlighterV2.manager.getCount();
+    } catch {
+      return 0;
+    }
+  }
+
   function activateRail(rail) {
-    rail.show?.();
-    rail.activateHighlighting?.();
-    const count = globalThis.HighlighterV2?.manager?.getCount() || 0;
-    return { initialized: true, highlightCount: count };
+    const noop = () => {};
+    const { show = noop, activateHighlighting = noop } = rail;
+    show.call(rail);
+    activateHighlighting.call(rail);
+    return { initialized: true, highlightCount: getHighlightCount() };
   }
 
   async function waitForRailReady(remainingMs) {
@@ -70,8 +108,9 @@ async function activateFloatingRailInPage() {
   /* eslint-enable unicorn/consistent-function-scoping */
 
   while (Date.now() - startTime <= timeout) {
-    if (globalThis.HighlighterV2?.rail) {
-      return activateRail(globalThis.HighlighterV2.rail);
+    const rail = getRail();
+    if (rail) {
+      return activateRail(rail);
     }
 
     if (globalThis.__NOTION_RAIL_READY__) {
@@ -97,45 +136,11 @@ function isRestrictedInjectionUrl(url) {
   }
 
   try {
-    // 使用統一配置的受限協議列表
-    if (RESTRICTED_PROTOCOLS.some(protocol => url.startsWith(protocol))) {
-      return true;
-    }
-
-    // 檢查 Chrome Web Store
-    if (url.startsWith('https://chrome.google.com/webstore')) {
-      return true;
-    }
-
-    // 解析 URL 檢查特定域名
     const urlObj = new URL(url);
-
-    // 檢查受限域名列表
-    const blockedHosts = [
-      { host: 'chrome.google.com', pathPrefix: '/webstore' },
-      { host: 'chromewebstore.google.com' },
-      { host: 'microsoftedge.microsoft.com', pathPrefix: '/addons' },
-      { host: 'addons.mozilla.org' },
-    ];
-
-    const isBlockedHost = blockedHosts.some(({ host, pathPrefix }) => {
-      if (urlObj.host !== host) {
-        return false;
-      }
-      if (!pathPrefix) {
-        return true;
-      }
-      return urlObj.pathname.startsWith(pathPrefix);
-    });
-
-    if (isBlockedHost) {
-      return true;
-    }
-
-    // 不對 Notion 自身頁面注入腳本 (包含子域名如 custom.notion.site)
-    const notionDomains = ['notion.so', 'notion.com', 'notion.site'];
-    return notionDomains.some(
-      domain => urlObj.host === domain || urlObj.host.endsWith(`.${domain}`)
+    return (
+      RESTRICTED_PROTOCOLS.some(protocol => url.startsWith(protocol)) ||
+      isBlockedInjectionHost(urlObj) ||
+      isNotionInjectionHost(urlObj.host)
     );
   } catch (error) {
     const sanitizedErrorMsg = String(error.message).replaceAll(url, '[invalid-url]');

--- a/scripts/background/services/InjectionService.js
+++ b/scripts/background/services/InjectionService.js
@@ -45,15 +45,27 @@ const NOTION_DOMAINS = ['notion.so', 'notion.com', 'notion.site'];
 
 function isBlockedInjectionHost(urlObj) {
   return BLOCKED_INJECTION_HOSTS.some(({ host, pathPrefix }) => {
-    if (urlObj.host !== host) {
+    if (urlObj.hostname !== host) {
       return false;
     }
     return !pathPrefix || urlObj.pathname.startsWith(pathPrefix);
   });
 }
 
-function isNotionInjectionHost(host) {
-  return NOTION_DOMAINS.some(domain => host === domain || host.endsWith(`.${domain}`));
+function isNotionInjectionHost(hostname) {
+  const normalizedHostname = String(hostname || '').toLowerCase();
+  return NOTION_DOMAINS.some(
+    domain => normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
+  );
+}
+
+function hasRestrictedInjectionProtocol(urlObj) {
+  const canonicalProtocol = urlObj.protocol.toLowerCase();
+  const canonicalHref = urlObj.href.toLowerCase();
+  return RESTRICTED_PROTOCOLS.some(protocol => {
+    const normalizedProtocol = protocol.toLowerCase();
+    return canonicalProtocol === normalizedProtocol || canonicalHref.startsWith(normalizedProtocol);
+  });
 }
 
 async function activateFloatingRailInPage() {
@@ -89,13 +101,27 @@ async function activateFloatingRailInPage() {
   }
 
   async function waitForRailReady(remainingMs) {
+    if (remainingMs <= 0) {
+      return notReady();
+    }
+
+    const timeoutResult = { timedOut: true };
     const readyResult = await Promise.race([
-      globalThis.__NOTION_RAIL_READY__.catch(() => null),
-      delay(Math.max(0, remainingMs)).then(() => null),
+      globalThis.__NOTION_RAIL_READY__.catch(() => ({ rejected: true })),
+      delay(Math.max(0, Math.min(interval, remainingMs))).then(() => timeoutResult),
     ]);
 
-    if (readyResult?.success && readyResult.rail) {
-      return activateRail(readyResult.rail);
+    if (readyResult?.timedOut) {
+      return null;
+    }
+
+    if (readyResult?.success) {
+      const rail = readyResult.rail || getRail();
+      if (rail) {
+        return activateRail(rail);
+      }
+      await delay(Math.max(0, Math.min(interval, remainingMs)));
+      return null;
     }
 
     return notReady();
@@ -114,7 +140,11 @@ async function activateFloatingRailInPage() {
     }
 
     if (globalThis.__NOTION_RAIL_READY__) {
-      return waitForRailReady(timeout - (Date.now() - startTime));
+      const readyResult = await waitForRailReady(timeout - (Date.now() - startTime));
+      if (readyResult) {
+        return readyResult;
+      }
+      continue;
     }
 
     await delay(interval);
@@ -138,9 +168,9 @@ function isRestrictedInjectionUrl(url) {
   try {
     const urlObj = new URL(url);
     return (
-      RESTRICTED_PROTOCOLS.some(protocol => url.startsWith(protocol)) ||
+      hasRestrictedInjectionProtocol(urlObj) ||
       isBlockedInjectionHost(urlObj) ||
-      isNotionInjectionHost(urlObj.host)
+      isNotionInjectionHost(urlObj.hostname)
     );
   } catch (error) {
     const sanitizedErrorMsg = String(error.message).replaceAll(url, '[invalid-url]');

--- a/scripts/background/services/SaveStatusCoordinator.js
+++ b/scripts/background/services/SaveStatusCoordinator.js
@@ -31,6 +31,22 @@ function shouldUseCache({ forceRefresh, migratedFromOldKey, isCacheValid }) {
   return !forceRefresh && !migratedFromOldKey && isCacheValid;
 }
 
+function buildSavedStatus(stableUrl, savedData) {
+  return createSaveStatusResponse({
+    statusKind: SAVE_STATUS_KINDS.SAVED,
+    stableUrl,
+    savedData,
+  });
+}
+
+function buildUnverifiedSavedStatus(stableUrl, savedData) {
+  return createSaveStatusResponse({
+    statusKind: SAVE_STATUS_KINDS.UNVERIFIED_SAVED,
+    stableUrl,
+    savedData,
+  });
+}
+
 async function touchLastVerifiedIfNeeded(context, deps) {
   await deps.storageService.setSavedPageData(context.normUrl, {
     ...context.savedData,
@@ -54,11 +70,7 @@ async function handleDeletedRemoteStatus(context, deps, savedData) {
       });
     }
 
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.SAVED,
-      stableUrl: cleanupUrl,
-      savedData: latestSavedData,
-    });
+    return buildSavedStatus(cleanupUrl, latestSavedData);
   }
 
   if (!clearResult.cleared) {
@@ -75,6 +87,35 @@ async function handleDeletedRemoteStatus(context, deps, savedData) {
     statusKind: SAVE_STATUS_KINDS.DELETED_REMOTE,
     stableUrl: cleanupUrl,
   });
+}
+
+async function resolveVerifiedSaveStatus(context, deps, savedData) {
+  const { normUrl } = context;
+  const exists = await resolveExistsWithRetry(savedData, deps);
+
+  if (exists === null) {
+    return buildUnverifiedSavedStatus(normUrl, savedData);
+  }
+
+  const deletionCheck = deps.tabService.consumeDeletionConfirmation(savedData.notionPageId, exists);
+
+  if (exists === false && deletionCheck.shouldDelete) {
+    return handleDeletedRemoteStatus(context, deps, savedData);
+  }
+
+  if (exists === false && deletionCheck.deletionPending) {
+    return createSaveStatusResponse({
+      statusKind: SAVE_STATUS_KINDS.DELETION_PENDING,
+      stableUrl: normUrl,
+      savedData,
+    });
+  }
+
+  if (exists === true) {
+    await touchLastVerifiedIfNeeded(context, deps);
+  }
+
+  return buildSavedStatus(normUrl, savedData);
 }
 
 export async function resolveSaveStatus(context, rawDeps) {
@@ -107,53 +148,13 @@ export async function resolveSaveStatus(context, rawDeps) {
       isCacheValid,
     })
   ) {
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.SAVED,
-      stableUrl: normUrl,
-      savedData,
-    });
+    return buildSavedStatus(normUrl, savedData);
   }
 
   deps.activeToken = await deps.getActiveToken();
   if (!deps.activeToken?.token) {
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.UNVERIFIED_SAVED,
-      stableUrl: normUrl,
-      savedData,
-    });
+    return buildUnverifiedSavedStatus(normUrl, savedData);
   }
 
-  const exists = await resolveExistsWithRetry(savedData, deps);
-
-  if (exists === null) {
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.UNVERIFIED_SAVED,
-      stableUrl: normUrl,
-      savedData,
-    });
-  }
-
-  const deletionCheck = deps.tabService.consumeDeletionConfirmation(savedData.notionPageId, exists);
-
-  if (exists === false && deletionCheck.shouldDelete) {
-    return handleDeletedRemoteStatus(context, deps, savedData);
-  }
-
-  if (exists === false && deletionCheck.deletionPending) {
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.DELETION_PENDING,
-      stableUrl: normUrl,
-      savedData,
-    });
-  }
-
-  if (exists === true) {
-    await touchLastVerifiedIfNeeded(context, deps);
-  }
-
-  return createSaveStatusResponse({
-    statusKind: SAVE_STATUS_KINDS.SAVED,
-    stableUrl: normUrl,
-    savedData,
-  });
+  return resolveVerifiedSaveStatus(context, deps, savedData);
 }

--- a/scripts/background/services/SaveStatusCoordinator.js
+++ b/scripts/background/services/SaveStatusCoordinator.js
@@ -103,14 +103,6 @@ async function resolveVerifiedSaveStatus(context, deps, savedData) {
     return handleDeletedRemoteStatus(context, deps, savedData);
   }
 
-  if (exists === false && deletionCheck.deletionPending) {
-    return createSaveStatusResponse({
-      statusKind: SAVE_STATUS_KINDS.DELETION_PENDING,
-      stableUrl: normUrl,
-      savedData,
-    });
-  }
-
   if (exists === false) {
     return createSaveStatusResponse({
       statusKind: SAVE_STATUS_KINDS.DELETION_PENDING,
@@ -119,9 +111,7 @@ async function resolveVerifiedSaveStatus(context, deps, savedData) {
     });
   }
 
-  if (exists === true) {
-    await touchLastVerifiedIfNeeded(context, deps);
-  }
+  await touchLastVerifiedIfNeeded(context, deps);
 
   return buildSavedStatus(normUrl, savedData);
 }

--- a/scripts/background/services/SaveStatusCoordinator.js
+++ b/scripts/background/services/SaveStatusCoordinator.js
@@ -111,6 +111,14 @@ async function resolveVerifiedSaveStatus(context, deps, savedData) {
     });
   }
 
+  if (exists === false) {
+    return createSaveStatusResponse({
+      statusKind: SAVE_STATUS_KINDS.DELETION_PENDING,
+      stableUrl: normUrl,
+      savedData,
+    });
+  }
+
   if (exists === true) {
     await touchLastVerifiedIfNeeded(context, deps);
   }

--- a/scripts/background/services/StorageService.js
+++ b/scripts/background/services/StorageService.js
@@ -172,6 +172,39 @@ class StorageService {
     return { lockKey: contract.mutationTargetKey, aliasCandidate, contract };
   }
 
+  _buildPageStateKeys(normalizedUrl) {
+    return {
+      pageKey: `${PAGE_PREFIX}${normalizedUrl}`,
+      savedKey: `${SAVED_PREFIX}${normalizedUrl}`,
+      aliasKey: `${URL_ALIAS_PREFIX}${normalizedUrl}`,
+    };
+  }
+
+  _buildLegacyPageState(savedKey, savedData, resolvedUrl = null) {
+    return {
+      format: 'legacy',
+      savedKey,
+      savedData,
+      ...(resolvedUrl ? { resolvedUrl } : {}),
+    };
+  }
+
+  async _getAliasedPageState(stableUrl) {
+    const stablePageKey = `${PAGE_PREFIX}${stableUrl}`;
+    const stableSavedKey = `${SAVED_PREFIX}${stableUrl}`;
+    const result = (await this.storage.local.get([stablePageKey, stableSavedKey])) || {};
+
+    if (result[stablePageKey]) {
+      return { format: 'new', key: stablePageKey, data: result[stablePageKey] };
+    }
+
+    if (result[stableSavedKey]) {
+      return this._buildLegacyPageState(stableSavedKey, result[stableSavedKey], stableUrl);
+    }
+
+    return null;
+  }
+
   /**
    * 批量讀取頁面狀態（新舊格式統一入口）
    *
@@ -183,9 +216,7 @@ class StorageService {
    * @private
    */
   async _getPageState(normalizedUrl) {
-    const pageKey = `${PAGE_PREFIX}${normalizedUrl}`;
-    const savedKey = `${SAVED_PREFIX}${normalizedUrl}`;
-    const aliasKey = `${URL_ALIAS_PREFIX}${normalizedUrl}`;
+    const { pageKey, savedKey, aliasKey } = this._buildPageStateKeys(normalizedUrl);
 
     const result = (await this.storage.local.get([pageKey, savedKey, aliasKey])) || {};
 
@@ -197,26 +228,13 @@ class StorageService {
     // 有 alias → 嘗試查詢 stable URL 的 page_*
     const stableUrl = result[aliasKey];
     if (stableUrl) {
-      const stablePageKey = `${PAGE_PREFIX}${stableUrl}`;
-      const stableSavedKey = `${SAVED_PREFIX}${stableUrl}`;
-      const r2 = (await this.storage.local.get([stablePageKey, stableSavedKey])) || {};
-      if (r2[stablePageKey]) {
-        return { format: 'new', key: stablePageKey, data: r2[stablePageKey] };
-      }
-      if (r2[stableSavedKey]) {
-        // 使用 stableUrl（而非 normalizedUrl）觸發升級，確保寫入正確的 key
-        return {
-          format: 'legacy',
-          savedKey: stableSavedKey,
-          savedData: r2[stableSavedKey],
-          resolvedUrl: stableUrl,
-        };
-      }
+      // 使用 stableUrl（而非 normalizedUrl）觸發升級，確保寫入正確的 key
+      return this._getAliasedPageState(stableUrl);
     }
 
     // 舊格式（saved_*）
     if (result[savedKey]) {
-      return { format: 'legacy', savedKey, savedData: result[savedKey] };
+      return this._buildLegacyPageState(savedKey, result[savedKey]);
     }
 
     return null;
@@ -653,26 +671,16 @@ class StorageService {
   _buildHighlightsUpdate(canonicalCurrent, migrationSource, highlights, normalizedUrl) {
     const now = Date.now();
     if (canonicalCurrent) {
-      return {
-        ...canonicalCurrent,
-        highlights,
-        metadata: {
-          ...canonicalCurrent.metadata,
-          lastUpdated: now,
-        },
-      };
+      return this._buildExistingHighlightsPage(canonicalCurrent, highlights, now);
     }
 
     if (migrationSource?.key?.startsWith(PAGE_PREFIX)) {
-      return {
-        ...migrationSource.value,
+      return this._buildExistingHighlightsPage(
+        migrationSource.value,
         highlights,
-        metadata: {
-          ...migrationSource.value.metadata,
-          lastUpdated: now,
-          migratedFrom: migrationSource.key,
-        },
-      };
+        now,
+        migrationSource.key
+      );
     }
 
     return this._buildPageObject(
@@ -681,6 +689,18 @@ class StorageService {
       normalizedUrl,
       migrationSource?.key || undefined
     );
+  }
+
+  _buildExistingHighlightsPage(pageData, highlights, now, migratedFrom = null) {
+    return {
+      ...pageData,
+      highlights,
+      metadata: {
+        ...pageData.metadata,
+        lastUpdated: now,
+        ...(migratedFrom ? { migratedFrom } : {}),
+      },
+    };
   }
 
   /**
@@ -741,19 +761,7 @@ class StorageService {
     const existing = this._pruneExpiredUpgradeFailure(url, now);
     const attempts = (existing?.attempts || 0) + 1;
     const firstFailureAt = existing?.firstFailureAt || now;
-    const reachedMaxAttempts = attempts >= UPGRADE_RETRY_MAX_ATTEMPTS;
-
-    let nextRetryAt;
-    if (reachedMaxAttempts) {
-      nextRetryAt = firstFailureAt + UPGRADE_RETRY_TTL_MS;
-    } else {
-      const delay = Math.min(
-        UPGRADE_RETRY_MAX_DELAY_MS,
-        UPGRADE_RETRY_BASE_DELAY_MS * Math.pow(2, attempts - 1)
-      );
-      const jitterDelay = Math.floor(delay * (0.5 + Math.random() * 0.5)); // eslint-disable-line sonarjs/pseudo-random
-      nextRetryAt = now + jitterDelay;
-    }
+    const nextRetryAt = this._resolveUpgradeNextRetryAt({ attempts, firstFailureAt, now });
 
     const state = {
       attempts,
@@ -763,6 +771,19 @@ class StorageService {
     };
     this._failedUpgradeAttempts.set(url, state);
     return state;
+  }
+
+  _resolveUpgradeNextRetryAt({ attempts, firstFailureAt, now }) {
+    if (attempts >= UPGRADE_RETRY_MAX_ATTEMPTS) {
+      return firstFailureAt + UPGRADE_RETRY_TTL_MS;
+    }
+
+    const delay = Math.min(
+      UPGRADE_RETRY_MAX_DELAY_MS,
+      UPGRADE_RETRY_BASE_DELAY_MS * Math.pow(2, attempts - 1)
+    );
+    const jitterDelay = Math.floor(delay * (0.5 + Math.random() * 0.5)); // eslint-disable-line sonarjs/pseudo-random
+    return now + jitterDelay;
   }
 
   /**
@@ -1301,8 +1322,8 @@ class StorageService {
       return null;
     }
 
-    const shortExpected = expectedPageId ? expectedPageId.slice(0, 4) : 'none';
-    const shortFound = state.data?.notion?.pageId?.slice(0, 4) || 'unknown';
+    const shortExpected = this._formatShortPageId(expectedPageId, 'none');
+    const shortFound = this._formatShortPageId(state.data?.notion?.pageId, 'unknown');
 
     this.logger.warn?.('[StorageService] clearNotionState skipped: pageId mismatch', {
       expectedPageId: shortExpected,
@@ -1311,6 +1332,10 @@ class StorageService {
     });
 
     return { skipped: true, reason: 'pageId_mismatch' };
+  }
+
+  _formatShortPageId(pageId, fallback) {
+    return pageId ? pageId.slice(0, 4) : fallback;
   }
 
   /**

--- a/scripts/background/services/TabService.js
+++ b/scripts/background/services/TabService.js
@@ -1268,6 +1268,14 @@ function _migrationScript(trackingParams) {
   };
 
   // 內部輔助函數：遍歷 localStorage 尋找後備的 key
+  const parseOrigin = raw => {
+    try {
+      return new URL(raw).origin;
+    } catch {
+      return null;
+    }
+  };
+
   const findLegacyHighlightFallbackKey = currentOrigin => {
     let legacyCandidate = null;
     for (let i = 0; i < localStorage.length; i++) {
@@ -1277,21 +1285,13 @@ function _migrationScript(trackingParams) {
       }
 
       const keyUrl = k.replace('highlights_', '');
-      if (!currentOrigin) {
-        if (!legacyCandidate) {
-          legacyCandidate = k;
-        }
-        continue;
+      const keyOrigin = parseOrigin(keyUrl);
+      if (currentOrigin && keyOrigin === currentOrigin) {
+        return k;
       }
 
-      try {
-        if (new URL(keyUrl).origin === currentOrigin) {
-          return k;
-        }
-      } catch {
-        if (!legacyCandidate) {
-          legacyCandidate = k;
-        }
+      if (!currentOrigin || !keyOrigin) {
+        legacyCandidate ||= k;
       }
     }
     return legacyCandidate;

--- a/scripts/background/services/TabService.js
+++ b/scripts/background/services/TabService.js
@@ -209,6 +209,29 @@ function hasMigratedHighlightData(result) {
   return result.data.length > 0;
 }
 
+const TAB_SERVICE_DEPENDENCY_DEFAULTS = Object.freeze({
+  logger: Logger,
+  injectionService: undefined,
+  normalizeUrl: identityUrl,
+  computeStableUrl: null,
+  getSavedPageData: resolveNull,
+  isRestrictedUrl: returnFalse,
+  isRecoverableError: returnFalse,
+  onNoHighlightsFound: null,
+  checkPageExists: resolveNull,
+  getApiKey: resolveNull,
+  clearPageState: resolveVoid,
+  clearNotionState: resolveVoid,
+  setSavedPageData: resolveVoid,
+});
+
+function resolveTabServiceDependencies(options) {
+  return {
+    ...TAB_SERVICE_DEPENDENCY_DEFAULTS,
+    ...options,
+  };
+}
+
 /**
  * TabService 類
  */
@@ -229,37 +252,39 @@ class TabService {
    *   - highlightsKey: 標註存儲鍵名（格式: "highlights_{normUrl}"）
    */
   constructor(options = {}) {
+    const deps = resolveTabServiceDependencies(options);
+
     // === 核心依賴 ===
-    this.logger = options.logger ?? Logger;
-    this.injectionService = options.injectionService;
+    this.logger = deps.logger;
+    this.injectionService = deps.injectionService;
 
     // === URL 處理 ===
-    this.normalizeUrl = options.normalizeUrl ?? identityUrl;
-    this.computeStableUrl = options.computeStableUrl ?? null;
+    this.normalizeUrl = deps.normalizeUrl;
+    this.computeStableUrl = deps.computeStableUrl;
 
     // === 存儲查詢 ===
-    this.getSavedPageData = options.getSavedPageData ?? resolveNull;
+    this.getSavedPageData = deps.getSavedPageData;
 
     // === 安全檢查 ===
-    this.isRestrictedUrl = options.isRestrictedUrl ?? returnFalse;
-    this.isRecoverableError = options.isRecoverableError ?? returnFalse;
+    this.isRestrictedUrl = deps.isRestrictedUrl;
+    this.isRecoverableError = deps.isRecoverableError;
 
     // === 回調與狀態 ===
     // 無標註時觸發（可用於遷移或其他邏輯）
-    this.onNoHighlightsFound = options.onNoHighlightsFound ?? null;
+    this.onNoHighlightsFound = deps.onNoHighlightsFound;
     // 追蹤每個 tabId 的待處理監聽器，防止重複註冊
     this.pendingListeners = new Map();
     // 追蹤正在處理中的 tab，防止並發調用
     this.processingTabs = new Map();
 
     // === 頁面驗證邏輯 (_verifyAndUpdateStatus 使用) ===
-    this.checkPageExists = options.checkPageExists ?? resolveNull;
-    this.getApiKey = options.getApiKey ?? resolveNull;
-    this.clearPageState = options.clearPageState ?? resolveVoid;
-    this.clearNotionState = options.clearNotionState ?? resolveVoid;
+    this.checkPageExists = deps.checkPageExists;
+    this.getApiKey = deps.getApiKey;
+    this.clearPageState = deps.clearPageState;
+    this.clearNotionState = deps.clearNotionState;
     this.clearNotionStateWithRetry =
-      options.clearNotionStateWithRetry ?? createDefaultClearNotionStateWithRetry(this);
-    this.setSavedPageData = options.setSavedPageData ?? resolveVoid;
+      deps.clearNotionStateWithRetry ?? createDefaultClearNotionStateWithRetry(this);
+    this.setSavedPageData = deps.setSavedPageData;
 
     // 連續不存在保護：短時間窗內連續兩次 false 才清理。
     // Map metadata 讓暫時性 false negative 過期後重新視為第一次失敗。
@@ -1197,7 +1222,14 @@ class TabService {
 function _migrationScript(trackingParams) {
   /* eslint-disable unicorn/consistent-function-scoping */
   // 檢測開發環境
-  const isDev = chrome?.runtime?.getManifest?.()?.version_name?.includes('dev');
+  const getIsDev = () => {
+    try {
+      return chrome.runtime.getManifest().version_name.includes('dev');
+    } catch {
+      return false;
+    }
+  };
+  const isDev = getIsDev();
 
   // 內部輔助函數：結構化日誌
   const log = (level, msg, detail) => {
@@ -1244,10 +1276,16 @@ function _migrationScript(trackingParams) {
         continue;
       }
 
+      const keyUrl = k.replace('highlights_', '');
+      if (!currentOrigin) {
+        if (!legacyCandidate) {
+          legacyCandidate = k;
+        }
+        continue;
+      }
+
       try {
-        const keyUrl = k.replace('highlights_', '');
-        const parsedUrlOrigin = new URL(keyUrl).origin;
-        if (currentOrigin && parsedUrlOrigin === currentOrigin) {
+        if (new URL(keyUrl).origin === currentOrigin) {
           return k;
         }
       } catch {

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -109,6 +109,24 @@ describe('InjectionService', () => {
       expect(isRestrictedInjectionUrl('https://chromewebstore.google.com/detail/xyz')).toBe(true);
     });
 
+    it('should restrict blocked hosts even when URL includes ports or case variants', () => {
+      expect(isRestrictedInjectionUrl('HTTPS://chrome.google.com:443/webstore/detail/xyz')).toBe(
+        true
+      );
+      expect(isRestrictedInjectionUrl('https://chromewebstore.google.com:8443/detail/xyz')).toBe(
+        true
+      );
+    });
+
+    it('should restrict Notion hosts even when URL includes ports or case variants', () => {
+      expect(isRestrictedInjectionUrl('HTTPS://www.notion.so:443/workspace')).toBe(true);
+      expect(isRestrictedInjectionUrl('https://team.notion.site:8443/page')).toBe(true);
+    });
+
+    it('should restrict protocols after URL canonicalization', () => {
+      expect(isRestrictedInjectionUrl('CHROME://extensions')).toBe(true);
+    });
+
     it('should return false for normal urls', () => {
       expect(isRestrictedInjectionUrl('https://example.com')).toBe(false);
     });
@@ -295,6 +313,77 @@ describe('InjectionService', () => {
         initialized: false,
         highlightCount: 0,
       });
+    });
+
+    it('[REGRESSION] rail readiness timeout 時應回退為未初始化狀態', async () => {
+      jest.useFakeTimers();
+      try {
+        globalThis.__NOTION_RAIL_READY__ = new Promise(() => {});
+
+        chrome.scripting.executeScript.mockImplementation(async (opts, verifyResult) => {
+          if (opts.files) {
+            verifyResult([]);
+            return;
+          }
+
+          const injectedFunc = recreateInjectedFunction(opts.func);
+          const resultPromise = injectedFunc();
+          await jest.advanceTimersByTimeAsync(2000);
+          const result = await resultPromise;
+          verifyResult([{ result }]);
+        });
+
+        await expect(service.injectHighlighter(1)).resolves.toEqual({
+          initialized: false,
+          highlightCount: 0,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('[REGRESSION] rail ready 前應持續輪詢直到 activateRail', async () => {
+      jest.useFakeTimers();
+      try {
+        globalThis.HighlighterV2 = {
+          manager: { getCount: jest.fn(() => 7) },
+        };
+        const railShow = jest.fn();
+        const activateHighlighting = jest.fn();
+        let resolveRailReady = null;
+        globalThis.__NOTION_RAIL_READY__ = new Promise(resolve => {
+          resolveRailReady = resolve;
+        });
+
+        chrome.scripting.executeScript.mockImplementation(async (opts, verifyResult) => {
+          if (opts.files) {
+            verifyResult([]);
+            return;
+          }
+
+          const injectedFunc = recreateInjectedFunction(opts.func);
+          const resultPromise = injectedFunc();
+          resolveRailReady({ success: true });
+          await Promise.resolve();
+          await jest.advanceTimersByTimeAsync(100);
+          globalThis.HighlighterV2.rail = {
+            show: railShow,
+            activateHighlighting,
+          };
+          await jest.advanceTimersByTimeAsync(100);
+          const result = await resultPromise;
+          verifyResult([{ result }]);
+        });
+
+        await expect(service.injectHighlighter(1)).resolves.toEqual({
+          initialized: true,
+          highlightCount: 7,
+        });
+        expect(railShow).toHaveBeenCalledTimes(1);
+        expect(activateHighlighting).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -338,6 +338,8 @@ describe('InjectionService', () => {
           highlightCount: 0,
         });
       } finally {
+        delete globalThis.__NOTION_RAIL_READY__;
+        delete globalThis.HighlighterV2;
         jest.useRealTimers();
       }
     });
@@ -382,6 +384,8 @@ describe('InjectionService', () => {
         expect(railShow).toHaveBeenCalledTimes(1);
         expect(activateHighlighting).toHaveBeenCalledTimes(1);
       } finally {
+        delete globalThis.__NOTION_RAIL_READY__;
+        delete globalThis.HighlighterV2;
         jest.useRealTimers();
       }
     });

--- a/tests/unit/background/services/InjectionService.test.js
+++ b/tests/unit/background/services/InjectionService.test.js
@@ -622,6 +622,50 @@ describe('InjectionService', () => {
         expect.any(Function)
       );
     });
+
+    it('應在 Bundle 注入遇可恢復錯誤時返回 false', async () => {
+      chrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        chrome.runtime.lastError = undefined;
+        callback({ status: 'preloader_only' });
+      });
+      chrome.scripting.executeScript.mockImplementation((opts, callback) => {
+        chrome.runtime.lastError = { message: 'Cannot access contents of page' };
+        callback();
+      });
+
+      await expect(service.ensureBundleInjected(1)).resolves.toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Bundle injection skipped'),
+        expect.objectContaining({
+          action: 'ensureBundleInjected',
+          result: 'skipped',
+          error: expect.stringContaining('Cannot access contents of page'),
+        })
+      );
+    });
+
+    it('應在 Bundle 注入遇不可恢復錯誤時記錄並向外拋出', async () => {
+      chrome.tabs.sendMessage.mockImplementation((tabId, message, callback) => {
+        chrome.runtime.lastError = undefined;
+        callback({ status: 'preloader_only' });
+      });
+      chrome.scripting.executeScript.mockImplementation((opts, callback) => {
+        chrome.runtime.lastError = { message: 'SyntaxError: unexpected token' };
+        callback();
+      });
+
+      await expect(service.ensureBundleInjected(1)).rejects.toThrow(
+        'SyntaxError: unexpected token'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Bundle injection failed'),
+        expect.objectContaining({
+          action: 'ensureBundleInjected',
+          result: 'failure',
+          error: expect.stringContaining('SyntaxError: unexpected token'),
+        })
+      );
+    });
   });
 
   describe('Edge Case Utilities', () => {
@@ -654,6 +698,10 @@ describe('InjectionService', () => {
         expect(msg).toContain('Runtime Error');
         expect(Logger.warn).toHaveBeenCalled();
       });
+
+      it('應將無 message 的 runtime error 序列化', () => {
+        expect(getRuntimeErrorMessage({ code: 'NO_MESSAGE' })).toBe('{"code":"NO_MESSAGE"}');
+      });
     });
   });
 
@@ -676,6 +724,11 @@ describe('InjectionService', () => {
       chrome.scripting.executeScript.mockImplementation((opts, cb) => cb());
       const result = await service.injectWithResponse(1, null, ['test.js']);
       expect(result).toEqual([{ result: { success: true } }]);
+    });
+
+    it('沒有 function 與 files 時應返回 null', async () => {
+      await expect(service.injectWithResponse(1, null, [])).resolves.toBeNull();
+      expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
     });
 
     it('應該在拋出異常時記錄脫敏後的錯誤並返回 null', async () => {
@@ -777,12 +830,54 @@ describe('InjectionService', () => {
       expect(activateHighlighting).toHaveBeenCalledWith();
     });
 
+    it('activateFloatingRailInPage 應直接啟動現有 rail 並回傳 highlight count', async () => {
+      const railShow = jest.fn();
+      const activateHighlighting = jest.fn();
+      globalThis.HighlighterV2 = {
+        rail: { show: railShow, activateHighlighting },
+        manager: { getCount: () => 5 },
+      };
+      chrome.scripting.executeScript.mockImplementation(async (opts, verifyResult) => {
+        if (opts.files) {
+          verifyResult([]);
+          return;
+        }
+        verifyResult([{ result: await opts.func() }]);
+      });
+
+      await expect(service.injectHighlighter(1)).resolves.toEqual({
+        initialized: true,
+        highlightCount: 5,
+      });
+      expect(railShow).toHaveBeenCalledTimes(1);
+      expect(activateHighlighting).toHaveBeenCalledTimes(1);
+    });
+
     it('collectHighlights 應該觸發無文件的注射並回傳陣列', async () => {
       chrome.scripting.executeScript.mockImplementation((opts, cb) => {
         cb([{ result: ['highlight1'] }]);
       });
       const result = await service.collectHighlights(1);
       expect(result).toEqual(['highlight1']);
+    });
+
+    it('collectHighlights 應執行頁面 callback 並回傳空陣列 fallback', async () => {
+      chrome.scripting.executeScript.mockImplementation(async (opts, cb) => {
+        cb([{ result: await opts.func() }]);
+      });
+
+      await expect(service.collectHighlights(1)).resolves.toEqual([]);
+    });
+
+    it('collectHighlights 應呼叫頁面 collectHighlights callback', async () => {
+      const collectHighlights = jest.fn(() => ['highlight-from-page']);
+      globalThis.collectHighlights = collectHighlights;
+      chrome.scripting.executeScript.mockImplementation(async (opts, cb) => {
+        cb([{ result: await opts.func() }]);
+      });
+
+      await expect(service.collectHighlights(1)).resolves.toEqual(['highlight-from-page']);
+      expect(collectHighlights).toHaveBeenCalledTimes(1);
     });
 
     it('clearPageHighlights 應該觸發無文件的注射', async () => {
@@ -797,6 +892,17 @@ describe('InjectionService', () => {
         }),
         expect.any(Function)
       );
+    });
+
+    it('clearPageHighlights 應呼叫頁面 clearPageHighlights callback', async () => {
+      const clearPageHighlights = jest.fn();
+      globalThis.clearPageHighlights = clearPageHighlights;
+      chrome.scripting.executeScript.mockImplementation(async (opts, cb) => {
+        cb([{ result: await opts.func() }]);
+      });
+
+      await expect(service.clearPageHighlights(1)).resolves.toBe(false);
+      expect(clearPageHighlights).toHaveBeenCalledTimes(1);
     });
 
     it('injectHighlightRestore 應該注入特定的腳本', async () => {

--- a/tests/unit/background/services/SaveStatusCoordinator.test.js
+++ b/tests/unit/background/services/SaveStatusCoordinator.test.js
@@ -138,6 +138,47 @@ describe('SaveStatusCoordinator', () => {
     );
   });
 
+  test('exists 為 false 且 deletion 未解決時不應回傳 saved', async () => {
+    context.forceRefresh = true;
+    deps.notionService.checkPageExists.mockResolvedValue(false);
+    deps.tabService.consumeDeletionConfirmation.mockReturnValue({
+      shouldDelete: false,
+      deletionPending: false,
+    });
+
+    const result = await resolveSaveStatus(context, deps);
+
+    expect(result.statusKind).toBe('deletion_pending');
+    expect(result.deletionPending).toBe(true);
+    expect(result.isSaved).toBe(true);
+    expect(result).not.toEqual(expect.objectContaining({ statusKind: 'saved' }));
+  });
+
+  test('exists 為 true 時應更新 lastVerifiedAt 並回傳 saved', async () => {
+    context.forceRefresh = true;
+    deps.notionService.checkPageExists.mockResolvedValue(true);
+    deps.tabService.consumeDeletionConfirmation.mockReturnValue({
+      shouldDelete: false,
+      deletionPending: false,
+    });
+
+    const result = await resolveSaveStatus(context, deps);
+
+    expect(deps.storageService.setSavedPageData).toHaveBeenCalledWith(
+      'https://example.com/article',
+      expect.objectContaining({ lastVerifiedAt: deps.now })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        statusKind: 'saved',
+        isSaved: true,
+        canSave: false,
+        canSyncHighlights: true,
+      })
+    );
+  });
+
   test('第二次命中遠端不存在且清理成功時應回傳 deleted_remote', async () => {
     context.forceRefresh = true;
     deps.notionService.checkPageExists.mockResolvedValue(false);


### PR DESCRIPTION
### 摘要
重構服務以減少複雜性，提升可維護性和可讀性。

### 變更內容
- 將重複的 URL 驗證邏輯提取到 `_normalizeImageUrlInput` 和 `_hasSupportedImageSource` 方法中。
- 簡化 `isValidImageUrl` 方法的邏輯，使用提取的方法進行驗證。
- 引入 `buildSavedStatus` 和 `buildUnverifiedSavedStatus` 函數以簡化狀態回應的生成。
- 重構 `TabService` 的依賴注入邏輯，使用 `resolveTabServiceDependencies` 函數來管理默認依賴。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

