### PR TITLE
test(native-esm): add scope parity diagnostic

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Native ESM 覆蓋率正確性診斷
         run: npm run test:coverage:native-esm:assert
 
-      - name: Native ESM official scope parity report
+      - name: Native ESM 官方範圍一致性報告
         if: always()
         run: npm run test:coverage:native-esm:scope-parity
 
@@ -135,7 +135,7 @@ jobs:
           if [ -f coverage/native-esm/scope-parity-summary.md ]; then
             cat coverage/native-esm/scope-parity-summary.md >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "未產生 native ESM scope parity 摘要。" >> "$GITHUB_STEP_SUMMARY"
+            echo "未產生 native ESM 範圍一致性摘要。" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: 上傳 native ESM 診斷 artifact

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -121,6 +121,7 @@ jobs:
         run: npm run test:coverage:native-esm:assert
 
       - name: Native ESM official scope parity report
+        if: always()
         run: npm run test:coverage:native-esm:scope-parity
 
       - name: 發佈 native ESM 診斷摘要

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Native ESM 覆蓋率正確性診斷
         run: npm run test:coverage:native-esm:assert
 
+      - name: Native ESM official scope parity report
+        run: npm run test:coverage:native-esm:scope-parity
+
       - name: 發佈 native ESM 診斷摘要
         if: always()
         run: |
@@ -127,6 +130,11 @@ jobs:
             cat coverage/native-esm/line-hit-summary.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "未產生 native ESM 診斷摘要。" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f coverage/native-esm/scope-parity-summary.md ]; then
+            cat coverage/native-esm/scope-parity-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "未產生 native ESM scope parity 摘要。" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: 上傳 native ESM 診斷 artifact
@@ -137,6 +145,8 @@ jobs:
           path: |
             coverage/native-esm/line-hit-summary.json
             coverage/native-esm/line-hit-summary.md
+            coverage/native-esm/scope-parity-summary.json
+            coverage/native-esm/scope-parity-summary.md
           retention-days: 14
           if-no-files-found: warn
 

--- a/jest.native-esm.config.cjs
+++ b/jest.native-esm.config.cjs
@@ -37,6 +37,7 @@ module.exports = {
     '<rootDir>/scripts/utils/image/srcsetExtractor.js',
     '<rootDir>/scripts/utils/image/srcsetParserAdapter.js',
     '<rootDir>/scripts/utils/image/srcsetUrlValidator.js',
+    '<rootDir>/pages/update-notification/update-notification.js',
   ],
   coverageThreshold: {
     global: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "jest --config jest.config.js --coverage",
     "test:coverage:native-esm": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.native-esm.config.cjs --coverage --runInBand",
     "test:coverage:native-esm:assert": "npm run test:coverage:native-esm && node tools/assert-native-esm-line-hits.mjs --summary-json coverage/native-esm/line-hit-summary.json --summary-md coverage/native-esm/line-hit-summary.md",
+    "test:coverage:native-esm:scope-parity": "node tools/report-native-esm-scope-parity.mjs --summary-json coverage/native-esm/scope-parity-summary.json --summary-md coverage/native-esm/scope-parity-summary.md",
     "test:quick": "jest --config jest.config.js --onlyChanged",
     "test:ci": "jest --config jest.config.js --ci --coverage --coverageReporters=text --coverageReporters=lcov --maxWorkers=2",
     "test:ci:diagnostic": "jest --config jest.config.js --ci --coverage --coverageReporters=text --coverageReporters=lcov --maxWorkers=2 --detectOpenHandles",

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -53,6 +53,11 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     fs.writeFileSync(testNativeCoveragePath, content, 'utf8');
   };
 
+  const expectNoSummaryFiles = outputRoot => {
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+  };
+
   beforeEach(() => {
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(allowedOutputRoot, { recursive: true, force: true });
@@ -305,8 +310,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('找不到 native ESM 覆蓋率檔案');
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+    expectNoSummaryFiles(outputRoot);
   });
 
   test.each([
@@ -331,8 +335,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('native ESM 覆蓋率檔案必須是 JSON object');
     expect(result.stderr).not.toContain('TypeError');
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+    expectNoSummaryFiles(outputRoot);
   });
 
   test('native coverage JSON 語法錯誤時 CLI 應輸出繁體中文錯誤', () => {
@@ -347,8 +350,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     expect(result.stderr).toContain(testNativeCoverageRelativePath);
     expect(result.stderr).toContain('原始錯誤：');
     expect(result.stderr).not.toContain('Unexpected end of JSON input');
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+    expectNoSummaryFiles(outputRoot);
   });
 
   test('native coverage entry 缺少 statement map 時 CLI 應拒絕 malformed schema', () => {
@@ -367,8 +369,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
       'native ESM coverage entry 的 statement hit map 必須是 JSON object'
     );
     expect(result.stderr).toContain('scripts/config/shared/storage.js');
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
-    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+    expectNoSummaryFiles(outputRoot);
   });
 
   test('CLI 成功訊息使用繁體中文摘要', () => {

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -19,9 +19,11 @@ const writeFile = (rootDir, relativePath, content = '') => {
 };
 
 const shouldRestoreNativeCoverageBackup = (nativeCoveragePath, nativeCoverageBackupPath) => {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   if (fs.existsSync(nativeCoveragePath)) {
     return false;
   }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   return fs.existsSync(nativeCoverageBackupPath);
 };
 
@@ -33,9 +35,11 @@ const shouldRemoveTestCreatedNativeCoverage = (
   if (!removeNativeCoverageAfterTest) {
     return false;
   }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   if (!fs.existsSync(nativeCoveragePath)) {
     return false;
   }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   return !fs.existsSync(nativeCoverageBackupPath);
 };
 

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -2,8 +2,8 @@
  * @jest-environment node
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const createDirectory = directoryPath => {
   // eslint-disable-next-line security/detect-non-literal-fs-filename

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -18,6 +18,27 @@ const writeFile = (rootDir, relativePath, content = '') => {
   fs.writeFileSync(filePath, content, 'utf8');
 };
 
+const shouldRestoreNativeCoverageBackup = (nativeCoveragePath, nativeCoverageBackupPath) => {
+  if (fs.existsSync(nativeCoveragePath)) {
+    return false;
+  }
+  return fs.existsSync(nativeCoverageBackupPath);
+};
+
+const shouldRemoveTestCreatedNativeCoverage = (
+  nativeCoveragePath,
+  nativeCoverageBackupPath,
+  removeNativeCoverageAfterTest
+) => {
+  if (!removeNativeCoverageAfterTest) {
+    return false;
+  }
+  if (!fs.existsSync(nativeCoveragePath)) {
+    return false;
+  }
+  return !fs.existsSync(nativeCoverageBackupPath);
+};
+
 describe('tools/report-native-esm-scope-parity.mjs', () => {
   const projectRoot = path.resolve(__dirname, '../../..');
   const tempRoot = path.join(projectRoot, '.tmp/test-scope-parity');
@@ -61,13 +82,15 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
   });
 
   afterEach(() => {
-    if (!fs.existsSync(nativeCoveragePath) && fs.existsSync(nativeCoverageBackupPath)) {
+    if (shouldRestoreNativeCoverageBackup(nativeCoveragePath, nativeCoverageBackupPath)) {
       fs.renameSync(nativeCoverageBackupPath, nativeCoveragePath);
     }
     if (
-      removeNativeCoverageAfterTest &&
-      fs.existsSync(nativeCoveragePath) &&
-      !fs.existsSync(nativeCoverageBackupPath)
+      shouldRemoveTestCreatedNativeCoverage(
+        nativeCoveragePath,
+        nativeCoverageBackupPath,
+        removeNativeCoverageAfterTest
+      )
     ) {
       fs.rmSync(nativeCoveragePath, { force: true });
     }

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -18,39 +18,15 @@ const writeFile = (rootDir, relativePath, content = '') => {
   fs.writeFileSync(filePath, content, 'utf8');
 };
 
-const shouldRestoreNativeCoverageBackup = (nativeCoveragePath, nativeCoverageBackupPath) => {
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  return fs.existsSync(nativeCoverageBackupPath);
-};
-
-const shouldRemoveTestCreatedNativeCoverage = (
-  nativeCoveragePath,
-  nativeCoverageBackupPath,
-  removeNativeCoverageAfterTest
-) => {
-  if (!removeNativeCoverageAfterTest) {
-    return false;
-  }
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  if (!fs.existsSync(nativeCoveragePath)) {
-    return false;
-  }
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  return !fs.existsSync(nativeCoverageBackupPath);
-};
-
 describe('tools/report-native-esm-scope-parity.mjs', () => {
   const projectRoot = path.resolve(__dirname, '../../..');
   const tempRoot = path.join(projectRoot, '.tmp/test-scope-parity');
   const cliPath = path.join(projectRoot, 'tools/report-native-esm-scope-parity.mjs');
-  const nativeCoveragePath = path.join(projectRoot, 'coverage/native-esm/coverage-final.json');
-  const nativeCoverageBackupPath = path.join(
-    projectRoot,
-    'coverage/native-esm/coverage-final.json.scope-parity-test-bak'
-  );
+  const testNativeCoverageRelativePath =
+    '.tmp/test-scope-parity/native-coverage/coverage-final.json';
+  const testNativeCoveragePath = path.join(projectRoot, testNativeCoverageRelativePath);
   const allowedOutputRoot = path.join(projectRoot, 'coverage/native-esm/test-scope-parity-output');
   let reporter;
-  let removeNativeCoverageAfterTest;
 
   const loadReporter = () => {
     reporter = require('../../../tools/report-native-esm-scope-parity-core.cjs');
@@ -64,6 +40,8 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
 
   const runCliWithSummary = summaryRoot =>
     runCliWithArgs([
+      '--native-coverage',
+      testNativeCoverageRelativePath,
       '--summary-json',
       path.join(summaryRoot, 'scope-parity-summary.json'),
       '--summary-md',
@@ -71,13 +49,8 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     ]);
 
   const writeNativeCoverageFixture = content => {
-    if (fs.existsSync(nativeCoveragePath)) {
-      fs.renameSync(nativeCoveragePath, nativeCoverageBackupPath);
-    } else {
-      removeNativeCoverageAfterTest = true;
-    }
-    createDirectory(path.dirname(nativeCoveragePath));
-    fs.writeFileSync(nativeCoveragePath, content, 'utf8');
+    createDirectory(path.dirname(testNativeCoveragePath));
+    fs.writeFileSync(testNativeCoveragePath, content, 'utf8');
   };
 
   beforeEach(() => {
@@ -85,24 +58,10 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     fs.rmSync(allowedOutputRoot, { recursive: true, force: true });
     createDirectory(tempRoot);
     createDirectory(allowedOutputRoot);
-    removeNativeCoverageAfterTest = false;
     loadReporter();
   });
 
   afterEach(() => {
-    if (shouldRestoreNativeCoverageBackup(nativeCoveragePath, nativeCoverageBackupPath)) {
-      fs.rmSync(nativeCoveragePath, { force: true });
-      fs.renameSync(nativeCoverageBackupPath, nativeCoveragePath);
-    }
-    if (
-      shouldRemoveTestCreatedNativeCoverage(
-        nativeCoveragePath,
-        nativeCoverageBackupPath,
-        removeNativeCoverageAfterTest
-      )
-    ) {
-      fs.rmSync(nativeCoveragePath, { force: true });
-    }
     fs.rmSync(tempRoot, { recursive: true, force: true });
     fs.rmSync(allowedOutputRoot, { recursive: true, force: true });
   });
@@ -341,9 +300,6 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
   test('缺少 native coverage-final.json 時 CLI 應失敗且不產生摘要', () => {
     const outputRoot = path.join(allowedOutputRoot, 'missing-coverage-output');
     createDirectory(outputRoot);
-    if (fs.existsSync(nativeCoveragePath)) {
-      fs.renameSync(nativeCoveragePath, nativeCoverageBackupPath);
-    }
 
     const result = runCliWithSummary(outputRoot);
 
@@ -354,6 +310,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
   });
 
   test.each([
+    ['--native-coverage', '--native-coverage 必須提供路徑值'],
     ['--summary-json', '--summary-json 必須提供路徑值'],
     ['--summary-md', '--summary-md 必須提供路徑值'],
   ])('CLI 缺少 %s 路徑值時應輸出明確錯誤', (flag, expectedMessage) => {
@@ -378,6 +335,42 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
   });
 
+  test('native coverage JSON 語法錯誤時 CLI 應輸出繁體中文錯誤', () => {
+    const outputRoot = path.join(allowedOutputRoot, 'invalid-json-output');
+    createDirectory(outputRoot);
+    writeNativeCoverageFixture('{');
+
+    const result = runCliWithSummary(outputRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('無法解析 native ESM 覆蓋率 JSON');
+    expect(result.stderr).toContain(testNativeCoverageRelativePath);
+    expect(result.stderr).toContain('原始錯誤：');
+    expect(result.stderr).not.toContain('Unexpected end of JSON input');
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+  });
+
+  test('native coverage entry 缺少 statement map 時 CLI 應拒絕 malformed schema', () => {
+    const outputRoot = path.join(allowedOutputRoot, 'malformed-entry-output');
+    createDirectory(outputRoot);
+    writeNativeCoverageFixture(
+      JSON.stringify({
+        [path.join(projectRoot, 'scripts/config/shared/storage.js')]: {},
+      })
+    );
+
+    const result = runCliWithSummary(outputRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'native ESM coverage entry 的 statement hit map 必須是 JSON object'
+    );
+    expect(result.stderr).toContain('scripts/config/shared/storage.js');
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+  });
+
   test('CLI 成功訊息使用繁體中文摘要', () => {
     writeNativeCoverageFixture(JSON.stringify({}));
     const outputRoot = path.join(allowedOutputRoot, 'success-output');
@@ -386,7 +379,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     const result = runCliWithSummary(outputRoot);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Native ESM scope parity 報告已寫入：');
+    expect(result.stdout).toContain('Native ESM 範圍一致性報告已寫入：');
     expect(result.stdout).toContain('official 檔案');
     expect(result.stdout).toContain('native candidate 檔案');
     expect(result.stdout).not.toContain('report written');

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -1,0 +1,212 @@
+/**
+ * @jest-environment node
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const createDirectory = directoryPath => {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  fs.mkdirSync(directoryPath, { recursive: true });
+};
+
+const writeFile = (rootDir, relativePath, content = '') => {
+  const filePath = path.join(rootDir, relativePath);
+  createDirectory(path.dirname(filePath));
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  fs.writeFileSync(filePath, content, 'utf8');
+};
+
+describe('tools/report-native-esm-scope-parity.mjs', () => {
+  const projectRoot = path.resolve(__dirname, '../../..');
+  const tempRoot = path.join(projectRoot, '.tmp/test-scope-parity');
+  let reporter;
+
+  const loadReporter = () => {
+    reporter = require('../../../tools/report-native-esm-scope-parity-core.cjs');
+  };
+
+  beforeEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    createDirectory(tempRoot);
+    loadReporter();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test('coverage patterns include scripts and pages production JavaScript files', () => {
+    writeFile(tempRoot, 'scripts/background/utils/BlockBuilder.js');
+    writeFile(tempRoot, 'pages/update-notification/update-notification.js');
+    writeFile(tempRoot, 'pages/update-notification/update-notification.css');
+
+    const files = reporter.listJavaScriptSourceFiles(tempRoot, ['scripts', 'pages']);
+    const result = reporter.evaluateCoveragePatterns(files, [
+      '<rootDir>/scripts/**/*.js',
+      '<rootDir>/pages/**/*.js',
+    ]);
+
+    expect(result.included).toEqual([
+      'pages/update-notification/update-notification.js',
+      'scripts/background/utils/BlockBuilder.js',
+    ]);
+    expect(result.excluded).toEqual([]);
+    expect(result.unsupportedPatterns).toEqual([]);
+  });
+
+  test('coverage exclusions remove exact, subtree, and test-like source files', () => {
+    writeFile(tempRoot, 'scripts/config/index.js');
+    writeFile(tempRoot, 'scripts/config/extension/notionApi.js');
+    writeFile(tempRoot, 'scripts/config/shared/storage.js');
+    writeFile(tempRoot, 'scripts/config/shared/storage.test.js');
+    writeFile(tempRoot, 'scripts/config/shared/storage.spec.js');
+
+    const files = reporter.listJavaScriptSourceFiles(tempRoot, ['scripts']);
+    const result = reporter.evaluateCoveragePatterns(files, [
+      '<rootDir>/scripts/**/*.js',
+      '!<rootDir>/scripts/config/index.js',
+      '!<rootDir>/scripts/config/extension/**/*.js',
+      '!<rootDir>/scripts/**/*.test.js',
+      '!<rootDir>/scripts/**/*.spec.js',
+    ]);
+
+    expect(result.included).toEqual(['scripts/config/shared/storage.js']);
+    expect(result.excluded).toEqual([
+      'scripts/config/extension/notionApi.js',
+      'scripts/config/index.js',
+      'scripts/config/shared/storage.spec.js',
+      'scripts/config/shared/storage.test.js',
+    ]);
+    expect(result.unsupportedPatterns).toEqual([]);
+  });
+
+  test('scope summary classifies missing, extra, and zero-coverage canary files', () => {
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: [
+        'pages/update-notification/update-notification.js',
+        'scripts/background/utils/BlockBuilder.js',
+        'scripts/config/shared/storage.js',
+      ],
+      officialExcluded: ['scripts/config/index.js'],
+      nativeIncluded: ['scripts/background/utils/BlockBuilder.js', 'scripts/config/index.js'],
+      nativeCoverageEntries: {
+        'scripts/background/utils/BlockBuilder.js': { statementHits: [1] },
+      },
+      zeroCoverageCanaryPaths: ['pages/update-notification/update-notification.js'],
+      unsupportedPatterns: [],
+    });
+
+    expect(summary.totals).toEqual({
+      officialIncluded: 3,
+      officialExcluded: 1,
+      nativeIncluded: 2,
+      missingFromNativeCandidate: 2,
+      extraNativeCandidate: 1,
+      zeroCoverageCanaries: 1,
+      unsupportedPatterns: 0,
+    });
+    expect(summary.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'pages/update-notification/update-notification.js',
+          classification: 'zero-coverage-canary',
+          nativeCandidate: 'missing',
+          nativeCoverageEntry: 'missing',
+        }),
+        expect.objectContaining({
+          path: 'scripts/config/shared/storage.js',
+          classification: 'missing-from-native-candidate',
+        }),
+        expect.objectContaining({
+          path: 'scripts/config/index.js',
+          classification: 'extra-native-candidate',
+        }),
+      ])
+    );
+    expect(summary.gates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'official-scope-parity',
+          status: 'fail',
+          blocking: false,
+        }),
+        expect.objectContaining({
+          id: 'zero-coverage-canary',
+          status: 'fail',
+          blocking: false,
+        }),
+        expect.objectContaining({
+          id: 'report-integrity',
+          status: 'pass',
+          blocking: true,
+        }),
+      ])
+    );
+  });
+
+  test('scope summary records zero canary pass when native coverage contains only zero hits', () => {
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: ['pages/update-notification/update-notification.js'],
+      officialExcluded: [],
+      nativeIncluded: ['pages/update-notification/update-notification.js'],
+      nativeCoverageEntries: {
+        'pages/update-notification/update-notification.js': { statementHits: [0, 0] },
+      },
+      zeroCoverageCanaryPaths: ['pages/update-notification/update-notification.js'],
+      unsupportedPatterns: [],
+    });
+
+    expect(summary.files).toEqual([
+      expect.objectContaining({
+        path: 'pages/update-notification/update-notification.js',
+        classification: 'zero-coverage-canary',
+        nativeCoverageEntry: 'zero',
+      }),
+    ]);
+    expect(summary.gates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'zero-coverage-canary', status: 'pass' }),
+      ])
+    );
+  });
+
+  test('unsupported patterns are recorded and make report integrity fail', () => {
+    const files = ['scripts/background/utils/BlockBuilder.js'];
+    const result = reporter.evaluateCoveragePatterns(files, ['<rootDir>/scripts/**/{foo,bar}.js']);
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: [],
+      officialExcluded: [],
+      nativeIncluded: [],
+      nativeCoverageEntries: {},
+      zeroCoverageCanaryPaths: ['pages/update-notification/update-notification.js'],
+      unsupportedPatterns: result.unsupportedPatterns,
+    });
+
+    expect(result.unsupportedPatterns).toEqual(['<rootDir>/scripts/**/{foo,bar}.js']);
+    expect(summary.totals.unsupportedPatterns).toBe(1);
+    expect(summary.gates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'report-integrity', status: 'fail', blocking: true }),
+      ])
+    );
+  });
+
+  test('markdown summary states diagnostic boundary and Codecov isolation', () => {
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: ['pages/update-notification/update-notification.js'],
+      officialExcluded: [],
+      nativeIncluded: [],
+      nativeCoverageEntries: {},
+      zeroCoverageCanaryPaths: ['pages/update-notification/update-notification.js'],
+      unsupportedPatterns: [],
+    });
+
+    const markdown = reporter.renderMarkdownSummary(summary);
+
+    expect(markdown).toContain('coverage/jest/lcov.info');
+    expect(markdown).toContain('僅供診斷');
+    expect(markdown).toContain('official-scope-parity');
+    expect(markdown).toContain('pages/update-notification/update-notification.js');
+  });
+});

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -54,7 +54,9 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
   };
 
   const expectNoSummaryFiles = outputRoot => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- 測試檢查暫存輸出檔案
     expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- 測試檢查暫存輸出檔案
     expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
   };
 

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -4,6 +4,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const createDirectory = directoryPath => {
   // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -20,20 +21,58 @@ const writeFile = (rootDir, relativePath, content = '') => {
 describe('tools/report-native-esm-scope-parity.mjs', () => {
   const projectRoot = path.resolve(__dirname, '../../..');
   const tempRoot = path.join(projectRoot, '.tmp/test-scope-parity');
+  const cliPath = path.join(projectRoot, 'tools/report-native-esm-scope-parity.mjs');
+  const nativeCoveragePath = path.join(projectRoot, 'coverage/native-esm/coverage-final.json');
+  const nativeCoverageBackupPath = path.join(
+    projectRoot,
+    'coverage/native-esm/coverage-final.json.scope-parity-test-bak'
+  );
+  const allowedOutputRoot = path.join(projectRoot, 'coverage/native-esm/test-scope-parity-output');
   let reporter;
+  let removeNativeCoverageAfterTest;
 
   const loadReporter = () => {
     reporter = require('../../../tools/report-native-esm-scope-parity-core.cjs');
   };
 
+  const runCliWithSummary = summaryRoot =>
+    spawnSync(
+      process.execPath,
+      [
+        cliPath,
+        '--summary-json',
+        path.join(summaryRoot, 'scope-parity-summary.json'),
+        '--summary-md',
+        path.join(summaryRoot, 'scope-parity-summary.md'),
+      ],
+      {
+        cwd: projectRoot,
+        encoding: 'utf8',
+      }
+    );
+
   beforeEach(() => {
     fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(allowedOutputRoot, { recursive: true, force: true });
     createDirectory(tempRoot);
+    createDirectory(allowedOutputRoot);
+    removeNativeCoverageAfterTest = false;
     loadReporter();
   });
 
   afterEach(() => {
+    if (!fs.existsSync(nativeCoveragePath) && fs.existsSync(nativeCoverageBackupPath)) {
+      fs.renameSync(nativeCoverageBackupPath, nativeCoveragePath);
+    }
+    if (
+      removeNativeCoverageAfterTest &&
+      fs.existsSync(nativeCoveragePath) &&
+      !fs.existsSync(nativeCoverageBackupPath)
+    ) {
+      fs.rmSync(nativeCoveragePath, { force: true });
+    }
     fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(allowedOutputRoot, { recursive: true, force: true });
   });
 
   test('coverage patterns include scripts and pages production JavaScript files', () => {
@@ -163,10 +202,47 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
         classification: 'zero-coverage-canary',
         nativeCoverageEntry: 'zero',
       }),
+      expect.objectContaining({
+        path: 'pages/update-notification/update-notification.js',
+        classification: 'included-in-both',
+        nativeCoverageEntry: 'zero',
+      }),
     ]);
     expect(summary.gates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'zero-coverage-canary', status: 'pass' }),
+      ])
+    );
+  });
+
+  test('zero canary still contributes to native extra scope drift', () => {
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: [],
+      officialExcluded: [],
+      nativeIncluded: ['pages/update-notification/update-notification.js'],
+      nativeCoverageEntries: {
+        'pages/update-notification/update-notification.js': { statementHits: [0, 0] },
+      },
+      zeroCoverageCanaryPaths: ['pages/update-notification/update-notification.js'],
+      unsupportedPatterns: [],
+    });
+
+    expect(summary.totals.extraNativeCandidate).toBe(1);
+    expect(summary.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'pages/update-notification/update-notification.js',
+          classification: 'zero-coverage-canary',
+        }),
+        expect.objectContaining({
+          path: 'pages/update-notification/update-notification.js',
+          classification: 'extra-native-candidate',
+        }),
+      ])
+    );
+    expect(summary.gates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'official-scope-parity', status: 'fail' }),
       ])
     );
   });
@@ -208,5 +284,38 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     expect(markdown).toContain('僅供診斷');
     expect(markdown).toContain('official-scope-parity');
     expect(markdown).toContain('pages/update-notification/update-notification.js');
+  });
+
+  test('缺少 native coverage-final.json 時 CLI 應失敗且不產生摘要', () => {
+    const outputRoot = path.join(allowedOutputRoot, 'missing-coverage-output');
+    createDirectory(outputRoot);
+    if (fs.existsSync(nativeCoveragePath)) {
+      fs.renameSync(nativeCoveragePath, nativeCoverageBackupPath);
+    }
+
+    const result = runCliWithSummary(outputRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('找不到 native ESM 覆蓋率檔案');
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+  });
+
+  test('CLI 成功訊息使用繁體中文摘要', () => {
+    if (!fs.existsSync(nativeCoveragePath)) {
+      createDirectory(path.dirname(nativeCoveragePath));
+      fs.writeFileSync(nativeCoveragePath, JSON.stringify({}), 'utf8');
+      removeNativeCoverageAfterTest = true;
+    }
+    const outputRoot = path.join(allowedOutputRoot, 'success-output');
+    createDirectory(outputRoot);
+
+    const result = runCliWithSummary(outputRoot);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Native ESM scope parity 報告已寫入：');
+    expect(result.stdout).toContain('official 檔案');
+    expect(result.stdout).toContain('native candidate 檔案');
+    expect(result.stdout).not.toContain('report written');
   });
 });

--- a/tests/unit/scripts/report-native-esm-scope-parity.test.js
+++ b/tests/unit/scripts/report-native-esm-scope-parity.test.js
@@ -20,10 +20,6 @@ const writeFile = (rootDir, relativePath, content = '') => {
 
 const shouldRestoreNativeCoverageBackup = (nativeCoveragePath, nativeCoverageBackupPath) => {
   // eslint-disable-next-line security/detect-non-literal-fs-filename
-  if (fs.existsSync(nativeCoveragePath)) {
-    return false;
-  }
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
   return fs.existsSync(nativeCoverageBackupPath);
 };
 
@@ -60,21 +56,29 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     reporter = require('../../../tools/report-native-esm-scope-parity-core.cjs');
   };
 
+  const runCliWithArgs = args =>
+    spawnSync(process.execPath, [cliPath, ...args], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+
   const runCliWithSummary = summaryRoot =>
-    spawnSync(
-      process.execPath,
-      [
-        cliPath,
-        '--summary-json',
-        path.join(summaryRoot, 'scope-parity-summary.json'),
-        '--summary-md',
-        path.join(summaryRoot, 'scope-parity-summary.md'),
-      ],
-      {
-        cwd: projectRoot,
-        encoding: 'utf8',
-      }
-    );
+    runCliWithArgs([
+      '--summary-json',
+      path.join(summaryRoot, 'scope-parity-summary.json'),
+      '--summary-md',
+      path.join(summaryRoot, 'scope-parity-summary.md'),
+    ]);
+
+  const writeNativeCoverageFixture = content => {
+    if (fs.existsSync(nativeCoveragePath)) {
+      fs.renameSync(nativeCoveragePath, nativeCoverageBackupPath);
+    } else {
+      removeNativeCoverageAfterTest = true;
+    }
+    createDirectory(path.dirname(nativeCoveragePath));
+    fs.writeFileSync(nativeCoveragePath, content, 'utf8');
+  };
 
   beforeEach(() => {
     fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -87,6 +91,7 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
 
   afterEach(() => {
     if (shouldRestoreNativeCoverageBackup(nativeCoveragePath, nativeCoverageBackupPath)) {
+      fs.rmSync(nativeCoveragePath, { force: true });
       fs.renameSync(nativeCoverageBackupPath, nativeCoveragePath);
     }
     if (
@@ -274,6 +279,26 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     );
   });
 
+  test('scope summary treats omitted native coverage entries as missing records', () => {
+    const summary = reporter.buildScopeParitySummary({
+      officialIncluded: ['scripts/background/utils/BlockBuilder.js'],
+      officialExcluded: [],
+      nativeIncluded: ['scripts/background/utils/BlockBuilder.js'],
+      zeroCoverageCanaryPaths: [],
+      unsupportedPatterns: [],
+    });
+
+    expect(summary.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'scripts/background/utils/BlockBuilder.js',
+          nativeCoverageEntry: 'missing',
+          classification: 'included-in-both',
+        }),
+      ])
+    );
+  });
+
   test('unsupported patterns are recorded and make report integrity fail', () => {
     const files = ['scripts/background/utils/BlockBuilder.js'];
     const result = reporter.evaluateCoveragePatterns(files, ['<rootDir>/scripts/**/{foo,bar}.js']);
@@ -328,12 +353,33 @@ describe('tools/report-native-esm-scope-parity.mjs', () => {
     expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
   });
 
+  test.each([
+    ['--summary-json', '--summary-json 必須提供路徑值'],
+    ['--summary-md', '--summary-md 必須提供路徑值'],
+  ])('CLI 缺少 %s 路徑值時應輸出明確錯誤', (flag, expectedMessage) => {
+    const result = runCliWithArgs([flag]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(expectedMessage);
+    expect(result.stderr).not.toContain('TypeError');
+  });
+
+  test('native coverage JSON 為 null 時 CLI 應失敗且不產生摘要', () => {
+    const outputRoot = path.join(allowedOutputRoot, 'null-coverage-output');
+    createDirectory(outputRoot);
+    writeNativeCoverageFixture('null');
+
+    const result = runCliWithSummary(outputRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('native ESM 覆蓋率檔案必須是 JSON object');
+    expect(result.stderr).not.toContain('TypeError');
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.json'))).toBe(false);
+    expect(fs.existsSync(path.join(outputRoot, 'scope-parity-summary.md'))).toBe(false);
+  });
+
   test('CLI 成功訊息使用繁體中文摘要', () => {
-    if (!fs.existsSync(nativeCoveragePath)) {
-      createDirectory(path.dirname(nativeCoveragePath));
-      fs.writeFileSync(nativeCoveragePath, JSON.stringify({}), 'utf8');
-      removeNativeCoverageAfterTest = true;
-    }
+    writeNativeCoverageFixture(JSON.stringify({}));
     const outputRoot = path.join(allowedOutputRoot, 'success-output');
     createDirectory(outputRoot);
 

--- a/tools/report-native-esm-scope-parity-core.cjs
+++ b/tools/report-native-esm-scope-parity-core.cjs
@@ -1,0 +1,363 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const defaultZeroCoverageCanaryPaths = ['pages/update-notification/update-notification.js'];
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function normalizeRelativePath(filePath) {
+  return toPosix(filePath).replace(/^\.\//, '');
+}
+
+function normalizePattern(pattern) {
+  return pattern.trim().replace(/^!/, '').replace(/^<rootDir>\//, '').replace(/^\.\//, '');
+}
+
+function isDescendantPath(relativePath) {
+  return relativePath !== '' && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+function assertPathInsideDirectory(filePath, directoryPath, message) {
+  const relativePath = path.relative(directoryPath, filePath);
+  if (relativePath === '' || isDescendantPath(relativePath)) {
+    return;
+  }
+  throw new Error(message);
+}
+
+function isSupportedPattern(pattern) {
+  const normalizedPattern = normalizePattern(pattern);
+  return normalizedPattern === '**/node_modules/**' || /^[^{}()[\]]+$/.test(normalizedPattern);
+}
+
+function escapeRegExp(value) {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+function globToRegExp(pattern) {
+  const normalizedPattern = normalizePattern(pattern);
+  let expression = '^';
+  for (let index = 0; index < normalizedPattern.length; index += 1) {
+    const char = normalizedPattern[index];
+    const next = normalizedPattern[index + 1];
+    const afterNext = normalizedPattern[index + 2];
+
+    if (char === '*' && next === '*' && afterNext === '/') {
+      expression += '(?:.*/)?';
+      index += 2;
+      continue;
+    }
+
+    if (char === '*' && next === '*') {
+      expression += '.*';
+      index += 1;
+      continue;
+    }
+
+    if (char === '*') {
+      expression += '[^/]*';
+      continue;
+    }
+
+    expression += escapeRegExp(char);
+  }
+  expression += '$';
+  return new RegExp(expression);
+}
+
+function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizeRelativePath(filePath));
+}
+
+function collectFiles(rootDir, currentDir, roots, files) {
+  for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+    const absolutePath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(rootDir, absolutePath, roots, files);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.js')) {
+      continue;
+    }
+    const relativePath = normalizeRelativePath(path.relative(rootDir, absolutePath));
+    if (roots.some(root => relativePath === root || relativePath.startsWith(`${root}/`))) {
+      files.push(relativePath);
+    }
+  }
+}
+
+function listJavaScriptSourceFiles(rootDir, roots) {
+  const files = [];
+  const normalizedRoots = roots.map(root => normalizeRelativePath(root).replace(/\/$/, ''));
+  for (const root of normalizedRoots) {
+    const rootPath = path.join(rootDir, root);
+    if (fs.existsSync(rootPath)) {
+      collectFiles(rootDir, rootPath, normalizedRoots, files);
+    }
+  }
+  return [...new Set(files)].sort();
+}
+
+function evaluateCoveragePatterns(files, patterns) {
+  const included = new Set();
+  const excluded = new Set();
+  const unsupportedPatterns = [];
+
+  for (const pattern of patterns) {
+    if (!isSupportedPattern(pattern)) {
+      unsupportedPatterns.push(pattern);
+      continue;
+    }
+    const isExclusion = pattern.trim().startsWith('!');
+    for (const file of files) {
+      if (!matchesPattern(file, pattern)) {
+        continue;
+      }
+      if (isExclusion) {
+        included.delete(file);
+        excluded.add(file);
+      } else if (!excluded.has(file)) {
+        included.add(file);
+      }
+    }
+  }
+
+  return {
+    included: [...included].sort(),
+    excluded: [...excluded].sort(),
+    unsupportedPatterns,
+  };
+}
+
+function classifyCoverageEntry(entry) {
+  if (!entry) {
+    return 'missing';
+  }
+  const hits = entry.statementHits || [];
+  if (hits.length === 0 || hits.every(hit => hit === 0)) {
+    return 'zero';
+  }
+  return 'nonzero';
+}
+
+function createFileRecords({
+  officialIncluded,
+  officialExcluded,
+  nativeIncluded,
+  nativeCoverageEntries,
+  zeroCoverageCanaryPaths,
+}) {
+  const officialIncludedSet = new Set(officialIncluded);
+  const officialExcludedSet = new Set(officialExcluded);
+  const nativeIncludedSet = new Set(nativeIncluded);
+  const allFiles = new Set([...officialIncluded, ...officialExcluded, ...nativeIncluded, ...zeroCoverageCanaryPaths]);
+
+  return [...allFiles].sort().flatMap(filePath => {
+    const official = officialIncludedSet.has(filePath)
+      ? 'included'
+      : officialExcludedSet.has(filePath)
+        ? 'excluded'
+        : 'not_in_scope';
+    const nativeCandidate = nativeIncludedSet.has(filePath) ? 'included' : 'missing';
+    const nativeCoverageEntry = classifyCoverageEntry(nativeCoverageEntries[filePath]);
+    const isZeroCanary = zeroCoverageCanaryPaths.includes(filePath);
+
+    if (isZeroCanary) {
+      return [
+        {
+          path: filePath,
+          official,
+          nativeCandidate,
+          nativeCoverageEntry,
+          classification: 'zero-coverage-canary',
+          reason: 'Official in-scope page script should remain visible as 0% before cutover.',
+        },
+      ];
+    }
+
+    if (official === 'included' && nativeCandidate === 'missing') {
+      return [
+        {
+          path: filePath,
+          official,
+          nativeCandidate,
+          nativeCoverageEntry,
+          classification: 'missing-from-native-candidate',
+          reason: 'Official coverage scope includes this file, but native candidate scope does not.',
+        },
+      ];
+    }
+
+    if (official !== 'included' && nativeCandidate === 'included') {
+      return [
+        {
+          path: filePath,
+          official,
+          nativeCandidate,
+          nativeCoverageEntry,
+          classification: 'extra-native-candidate',
+          reason: 'Native candidate includes a file outside official included coverage scope.',
+        },
+      ];
+    }
+
+    if (official === 'included' && nativeCandidate === 'included') {
+      return [
+        {
+          path: filePath,
+          official,
+          nativeCandidate,
+          nativeCoverageEntry,
+          classification: 'included-in-both',
+          reason: 'File is included by both official and native candidate coverage scopes.',
+        },
+      ];
+    }
+
+    return [];
+  });
+}
+
+function createGateRecords({ files, unsupportedPatterns }) {
+  const missingCount = files.filter(file => file.official === 'included' && file.nativeCandidate === 'missing').length;
+  const extraCount = files.filter(file => file.classification === 'extra-native-candidate').length;
+  const zeroCanaries = files.filter(file => file.classification === 'zero-coverage-canary');
+  const zeroCanaryPass = zeroCanaries.length > 0 && zeroCanaries.every(file => file.nativeCoverageEntry === 'zero');
+
+  return [
+    {
+      id: 'official-scope-parity',
+      status: missingCount === 0 && extraCount === 0 ? 'pass' : 'fail',
+      blocking: false,
+      evidence:
+        missingCount === 0 && extraCount === 0
+          ? 'Native candidate scope matches official included coverage scope.'
+          : `Native candidate differs from official scope: ${missingCount} missing, ${extraCount} extra.`,
+    },
+    {
+      id: 'zero-coverage-canary',
+      status: zeroCanaryPass ? 'pass' : 'fail',
+      blocking: false,
+      evidence: zeroCanaryPass
+        ? 'Zero-coverage canary appears in native coverage output with zero hits.'
+        : 'Zero-coverage canary is missing or not represented as a zero-hit file.',
+    },
+    {
+      id: 'report-integrity',
+      status: unsupportedPatterns.length === 0 ? 'pass' : 'fail',
+      blocking: true,
+      evidence:
+        unsupportedPatterns.length === 0
+          ? 'Configs, source files, coverage entries, and output paths stayed under repo root / coverage/native-esm.'
+          : `${unsupportedPatterns.length} unsupported collectCoverageFrom pattern(s) found.`,
+    },
+  ];
+}
+
+function buildScopeParitySummary({
+  officialIncluded,
+  officialExcluded,
+  nativeIncluded,
+  nativeCoverageEntries,
+  zeroCoverageCanaryPaths = defaultZeroCoverageCanaryPaths,
+  unsupportedPatterns,
+  officialConfigPath = 'jest.config.js',
+  nativeConfigPath = 'jest.native-esm.config.cjs',
+  nativeCoveragePath = 'coverage/native-esm/coverage-final.json',
+}) {
+  const files = createFileRecords({
+    officialIncluded,
+    officialExcluded,
+    nativeIncluded,
+    nativeCoverageEntries,
+    zeroCoverageCanaryPaths,
+  });
+  const missingCount = files.filter(file => file.official === 'included' && file.nativeCandidate === 'missing').length;
+  const extraCount = files.filter(file => file.classification === 'extra-native-candidate').length;
+
+  return {
+    schemaVersion: 1,
+    diagnosticOnly: true,
+    officialConfigPath,
+    nativeConfigPath,
+    nativeCoveragePath,
+    totals: {
+      officialIncluded: officialIncluded.length,
+      officialExcluded: officialExcluded.length,
+      nativeIncluded: nativeIncluded.length,
+      missingFromNativeCandidate: missingCount,
+      extraNativeCandidate: extraCount,
+      zeroCoverageCanaries: zeroCoverageCanaryPaths.length,
+      unsupportedPatterns: unsupportedPatterns.length,
+    },
+    files,
+    unsupportedPatterns,
+    gates: createGateRecords({ files, unsupportedPatterns }),
+  };
+}
+
+function formatGateStatus(status) {
+  return {
+    pass: '通過',
+    fail: '失敗',
+  }[status] || status;
+}
+
+function escapeMarkdownTableCell(value) {
+  return String(value).replace(/\r?\n/g, ' ').replaceAll('|', String.raw`\|`);
+}
+
+function renderMarkdownSummary(summary) {
+  const gateRows = summary.gates
+    .map(
+      gate =>
+        `| \`${gate.id}\` | ${formatGateStatus(gate.status)} | ${gate.blocking ? '是' : '否'} | ${escapeMarkdownTableCell(gate.evidence)} |`
+    )
+    .join('\n');
+  const fileRows = summary.files
+    .map(
+      file =>
+        `| \`${file.path}\` | ${file.official} | ${file.nativeCandidate} | ${file.nativeCoverageEntry} | ${file.classification} | ${escapeMarkdownTableCell(file.reason)} |`
+    )
+    .join('\n');
+
+  return `# Native ESM Scope Parity Summary
+
+> 僅供診斷。這不是正式 coverage truth；Codecov 仍使用 \`coverage/jest/lcov.info\`。
+
+## Totals
+
+- Official included files: ${summary.totals.officialIncluded}
+- Official excluded files: ${summary.totals.officialExcluded}
+- Native candidate files: ${summary.totals.nativeIncluded}
+- Missing from native candidate: ${summary.totals.missingFromNativeCandidate}
+- Extra native candidate files: ${summary.totals.extraNativeCandidate}
+- Zero-coverage canaries: ${summary.totals.zeroCoverageCanaries}
+- Unsupported patterns: ${summary.totals.unsupportedPatterns}
+
+## Gates
+
+| Gate | 狀態 | 阻擋 | 證據 |
+| --- | --- | --- | --- |
+${gateRows}
+
+## File Classifications
+
+| File | Official | Native Candidate | Native Coverage Entry | Classification | Reason |
+| --- | --- | --- | --- | --- | --- |
+${fileRows}
+`;
+}
+
+module.exports = {
+  assertPathInsideDirectory,
+  buildScopeParitySummary,
+  defaultZeroCoverageCanaryPaths,
+  evaluateCoveragePatterns,
+  listJavaScriptSourceFiles,
+  normalizePattern,
+  normalizeRelativePath,
+  renderMarkdownSummary,
+};

--- a/tools/report-native-esm-scope-parity-core.cjs
+++ b/tools/report-native-esm-scope-parity-core.cjs
@@ -136,10 +136,23 @@ function classifyCoverageEntry(entry) {
     return 'missing';
   }
   const hits = entry.statementHits || [];
-  if (hits.length === 0 || hits.every(hit => hit === 0)) {
+  if (hits.length === 0) {
+    return 'zero';
+  }
+  if (hits.every(hit => hit === 0)) {
     return 'zero';
   }
   return 'nonzero';
+}
+
+function getOfficialScopeStatus(filePath, officialIncludedSet, officialExcludedSet) {
+  if (officialIncludedSet.has(filePath)) {
+    return 'included';
+  }
+  if (officialExcludedSet.has(filePath)) {
+    return 'excluded';
+  }
+  return 'not_in_scope';
 }
 
 function createFileRecords({
@@ -155,11 +168,7 @@ function createFileRecords({
   const allFiles = new Set([...officialIncluded, ...officialExcluded, ...nativeIncluded, ...zeroCoverageCanaryPaths]);
 
   return [...allFiles].sort().flatMap(filePath => {
-    const official = officialIncludedSet.has(filePath)
-      ? 'included'
-      : officialExcludedSet.has(filePath)
-        ? 'excluded'
-        : 'not_in_scope';
+    const official = getOfficialScopeStatus(filePath, officialIncludedSet, officialExcludedSet);
     const nativeCandidate = nativeIncludedSet.has(filePath) ? 'included' : 'missing';
     const nativeCoverageEntry = classifyCoverageEntry(nativeCoverageEntries[filePath]);
     const isZeroCanary = zeroCoverageCanaryPaths.includes(filePath);

--- a/tools/report-native-esm-scope-parity-core.cjs
+++ b/tools/report-native-esm-scope-parity-core.cjs
@@ -262,7 +262,7 @@ function buildScopeParitySummary({
   officialIncluded,
   officialExcluded,
   nativeIncluded,
-  nativeCoverageEntries,
+  nativeCoverageEntries = {},
   zeroCoverageCanaryPaths = defaultZeroCoverageCanaryPaths,
   unsupportedPatterns,
   officialConfigPath = 'jest.config.js',

--- a/tools/report-native-esm-scope-parity-core.cjs
+++ b/tools/report-native-esm-scope-parity-core.cjs
@@ -172,65 +172,58 @@ function createFileRecords({
     const nativeCandidate = nativeIncludedSet.has(filePath) ? 'included' : 'missing';
     const nativeCoverageEntry = classifyCoverageEntry(nativeCoverageEntries[filePath]);
     const isZeroCanary = zeroCoverageCanaryPaths.includes(filePath);
+    const records = [];
 
     if (isZeroCanary) {
-      return [
-        {
-          path: filePath,
-          official,
-          nativeCandidate,
-          nativeCoverageEntry,
-          classification: 'zero-coverage-canary',
-          reason: 'Official in-scope page script should remain visible as 0% before cutover.',
-        },
-      ];
+      records.push({
+        path: filePath,
+        official,
+        nativeCandidate,
+        nativeCoverageEntry,
+        classification: 'zero-coverage-canary',
+        reason: '正式範圍內的頁面腳本在切換前應維持可見，即使 native ESM 覆蓋率為 0%。',
+      });
     }
 
     if (official === 'included' && nativeCandidate === 'missing') {
-      return [
-        {
-          path: filePath,
-          official,
-          nativeCandidate,
-          nativeCoverageEntry,
-          classification: 'missing-from-native-candidate',
-          reason: 'Official coverage scope includes this file, but native candidate scope does not.',
-        },
-      ];
+      records.push({
+        path: filePath,
+        official,
+        nativeCandidate,
+        nativeCoverageEntry,
+        classification: 'missing-from-native-candidate',
+        reason: 'official coverage 範圍包含此檔案，但 native candidate 範圍未包含。',
+      });
     }
 
     if (official !== 'included' && nativeCandidate === 'included') {
-      return [
-        {
-          path: filePath,
-          official,
-          nativeCandidate,
-          nativeCoverageEntry,
-          classification: 'extra-native-candidate',
-          reason: 'Native candidate includes a file outside official included coverage scope.',
-        },
-      ];
+      records.push({
+        path: filePath,
+        official,
+        nativeCandidate,
+        nativeCoverageEntry,
+        classification: 'extra-native-candidate',
+        reason: 'native candidate 包含 official included coverage 範圍外的檔案。',
+      });
     }
 
     if (official === 'included' && nativeCandidate === 'included') {
-      return [
-        {
-          path: filePath,
-          official,
-          nativeCandidate,
-          nativeCoverageEntry,
-          classification: 'included-in-both',
-          reason: 'File is included by both official and native candidate coverage scopes.',
-        },
-      ];
+      records.push({
+        path: filePath,
+        official,
+        nativeCandidate,
+        nativeCoverageEntry,
+        classification: 'included-in-both',
+        reason: 'official 與 native candidate coverage 範圍都包含此檔案。',
+      });
     }
 
-    return [];
+    return records;
   });
 }
 
 function createGateRecords({ files, unsupportedPatterns }) {
-  const missingCount = files.filter(file => file.official === 'included' && file.nativeCandidate === 'missing').length;
+  const missingCount = files.filter(file => file.classification === 'missing-from-native-candidate').length;
   const extraCount = files.filter(file => file.classification === 'extra-native-candidate').length;
   const zeroCanaries = files.filter(file => file.classification === 'zero-coverage-canary');
   const zeroCanaryPass = zeroCanaries.length > 0 && zeroCanaries.every(file => file.nativeCoverageEntry === 'zero');
@@ -242,16 +235,16 @@ function createGateRecords({ files, unsupportedPatterns }) {
       blocking: false,
       evidence:
         missingCount === 0 && extraCount === 0
-          ? 'Native candidate scope matches official included coverage scope.'
-          : `Native candidate differs from official scope: ${missingCount} missing, ${extraCount} extra.`,
+          ? 'native candidate 範圍與 official included coverage 範圍一致。'
+          : `native candidate 與 official 範圍不一致：缺少 ${missingCount} 個，多出 ${extraCount} 個。`,
     },
     {
       id: 'zero-coverage-canary',
       status: zeroCanaryPass ? 'pass' : 'fail',
       blocking: false,
       evidence: zeroCanaryPass
-        ? 'Zero-coverage canary appears in native coverage output with zero hits.'
-        : 'Zero-coverage canary is missing or not represented as a zero-hit file.',
+        ? 'zero-coverage canary 已出現在 native coverage output，且命中數為 0。'
+        : 'zero-coverage canary 缺失，或未以零命中檔案呈現。',
     },
     {
       id: 'report-integrity',
@@ -259,8 +252,8 @@ function createGateRecords({ files, unsupportedPatterns }) {
       blocking: true,
       evidence:
         unsupportedPatterns.length === 0
-          ? 'Configs, source files, coverage entries, and output paths stayed under repo root / coverage/native-esm.'
-          : `${unsupportedPatterns.length} unsupported collectCoverageFrom pattern(s) found.`,
+          ? 'config、source file、coverage entry 與 output path 都維持在 repo root / coverage/native-esm 範圍內。'
+          : `發現 ${unsupportedPatterns.length} 個不支援的 collectCoverageFrom pattern。`,
     },
   ];
 }
@@ -283,7 +276,7 @@ function buildScopeParitySummary({
     nativeCoverageEntries,
     zeroCoverageCanaryPaths,
   });
-  const missingCount = files.filter(file => file.official === 'included' && file.nativeCandidate === 'missing').length;
+  const missingCount = files.filter(file => file.classification === 'missing-from-native-candidate').length;
   const extraCount = files.filter(file => file.classification === 'extra-native-candidate').length;
 
   return {
@@ -332,29 +325,29 @@ function renderMarkdownSummary(summary) {
     )
     .join('\n');
 
-  return `# Native ESM Scope Parity Summary
+  return `# Native ESM scope parity 摘要
 
-> 僅供診斷。這不是正式 coverage truth；Codecov 仍使用 \`coverage/jest/lcov.info\`。
+> 僅供診斷。這不是正式 coverage 依據；Codecov 仍使用 \`coverage/jest/lcov.info\`。
 
-## Totals
+## 總計
 
-- Official included files: ${summary.totals.officialIncluded}
-- Official excluded files: ${summary.totals.officialExcluded}
-- Native candidate files: ${summary.totals.nativeIncluded}
-- Missing from native candidate: ${summary.totals.missingFromNativeCandidate}
-- Extra native candidate files: ${summary.totals.extraNativeCandidate}
-- Zero-coverage canaries: ${summary.totals.zeroCoverageCanaries}
-- Unsupported patterns: ${summary.totals.unsupportedPatterns}
+- official included 檔案數：${summary.totals.officialIncluded}
+- official excluded 檔案數：${summary.totals.officialExcluded}
+- native candidate 檔案數：${summary.totals.nativeIncluded}
+- native candidate 缺少檔案數：${summary.totals.missingFromNativeCandidate}
+- native candidate 多出檔案數：${summary.totals.extraNativeCandidate}
+- zero-coverage canary 數：${summary.totals.zeroCoverageCanaries}
+- 不支援 pattern 數：${summary.totals.unsupportedPatterns}
 
-## Gates
+## 閘門
 
-| Gate | 狀態 | 阻擋 | 證據 |
+| 閘門 | 狀態 | 阻擋 | 證據 |
 | --- | --- | --- | --- |
 ${gateRows}
 
-## File Classifications
+## 檔案分類
 
-| File | Official | Native Candidate | Native Coverage Entry | Classification | Reason |
+| 檔案 | official 狀態 | native candidate 狀態 | native coverage entry | 分類 | 原因 |
 | --- | --- | --- | --- | --- | --- |
 ${fileRows}
 `;

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -35,12 +35,20 @@ function parseCliArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--summary-json') {
-      options.summaryJsonPath = argv[index + 1];
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--summary-json 必須提供路徑值');
+      }
+      options.summaryJsonPath = value;
       index += 1;
       continue;
     }
     if (arg === '--summary-md') {
-      options.summaryMarkdownPath = argv[index + 1];
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--summary-md 必須提供路徑值');
+      }
+      options.summaryMarkdownPath = value;
       index += 1;
       continue;
     }
@@ -56,6 +64,9 @@ function readNativeCoverageEntries(coveragePath) {
   }
   assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
   const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+  if (coverage === null || typeof coverage !== 'object' || Array.isArray(coverage)) {
+    throw new Error('native ESM 覆蓋率檔案必須是 JSON object');
+  }
   const entries = {};
   for (const [filePath, fileCoverage] of Object.entries(coverage)) {
     const absoluteFilePath = path.resolve(filePath);

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -27,6 +27,14 @@ function assertOutputPath(filePath) {
   );
 }
 
+function readRequiredOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value) {
+    throw new Error(`${optionName} 必須提供路徑值`);
+  }
+  return value;
+}
+
 function parseCliArgs(argv) {
   const options = {
     summaryJsonPath: 'coverage/native-esm/scope-parity-summary.json',
@@ -35,26 +43,38 @@ function parseCliArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--summary-json') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--summary-json 必須提供路徑值');
-      }
-      options.summaryJsonPath = value;
+      options.summaryJsonPath = readRequiredOptionValue(argv, index, arg);
       index += 1;
       continue;
     }
     if (arg === '--summary-md') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--summary-md 必須提供路徑值');
-      }
-      options.summaryMarkdownPath = value;
+      options.summaryMarkdownPath = readRequiredOptionValue(argv, index, arg);
       index += 1;
       continue;
     }
     throw new Error(`未知參數：${arg}`);
   }
   return options;
+}
+
+function isCoverageObject(coverage) {
+  if (coverage === null) {
+    return false;
+  }
+  if (Array.isArray(coverage)) {
+    return false;
+  }
+  return typeof coverage === 'object';
+}
+
+function toNativeCoverageEntry(filePath, fileCoverage) {
+  const absoluteFilePath = path.resolve(filePath);
+  assertPathInsideDirectory(absoluteFilePath, projectRoot, `coverage entry 必須位於 repo root 底下: ${filePath}`);
+  const relativePath = normalizeRelativePath(path.relative(projectRoot, absoluteFilePath));
+  if (relativePath.startsWith('.tmp/coverage-spike/')) {
+    throw new Error(`coverage entry 不可來自 .tmp/coverage-spike: ${filePath}`);
+  }
+  return [relativePath, { statementHits: Object.values(fileCoverage.s || {}) }];
 }
 
 function readNativeCoverageEntries(coveragePath) {
@@ -64,18 +84,13 @@ function readNativeCoverageEntries(coveragePath) {
   }
   assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
   const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
-  if (coverage === null || typeof coverage !== 'object' || Array.isArray(coverage)) {
+  if (!isCoverageObject(coverage)) {
     throw new Error('native ESM 覆蓋率檔案必須是 JSON object');
   }
   const entries = {};
   for (const [filePath, fileCoverage] of Object.entries(coverage)) {
-    const absoluteFilePath = path.resolve(filePath);
-    assertPathInsideDirectory(absoluteFilePath, projectRoot, `coverage entry 必須位於 repo root 底下: ${filePath}`);
-    const relativePath = normalizeRelativePath(path.relative(projectRoot, absoluteFilePath));
-    if (relativePath.startsWith('.tmp/coverage-spike/')) {
-      throw new Error(`coverage entry 不可來自 .tmp/coverage-spike: ${filePath}`);
-    }
-    entries[relativePath] = { statementHits: Object.values(fileCoverage.s || {}) };
+    const [relativePath, nativeCoverageEntry] = toNativeCoverageEntry(filePath, fileCoverage);
+    entries[relativePath] = nativeCoverageEntry;
   }
   return entries;
 }

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -86,15 +86,9 @@ function toNativeCoverageEntry(filePath, fileCoverage) {
   return [relativePath, { statementHits: Object.values(fileCoverage.s) }];
 }
 
-function readNativeCoverageEntries(coveragePath) {
-  const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
-  if (!fs.existsSync(absoluteCoveragePath)) {
-    throw new Error(`找不到 native ESM 覆蓋率檔案：${coveragePath}。請先執行 npm run test:coverage:native-esm。`);
-  }
-  assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
-  let coverage;
+function readCoverageJson(coveragePath, absoluteCoveragePath) {
   try {
-    coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+    return JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new Error(`無法解析 native ESM 覆蓋率 JSON：${coveragePath}。原始錯誤：${error.message}`, {
@@ -103,9 +97,22 @@ function readNativeCoverageEntries(coveragePath) {
     }
     throw error;
   }
+}
+
+function assertCoverageRootSchema(coverage) {
   if (!isCoverageObject(coverage)) {
     throw new Error('native ESM 覆蓋率檔案必須是 JSON object');
   }
+}
+
+function readNativeCoverageEntries(coveragePath) {
+  const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
+  if (!fs.existsSync(absoluteCoveragePath)) {
+    throw new Error(`找不到 native ESM 覆蓋率檔案：${coveragePath}。請先執行 npm run test:coverage:native-esm。`);
+  }
+  assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
+  const coverage = readCoverageJson(coveragePath, absoluteCoveragePath);
+  assertCoverageRootSchema(coverage);
   const entries = {};
   for (const [filePath, fileCoverage] of Object.entries(coverage)) {
     const [relativePath, nativeCoverageEntry] = toNativeCoverageEntry(filePath, fileCoverage);

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const allowedOutputRoot = path.join(projectRoot, 'coverage', 'native-esm');
+
+const {
+  assertPathInsideDirectory,
+  buildScopeParitySummary,
+  defaultZeroCoverageCanaryPaths,
+  evaluateCoveragePatterns,
+  listJavaScriptSourceFiles,
+  normalizeRelativePath,
+  renderMarkdownSummary,
+} = require('./report-native-esm-scope-parity-core.cjs');
+
+function assertOutputPath(filePath) {
+  assertPathInsideDirectory(
+    path.resolve(projectRoot, filePath),
+    allowedOutputRoot,
+    'summary output path 必須位於 coverage/native-esm 底下'
+  );
+}
+
+function parseCliArgs(argv) {
+  const options = {
+    summaryJsonPath: 'coverage/native-esm/scope-parity-summary.json',
+    summaryMarkdownPath: 'coverage/native-esm/scope-parity-summary.md',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--summary-json') {
+      options.summaryJsonPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--summary-md') {
+      options.summaryMarkdownPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`未知參數：${arg}`);
+  }
+  return options;
+}
+
+function readNativeCoverageEntries(coveragePath) {
+  const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
+  if (!fs.existsSync(absoluteCoveragePath)) {
+    return {};
+  }
+  assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
+  const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+  const entries = {};
+  for (const [filePath, fileCoverage] of Object.entries(coverage)) {
+    const absoluteFilePath = path.resolve(filePath);
+    assertPathInsideDirectory(absoluteFilePath, projectRoot, `coverage entry 必須位於 repo root 底下: ${filePath}`);
+    const relativePath = normalizeRelativePath(path.relative(projectRoot, absoluteFilePath));
+    if (relativePath.startsWith('.tmp/coverage-spike/')) {
+      throw new Error(`coverage entry 不可來自 .tmp/coverage-spike: ${filePath}`);
+    }
+    entries[relativePath] = { statementHits: Object.values(fileCoverage.s || {}) };
+  }
+  return entries;
+}
+
+function buildCurrentRepoSummary() {
+  const officialConfig = require(path.join(projectRoot, 'jest.config.js'));
+  const nativeConfig = require(path.join(projectRoot, 'jest.native-esm.config.cjs'));
+  const sourceFiles = listJavaScriptSourceFiles(projectRoot, ['scripts', 'pages']);
+  const officialScope = evaluateCoveragePatterns(sourceFiles, officialConfig.collectCoverageFrom || []);
+  const nativeScope = evaluateCoveragePatterns(sourceFiles, nativeConfig.collectCoverageFrom || []);
+  const nativeCoverageEntries = readNativeCoverageEntries('coverage/native-esm/coverage-final.json');
+
+  return buildScopeParitySummary({
+    officialIncluded: officialScope.included,
+    officialExcluded: officialScope.excluded,
+    nativeIncluded: nativeScope.included,
+    nativeCoverageEntries,
+    zeroCoverageCanaryPaths: defaultZeroCoverageCanaryPaths,
+    unsupportedPatterns: [...officialScope.unsupportedPatterns, ...nativeScope.unsupportedPatterns],
+  });
+}
+
+function writeOutputFiles(summary, options) {
+  assertOutputPath(options.summaryJsonPath);
+  assertOutputPath(options.summaryMarkdownPath);
+  const jsonPath = path.resolve(projectRoot, options.summaryJsonPath);
+  const markdownPath = path.resolve(projectRoot, options.summaryMarkdownPath);
+  fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+  fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+  fs.writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(markdownPath, renderMarkdownSummary(summary), 'utf8');
+}
+
+function runCli() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const summary = buildCurrentRepoSummary();
+  writeOutputFiles(summary, options);
+  console.log(
+    `Native ESM scope parity report written: ${summary.totals.officialIncluded} official files, ${summary.totals.nativeIncluded} native candidate files, ${summary.totals.missingFromNativeCandidate} missing, ${summary.totals.extraNativeCandidate} extra`
+  );
+  if (summary.totals.unsupportedPatterns > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -52,7 +52,7 @@ function parseCliArgs(argv) {
 function readNativeCoverageEntries(coveragePath) {
   const absoluteCoveragePath = path.resolve(projectRoot, coveragePath);
   if (!fs.existsSync(absoluteCoveragePath)) {
-    return {};
+    throw new Error(`找不到 native ESM 覆蓋率檔案：${coveragePath}。請先執行 npm run test:coverage:native-esm。`);
   }
   assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
   const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
@@ -103,7 +103,7 @@ function runCli() {
   const summary = buildCurrentRepoSummary();
   writeOutputFiles(summary, options);
   console.log(
-    `Native ESM scope parity report written: ${summary.totals.officialIncluded} official files, ${summary.totals.nativeIncluded} native candidate files, ${summary.totals.missingFromNativeCandidate} missing, ${summary.totals.extraNativeCandidate} extra`
+    `Native ESM scope parity 報告已寫入：${summary.totals.officialIncluded} 個 official 檔案，${summary.totals.nativeIncluded} 個 native candidate 檔案，缺少 ${summary.totals.missingFromNativeCandidate} 個，多出 ${summary.totals.extraNativeCandidate} 個`
   );
   if (summary.totals.unsupportedPatterns > 0) {
     process.exitCode = 1;

--- a/tools/report-native-esm-scope-parity.mjs
+++ b/tools/report-native-esm-scope-parity.mjs
@@ -37,11 +37,17 @@ function readRequiredOptionValue(argv, index, optionName) {
 
 function parseCliArgs(argv) {
   const options = {
+    nativeCoveragePath: 'coverage/native-esm/coverage-final.json',
     summaryJsonPath: 'coverage/native-esm/scope-parity-summary.json',
     summaryMarkdownPath: 'coverage/native-esm/scope-parity-summary.md',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+    if (arg === '--native-coverage') {
+      options.nativeCoveragePath = readRequiredOptionValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
     if (arg === '--summary-json') {
       options.summaryJsonPath = readRequiredOptionValue(argv, index, arg);
       index += 1;
@@ -74,7 +80,10 @@ function toNativeCoverageEntry(filePath, fileCoverage) {
   if (relativePath.startsWith('.tmp/coverage-spike/')) {
     throw new Error(`coverage entry 不可來自 .tmp/coverage-spike: ${filePath}`);
   }
-  return [relativePath, { statementHits: Object.values(fileCoverage.s || {}) }];
+  if (!isCoverageObject(fileCoverage) || !isCoverageObject(fileCoverage.s)) {
+    throw new Error(`native ESM coverage entry 的 statement hit map 必須是 JSON object：${relativePath}`);
+  }
+  return [relativePath, { statementHits: Object.values(fileCoverage.s) }];
 }
 
 function readNativeCoverageEntries(coveragePath) {
@@ -83,7 +92,17 @@ function readNativeCoverageEntries(coveragePath) {
     throw new Error(`找不到 native ESM 覆蓋率檔案：${coveragePath}。請先執行 npm run test:coverage:native-esm。`);
   }
   assertPathInsideDirectory(absoluteCoveragePath, projectRoot, 'native coverage path 必須位於 repo root 底下');
-  const coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+  let coverage;
+  try {
+    coverage = JSON.parse(fs.readFileSync(absoluteCoveragePath, 'utf8'));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`無法解析 native ESM 覆蓋率 JSON：${coveragePath}。原始錯誤：${error.message}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
   if (!isCoverageObject(coverage)) {
     throw new Error('native ESM 覆蓋率檔案必須是 JSON object');
   }
@@ -95,13 +114,13 @@ function readNativeCoverageEntries(coveragePath) {
   return entries;
 }
 
-function buildCurrentRepoSummary() {
+function buildCurrentRepoSummary(nativeCoveragePath) {
   const officialConfig = require(path.join(projectRoot, 'jest.config.js'));
   const nativeConfig = require(path.join(projectRoot, 'jest.native-esm.config.cjs'));
   const sourceFiles = listJavaScriptSourceFiles(projectRoot, ['scripts', 'pages']);
   const officialScope = evaluateCoveragePatterns(sourceFiles, officialConfig.collectCoverageFrom || []);
   const nativeScope = evaluateCoveragePatterns(sourceFiles, nativeConfig.collectCoverageFrom || []);
-  const nativeCoverageEntries = readNativeCoverageEntries('coverage/native-esm/coverage-final.json');
+  const nativeCoverageEntries = readNativeCoverageEntries(nativeCoveragePath);
 
   return buildScopeParitySummary({
     officialIncluded: officialScope.included,
@@ -126,10 +145,10 @@ function writeOutputFiles(summary, options) {
 
 function runCli() {
   const options = parseCliArgs(process.argv.slice(2));
-  const summary = buildCurrentRepoSummary();
+  const summary = buildCurrentRepoSummary(options.nativeCoveragePath);
   writeOutputFiles(summary, options);
   console.log(
-    `Native ESM scope parity 報告已寫入：${summary.totals.officialIncluded} 個 official 檔案，${summary.totals.nativeIncluded} 個 native candidate 檔案，缺少 ${summary.totals.missingFromNativeCandidate} 個，多出 ${summary.totals.extraNativeCandidate} 個`
+    `Native ESM 範圍一致性報告已寫入：${summary.totals.officialIncluded} 個 official 檔案，${summary.totals.nativeIncluded} 個 native candidate 檔案，缺少 ${summary.totals.missingFromNativeCandidate} 個，多出 ${summary.totals.extraNativeCandidate} 個`
   );
   if (summary.totals.unsupportedPatterns > 0) {
     process.exitCode = 1;


### PR DESCRIPTION
### 摘要
新增原生 ESM 範圍一致性診斷工具，以確保官方和原生 ESM 的覆蓋範圍一致。

### 變更內容
- 在 `package.json` 中新增 `test:coverage:native-esm:scope-parity` 腳本以執行範圍一致性診斷。
- 在 CI 工作流程中新增執行範圍一致性報告的步驟。
- 新增 `report-native-esm-scope-parity.mjs` 腳本以生成範圍一致性報告。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

