### PR TITLE
feat(test): clean up native ESM coverage and implement blocker ledger

### DIFF
--- a/scripts/utils/RetryManager.js
+++ b/scripts/utils/RetryManager.js
@@ -843,3 +843,5 @@ if (typeof module !== 'undefined' && module.exports) {
   globalThis.withRetry = withRetry;
   globalThis.fetchWithRetry = fetchWithRetry;
 }
+
+export { RetryManager, withRetry, fetchWithRetry };

--- a/scripts/utils/package.json
+++ b/scripts/utils/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/contract/module-surfaces/RetryManager.contract.test.js
+++ b/tests/contract/module-surfaces/RetryManager.contract.test.js
@@ -5,6 +5,9 @@ import vm from 'node:vm';
 
 import { RetryManager, withRetry, fetchWithRetry } from '../../../scripts/utils/RetryManager.js';
 
+const repoRoot = process.cwd();
+const retryManagerSourcePath = path.resolve(repoRoot, 'scripts/utils/RetryManager.js');
+
 describe('RetryManager module surface contracts', () => {
   test('ESM import exposes RetryManager helpers', () => {
     const exported = { RetryManager, withRetry, fetchWithRetry };
@@ -40,7 +43,7 @@ describe('RetryManager module surface contracts', () => {
         ].join('\n'),
       ],
       {
-        cwd: path.resolve(__dirname, '../..', '..'),
+        cwd: repoRoot,
         encoding: 'utf8',
       }
     );
@@ -51,8 +54,9 @@ describe('RetryManager module surface contracts', () => {
   });
 
   test('browser-style global fallback exposes RetryManager helpers', () => {
-    const sourcePath = path.join(__dirname, '../../../scripts/utils/RetryManager.js');
-    const source = fs.readFileSync(sourcePath, 'utf8').replaceAll(/export\s+\{[\s\S]*?\};/g, ''); // 移除靜態 export 以防在 VM script 執行時報 SyntaxError
+    const source = fs
+      .readFileSync(retryManagerSourcePath, 'utf8')
+      .replaceAll(/export\s+\{[\s\S]*?\};/g, ''); // 移除靜態 export 以防在 VM script 執行時報 SyntaxError
     const sandbox = {
       globalThis: {},
       setTimeout,
@@ -67,7 +71,7 @@ describe('RetryManager module surface contracts', () => {
     sandbox.globalThis = sandbox;
 
     // eslint-disable-next-line sonarjs/code-eval -- Intentional VM execution of trusted local source for browser-global contract testing.
-    vm.runInNewContext(source, sandbox, { filename: sourcePath });
+    vm.runInNewContext(source, sandbox, { filename: retryManagerSourcePath });
 
     expect(sandbox.RetryManager).toEqual(expect.any(Function));
     expect(sandbox.withRetry).toEqual(expect.any(Function));

--- a/tests/contract/module-surfaces/RetryManager.contract.test.js
+++ b/tests/contract/module-surfaces/RetryManager.contract.test.js
@@ -3,9 +3,11 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import vm from 'node:vm';
 
+import { RetryManager, withRetry, fetchWithRetry } from '../../../scripts/utils/RetryManager.js';
+
 describe('RetryManager module surface contracts', () => {
-  test('CommonJS require exposes RetryManager helpers', () => {
-    const exported = require('../../../scripts/utils/RetryManager.js');
+  test('ESM import exposes RetryManager helpers', () => {
+    const exported = { RetryManager, withRetry, fetchWithRetry };
 
     expect(exported).toEqual(
       expect.objectContaining({
@@ -16,20 +18,25 @@ describe('RetryManager module surface contracts', () => {
     );
   });
 
-  test('raw Node CommonJS require exposes RetryManager helpers without Jest transforms', () => {
+  test('raw Node ESM import exposes RetryManager helpers without Jest transforms', () => {
     const result = spawnSync(
       process.execPath,
       [
         '-e',
         [
-          "const exported = require('./scripts/utils/RetryManager.js');",
-          "for (const key of ['RetryManager', 'withRetry', 'fetchWithRetry']) {",
-          "  if (typeof exported[key] !== 'function') {",
-          '    console.error(`${key}:${typeof exported[key]}`);',
-          '    process.exit(1);',
+          '(async () => {',
+          "  const exported = await import('./scripts/utils/RetryManager.js');",
+          "  for (const key of ['RetryManager', 'withRetry', 'fetchWithRetry']) {",
+          "    if (typeof exported[key] !== 'function') {",
+          '      console.error(`${key}:${typeof exported[key]}`);',
+          '      process.exit(1);',
+          '    }',
           '  }',
-          '}',
-          "console.log('RetryManager raw CommonJS surface ok');",
+          "  console.log('RetryManager raw ESM surface ok');",
+          '})().catch(error => {',
+          '  console.error(error);',
+          '  process.exit(1);',
+          '});',
         ].join('\n'),
       ],
       {
@@ -40,7 +47,7 @@ describe('RetryManager module surface contracts', () => {
 
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('RetryManager raw CommonJS surface ok');
+    expect(result.stdout).toContain('RetryManager raw ESM surface ok');
   });
 
   test('browser-style global fallback exposes RetryManager helpers', () => {

--- a/tests/contract/module-surfaces/RetryManager.contract.test.js
+++ b/tests/contract/module-surfaces/RetryManager.contract.test.js
@@ -1,7 +1,7 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const { spawnSync } = require('node:child_process');
-const vm = require('node:vm');
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import vm from 'node:vm';
 
 describe('RetryManager module surface contracts', () => {
   test('CommonJS require exposes RetryManager helpers', () => {

--- a/tests/contract/module-surfaces/RetryManager.contract.test.js
+++ b/tests/contract/module-surfaces/RetryManager.contract.test.js
@@ -45,7 +45,7 @@ describe('RetryManager module surface contracts', () => {
 
   test('browser-style global fallback exposes RetryManager helpers', () => {
     const sourcePath = path.join(__dirname, '../../../scripts/utils/RetryManager.js');
-    const source = fs.readFileSync(sourcePath, 'utf8');
+    const source = fs.readFileSync(sourcePath, 'utf8').replaceAll(/export\s+\{[\s\S]*?\};/g, ''); // 移除靜態 export 以防在 VM script 執行時報 SyntaxError
     const sandbox = {
       globalThis: {},
       setTimeout,

--- a/tests/native-esm/coverage-line-hits.json
+++ b/tests/native-esm/coverage-line-hits.json
@@ -1,5 +1,10 @@
 [
   {
+    "fileSuffix": "scripts/highlighter/utils/floatingRailAvailability.js",
+    "lines": [43, 171],
+    "rationale": "withAvailableFloatingRail and formatRuntimeErrorMessage must retain source-line hits under native ESM."
+  },
+  {
     "fileSuffix": "scripts/highlighter/index.js",
     "lines": [74, 98],
     "rationale": "setupHighlighter and initHighlighter must retain source-line hits under native ESM."

--- a/tests/native-esm/highlighter/utils/floatingRailAvailability.native-esm.test.mjs
+++ b/tests/native-esm/highlighter/utils/floatingRailAvailability.native-esm.test.mjs
@@ -1,0 +1,294 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+let mockFloatingRailInstance;
+const mockInitialize = jest.fn();
+
+await jest.unstable_mockModule('../../../../scripts/highlighter/ui/FloatingRail.js', () => {
+  return {
+    FloatingRail: jest.fn().mockImplementation(manager => {
+      mockFloatingRailInstance = {
+        manager,
+        initialize: mockInitialize,
+        show: jest.fn().mockResolvedValue(true),
+        activateHighlighting: jest.fn(),
+      };
+      return mockFloatingRailInstance;
+    }),
+  };
+});
+
+const {
+  formatRuntimeErrorMessage,
+  withAvailableFloatingRail,
+} = await import('../../../../scripts/highlighter/utils/floatingRailAvailability.js');
+const { RUNTIME_ERROR_MESSAGES } = await import('../../../../scripts/config/messages/runtimeErrorMessages.js');
+
+function setHighlighterManager() {
+  globalThis.HighlighterV2 = {
+    manager: { some: 'manager_state' },
+    rail: undefined,
+  };
+}
+
+async function expectDynamicRailCallback(params = {}) {
+  const hasInitializeResult = Object.hasOwn(params, 'initializeResult');
+  const initializeResult = hasInitializeResult ? params.initializeResult : { success: true };
+  const sendResponse = jest.fn();
+  const onRailReady = params.activate
+    ? jest.fn(rail => rail.activateHighlighting())
+    : jest.fn().mockResolvedValue();
+
+  setHighlighterManager();
+  if (params.existingReadyResult) {
+    globalThis.__NOTION_RAIL_READY__ = Promise.resolve(params.existingReadyResult);
+  }
+  mockInitialize.mockResolvedValue(initializeResult);
+
+  await withAvailableFloatingRail(sendResponse, onRailReady, { sessionOverride: true });
+
+  expect(mockInitialize).toHaveBeenCalled();
+  expect(globalThis.HighlighterV2.rail).toBe(mockFloatingRailInstance);
+  expect(onRailReady).toHaveBeenCalledWith(mockFloatingRailInstance);
+  if (params.activate) {
+    expect(mockFloatingRailInstance.activateHighlighting).toHaveBeenCalledWith();
+  }
+  expect(sendResponse).toHaveBeenCalledWith({ success: true });
+}
+
+describe('floatingRailAvailability native ESM', () => {
+  describe('formatRuntimeErrorMessage', () => {
+    test('應允許白名單內的 runtime error 字串', () => {
+      expect(
+        formatRuntimeErrorMessage(
+          RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_SHOW_METHOD_MISSING,
+          RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTION_FAILED
+        )
+      ).toBe(RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_SHOW_METHOD_MISSING);
+    });
+
+    test('應允許白名單內的 runtime error.message', () => {
+      expect(
+        formatRuntimeErrorMessage(
+          new TypeError(RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTIVATE_METHOD_MISSING),
+          RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTION_FAILED
+        )
+      ).toBe(RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTIVATE_METHOD_MISSING);
+    });
+
+    test('任意字串應回退到 fallbackMessage', () => {
+      expect(
+        formatRuntimeErrorMessage(
+          'internal failure details',
+          RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTION_FAILED
+        )
+      ).toBe(RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTION_FAILED);
+    });
+
+    test('任意 error.message 應回退到 fallbackMessage', () => {
+      expect(
+        formatRuntimeErrorMessage(
+          new Error('unexpected rail crash'),
+          RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_INIT_FAILED
+        )
+      ).toBe(RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_INIT_FAILED);
+    });
+  });
+
+  describe('withAvailableFloatingRail', () => {
+    let originalHighlighterV2;
+    let originalNotionRailReady;
+
+    beforeEach(() => {
+      originalHighlighterV2 = globalThis.HighlighterV2;
+      originalNotionRailReady = globalThis.__NOTION_RAIL_READY__;
+      globalThis.HighlighterV2 = undefined;
+      globalThis.__NOTION_RAIL_READY__ = undefined;
+      mockInitialize.mockReset();
+      mockFloatingRailInstance = null;
+    });
+
+    afterEach(() => {
+      globalThis.HighlighterV2 = originalHighlighterV2;
+      globalThis.__NOTION_RAIL_READY__ = originalNotionRailReady;
+    });
+
+    test('當 HighlighterV2.manager 存在，但 active rail 與 ready promise 都不存在時，應動態建立 FloatingRail，執行 callback，並掛回 HighlighterV2.rail', async () => {
+      const sendResponse = jest.fn();
+      const onRailReady = jest.fn().mockResolvedValue();
+
+      const mockManager = { some: 'manager_state' };
+      globalThis.HighlighterV2 = {
+        manager: mockManager,
+        rail: undefined,
+      };
+
+      mockInitialize.mockResolvedValue({ success: true });
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(mockInitialize).toHaveBeenCalled();
+      expect(globalThis.HighlighterV2.rail).toBe(mockFloatingRailInstance);
+
+      expect(onRailReady).toHaveBeenCalledWith(mockFloatingRailInstance);
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
+
+    test('當 activeRail 已存在時，應立即呼叫 onRailReady 且不重新 initialize', async () => {
+      const sendResponse = jest.fn();
+      const activeRail = { show: jest.fn() };
+      const onRailReady = jest.fn().mockResolvedValue();
+
+      globalThis.HighlighterV2 = {
+        manager: { some: 'manager_state' },
+        rail: activeRail,
+      };
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(onRailReady).toHaveBeenCalledWith(activeRail);
+      expect(mockInitialize).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
+
+    test('當 __NOTION_RAIL_READY__ 已存在時，應等待既有 promise 後呼叫 onRailReady', async () => {
+      const sendResponse = jest.fn();
+      const readyRail = { show: jest.fn() };
+      const onRailReady = jest.fn().mockResolvedValue();
+      const existingReadyPromise = Promise.resolve({ success: true, rail: readyRail });
+
+      globalThis.HighlighterV2 = {
+        manager: { some: 'manager_state' },
+        rail: undefined,
+      };
+      globalThis.__NOTION_RAIL_READY__ = existingReadyPromise;
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(onRailReady).toHaveBeenCalledWith(readyRail);
+      expect(mockInitialize).not.toHaveBeenCalled();
+      expect(globalThis.__NOTION_RAIL_READY__).toBe(existingReadyPromise);
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+    });
+
+    test('sessionOverride=true 時，既有 ready promise 失敗後應動態建立 rail 並執行 callback', async () => {
+      expect.hasAssertions();
+      await expectDynamicRailCallback({
+        existingReadyResult: {
+          success: false,
+          error: '浮動側欄初始化已略過',
+        },
+      });
+    });
+
+    test('[REGRESSION] dynamic rail initialize 回傳 undefined 時應視為成功並啟動 callback', async () => {
+      expect.hasAssertions();
+      await expectDynamicRailCallback({
+        activate: true,
+        initializeResult: undefined,
+      });
+    });
+
+    test('[REGRESSION] sessionOverride recovery 的 initialize 回傳 undefined 時仍應啟動 callback', async () => {
+      expect.hasAssertions();
+      await expectDynamicRailCallback({
+        activate: true,
+        initializeResult: undefined,
+        existingReadyResult: {
+          success: false,
+          error: '浮動側欄初始化失敗',
+        },
+      });
+    });
+
+    test('當 HighlighterV2.manager 不存在時，應回傳 FLOATING_RAIL_NOT_INITIALIZED', async () => {
+      const sendResponse = jest.fn();
+      const onRailReady = jest.fn();
+
+      globalThis.HighlighterV2 = {
+        manager: undefined,
+        rail: undefined,
+      };
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(onRailReady).not.toHaveBeenCalled();
+      expect(mockInitialize).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_NOT_INITIALIZED,
+      });
+    });
+
+    test('當 onRailReady 拋錯時，應回傳 FLOATING_RAIL_ACTION_FAILED', async () => {
+      const sendResponse = jest.fn();
+      const activeRail = { show: jest.fn() };
+      const onRailReady = jest.fn(() => {
+        throw new Error('internal failure details');
+      });
+
+      globalThis.HighlighterV2 = {
+        manager: { some: 'manager_state' },
+        rail: activeRail,
+      };
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(onRailReady).toHaveBeenCalledWith(activeRail);
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_ACTION_FAILED,
+      });
+    });
+
+    test('當建立 FloatingRail 失敗時，應清除 ready promise 且回傳 FLOATING_RAIL_INIT_FAILED 錯誤', async () => {
+      const sendResponse = jest.fn();
+      const onRailReady = jest.fn();
+
+      const mockManager = { some: 'manager_state' };
+      globalThis.HighlighterV2 = {
+        manager: mockManager,
+        rail: undefined,
+      };
+
+      mockInitialize.mockResolvedValue({ success: false, error: 'Init failed' });
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(mockInitialize).toHaveBeenCalled();
+      expect(globalThis.HighlighterV2.rail).toBeUndefined();
+      expect(onRailReady).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_INIT_FAILED,
+      });
+      expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
+    });
+
+    test('當 initialize 拋錯時，應清除 __NOTION_RAIL_READY__ 且回傳 FLOATING_RAIL_INIT_FAILED', async () => {
+      const sendResponse = jest.fn();
+      const onRailReady = jest.fn();
+
+      globalThis.HighlighterV2 = {
+        manager: { some: 'manager_state' },
+        rail: undefined,
+      };
+
+      mockInitialize.mockRejectedValue(new Error('initialize crashed'));
+
+      await withAvailableFloatingRail(sendResponse, onRailReady);
+
+      expect(mockInitialize).toHaveBeenCalled();
+      expect(globalThis.HighlighterV2.rail).toBeUndefined();
+      expect(onRailReady).not.toHaveBeenCalled();
+      expect(globalThis.__NOTION_RAIL_READY__).toBeUndefined();
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: RUNTIME_ERROR_MESSAGES.FLOATING_RAIL_INIT_FAILED,
+      });
+    });
+  });
+});

--- a/tests/native-esm/pages/options/options.native-esm.test.mjs
+++ b/tests/native-esm/pages/options/options.native-esm.test.mjs
@@ -139,6 +139,9 @@ const { AuthManager } = await import('../../../../pages/options/AuthManager.js')
 const { cleanDatabaseId, formatTitle, setupTemplatePreview } = await import(
   '../../../../pages/options/options.js'
 );
+const { SearchableDatabaseSelector } = await import(
+  '../../../../pages/options/SearchableDatabaseSelector.js'
+);
 
 beforeAll(() => {
   HTMLDialogElement.prototype.showModal = function showModal() {
@@ -288,5 +291,70 @@ describe('options page native ESM diagnostics', () => {
     expect(preview.querySelector('strong').textContent).toContain('預覽');
     expect(preview.textContent).toContain('範例網頁標題');
     expect(preview.textContent).toContain('example.com');
+  });
+});
+
+describe('SearchableDatabaseSelector native ESM tests', () => {
+  let selector = null;
+  let mockShowStatus = null;
+  let mockLoadDataSources = null;
+  let mockGetApiKey = null;
+
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+    document.body.innerHTML = `
+      <div id="database-selector-container" class="hidden">
+        <input type="text" id="database-search" />
+        <button id="selector-toggle"></button>
+        <div id="database-dropdown" class="hidden"></div>
+        <div id="data-source-list"></div>
+        <div id="data-source-count"></div>
+        <button id="refresh-databases"></button>
+      </div>
+      <input type="hidden" id="database-id" />
+      <input type="hidden" id="database-type" />
+    `;
+
+    mockShowStatus = jest.fn();
+    mockLoadDataSources = jest.fn();
+    mockGetApiKey = jest.fn().mockResolvedValue('mock_api_key');
+
+    selector = new SearchableDatabaseSelector({
+      showStatus: mockShowStatus,
+      loadDataSources: mockLoadDataSources,
+      getApiKey: mockGetApiKey,
+    });
+  });
+
+  test('constructor initializes element mappings', () => {
+    expect(selector.container).toBeTruthy();
+    expect(selector.searchInput).toBeTruthy();
+  });
+
+  test('populateDataSources handles basic database records and populates lists', () => {
+    const mockDatabases = [
+      { id: 'db1', object: 'database', title: [{ plain_text: 'DB One' }] },
+      { id: 'page1', object: 'page', properties: { title: { title: [{ plain_text: 'Page One' }] } } },
+    ];
+    selector.populateDataSources(mockDatabases);
+    expect(selector.dataSources).toHaveLength(2);
+    expect(selector.dataSourceList.children).toHaveLength(2);
+    expect(selector.dataSourceList.children[0].textContent).toContain('DB One');
+    expect(selector.dataSourceList.children[1].textContent).toContain('Page One');
+    expect(selector.searchInput.placeholder).toBe('搜尋保存目標...');
+  });
+
+  test('extractDataSourceTitle extracts various title structures safely', () => {
+    const pageDb = {
+      object: 'page',
+      properties: { title: { title: [{ plain_text: 'Page Title' }] } }
+    };
+    expect(SearchableDatabaseSelector.extractDataSourceTitle(pageDb)).toBe('Page Title');
+
+    const topDb = {
+      object: 'database',
+      title: [{ plain_text: 'Top DB' }]
+    };
+    expect(SearchableDatabaseSelector.extractDataSourceTitle(topDb)).toBe('Top DB');
   });
 });

--- a/tests/native-esm/utils/rootUtils.native-esm.test.mjs
+++ b/tests/native-esm/utils/rootUtils.native-esm.test.mjs
@@ -30,7 +30,7 @@ beforeAll(() => {
   // 模擬 DOM 與全域事件
   globalThis.addEventListener = jest.fn();
   globalThis.removeEventListener = jest.fn();
-  
+
   globalThis.document = {
     createElementNS: jest.fn().mockImplementation(() => ({
       classList: { add: jest.fn() },
@@ -53,7 +53,8 @@ beforeAll(() => {
 describe('Root utils native ESM diagnostics', () => {
   // 1. esm-safe-now pure utils tests
   test('accountDisplayUtils: resolveAccountDisplayProfile', async () => {
-    const { resolveAccountDisplayProfile } = await import('../../../scripts/utils/accountDisplayUtils.js');
+    const { resolveAccountDisplayProfile } =
+      await import('../../../scripts/utils/accountDisplayUtils.js');
     const result = resolveAccountDisplayProfile({
       email: 'test@example.com',
       displayName: ' Test User ',
@@ -68,7 +69,7 @@ describe('Root utils native ESM diagnostics', () => {
 
   test('concurrencyUtils: pMap limitConcurrency', async () => {
     const { pMap } = await import('../../../scripts/utils/concurrencyUtils.js');
-    const result = await pMap([1, 2, 3], async (x) => x * 2, { concurrency: 2 });
+    const result = await pMap([1, 2, 3], async x => x * 2, { concurrency: 2 });
     expect(result).toEqual([2, 4, 6]);
   });
 
@@ -87,13 +88,18 @@ describe('Root utils native ESM diagnostics', () => {
 
   test('temporaryImageUrl: isTemporaryImageUrl', async () => {
     const { isTemporaryImageUrl } = await import('../../../scripts/utils/temporaryImageUrl.js');
-    expect(isTemporaryImageUrl('https://sub.patreonusercontent.com/avatar?token-time=123')).toBe(true);
+    expect(isTemporaryImageUrl('https://sub.patreonusercontent.com/avatar?token-time=123')).toBe(
+      true
+    );
     expect(isTemporaryImageUrl('https://example.com/avatar')).toBe(false);
   });
 
   test('urlUtils: normalizeUrl', async () => {
-    const { normalizeUrl, hasSameOrigin, isRootUrl } = await import('../../../scripts/utils/urlUtils.js');
-    expect(normalizeUrl('https://example.com/page?utm_source=test')).toBe('https://example.com/page');
+    const { normalizeUrl, hasSameOrigin, isRootUrl } =
+      await import('../../../scripts/utils/urlUtils.js');
+    expect(normalizeUrl('https://example.com/page?utm_source=test')).toBe(
+      'https://example.com/page'
+    );
     expect(hasSameOrigin('https://example.com/a', 'https://example.com/b')).toBe(true);
     expect(isRootUrl('https://example.com')).toBe(true);
     expect(isRootUrl('https://example.com/page')).toBe(false);
@@ -135,23 +141,26 @@ describe('Root utils native ESM diagnostics', () => {
     const LoggerModule = await import('../../../scripts/utils/Logger.js');
     const Logger = LoggerModule.default;
     const { LogExporter } = await import('../../../scripts/utils/LogExporter.js');
-    
+
     const mockBuffer = {
-      getAll: () => [{ timestamp: '2026-06-26T12:00:00.000Z', level: 'info', message: 'Hello' }]
+      getAll: () => [{ timestamp: '2026-06-26T12:00:00.000Z', level: 'info', message: 'Hello' }],
     };
     const spy = jest.spyOn(Logger, 'getBuffer').mockReturnValue(mockBuffer);
-    
+
     const exportResult = LogExporter.exportLogs({ format: 'txt' });
     expect(exportResult.mimeType).toBe('text/plain');
     expect(exportResult.content).toContain('Hello');
-    
+
     spy.mockRestore();
   });
 
   test('LogSanitizer: maskSensitiveString & sanitizeUrlForLogging', async () => {
-    const { maskSensitiveString, sanitizeUrlForLogging } = await import('../../../scripts/utils/LogSanitizer.js');
+    const { maskSensitiveString, sanitizeUrlForLogging } =
+      await import('../../../scripts/utils/LogSanitizer.js');
     expect(maskSensitiveString('secret_token123', 0, 0)).toBe('***');
-    expect(sanitizeUrlForLogging('https://example.com/page?utm_source=123&token=abc')).toBe('https://example.com/page?token=[REDACTED_TOKEN]');
+    expect(sanitizeUrlForLogging('https://example.com/page?utm_source=123&token=abc')).toBe(
+      'https://example.com/page?token=[REDACTED_TOKEN]'
+    );
   });
 
   test('Logger: static methods and dispatching', async () => {
@@ -162,7 +171,7 @@ describe('Root utils native ESM diagnostics', () => {
   });
 
   test('notionAuth: ensureNotionApiKey & isNonEmptyString', async () => {
-    const { ensureNotionApiKey, isNonEmptyString } = await import('../../../scripts/utils/notionAuth.js');
+    const { isNonEmptyString } = await import('../../../scripts/utils/notionAuth.js');
     expect(isNonEmptyString('token')).toBe(true);
     expect(isNonEmptyString('')).toBe(false);
   });
@@ -173,7 +182,8 @@ describe('Root utils native ESM diagnostics', () => {
   });
 
   test('securityUtils: validateSafeSvg & separateIconAndText', async () => {
-    const { separateIconAndText, validateSafeSvg } = await import('../../../scripts/utils/securityUtils.js');
+    const { separateIconAndText, validateSafeSvg } =
+      await import('../../../scripts/utils/securityUtils.js');
     expect(separateIconAndText('🚀 Hello')).toEqual({ icon: '🚀', text: ' Hello' });
     expect(validateSafeSvg('<svg></svg>')).toBe(true);
   });
@@ -203,4 +213,3 @@ describe('Root utils native ESM diagnostics', () => {
     expect(result).toBe('success_data');
   });
 });
-

--- a/tests/native-esm/utils/rootUtils.native-esm.test.mjs
+++ b/tests/native-esm/utils/rootUtils.native-esm.test.mjs
@@ -1,0 +1,206 @@
+import { describe, expect, jest, test, beforeAll } from '@jest/globals';
+
+// 1. 在動態導入任何模組之前，先建立 global Mocks
+beforeAll(() => {
+  globalThis.chrome = {
+    runtime: {
+      id: 'test-extension-id',
+      sendMessage: jest.fn(),
+      getManifest: jest.fn().mockReturnValue({ version: '1.0.0' }),
+    },
+    alarms: {
+      onAlarm: {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      },
+      create: jest.fn(),
+      clear: jest.fn(),
+    },
+    storage: {
+      local: {
+        get: jest.fn().mockImplementation(() => Promise.resolve({})),
+        set: jest.fn().mockImplementation(() => Promise.resolve()),
+      },
+    },
+  };
+  globalThis.analytics = {
+    track: jest.fn(),
+  };
+
+  // 模擬 DOM 與全域事件
+  globalThis.addEventListener = jest.fn();
+  globalThis.removeEventListener = jest.fn();
+  
+  globalThis.document = {
+    createElementNS: jest.fn().mockImplementation(() => ({
+      classList: { add: jest.fn() },
+      setAttribute: jest.fn(),
+      append: jest.fn(),
+    })),
+    createElement: jest.fn().mockImplementation(() => ({
+      append: jest.fn(),
+    })),
+    body: {
+      append: jest.fn(),
+    },
+    addEventListener: jest.fn(),
+  };
+  globalThis.window = {
+    addEventListener: jest.fn(),
+  };
+});
+
+describe('Root utils native ESM diagnostics', () => {
+  // 1. esm-safe-now pure utils tests
+  test('accountDisplayUtils: resolveAccountDisplayProfile', async () => {
+    const { resolveAccountDisplayProfile } = await import('../../../scripts/utils/accountDisplayUtils.js');
+    const result = resolveAccountDisplayProfile({
+      email: 'test@example.com',
+      displayName: ' Test User ',
+    });
+    expect(result).toEqual({
+      normalizedDisplayName: 'Test User',
+      email: 'test@example.com',
+      displayLabel: 'Test User',
+      avatarFallbackInitial: 'T',
+    });
+  });
+
+  test('concurrencyUtils: pMap limitConcurrency', async () => {
+    const { pMap } = await import('../../../scripts/utils/concurrencyUtils.js');
+    const result = await pMap([1, 2, 3], async (x) => x * 2, { concurrency: 2 });
+    expect(result).toEqual([2, 4, 6]);
+  });
+
+  test('contentUtils: isTitleConsistent', async () => {
+    const { isTitleConsistent } = await import('../../../scripts/utils/contentUtils.js');
+    expect(isTitleConsistent('News Title', 'News Title | HK01')).toBe(true);
+    expect(isTitleConsistent('Short', 'Short Title')).toBe(true); // 太短直接放行
+  });
+
+  test('keyOrdering: compareKeysAlphabetically', async () => {
+    const { compareKeysAlphabetically } = await import('../../../scripts/utils/keyOrdering.js');
+    const list = ['key_b', 'key_a'];
+    list.sort(compareKeysAlphabetically);
+    expect(list).toEqual(['key_a', 'key_b']);
+  });
+
+  test('temporaryImageUrl: isTemporaryImageUrl', async () => {
+    const { isTemporaryImageUrl } = await import('../../../scripts/utils/temporaryImageUrl.js');
+    expect(isTemporaryImageUrl('https://sub.patreonusercontent.com/avatar?token-time=123')).toBe(true);
+    expect(isTemporaryImageUrl('https://example.com/avatar')).toBe(false);
+  });
+
+  test('urlUtils: normalizeUrl', async () => {
+    const { normalizeUrl, hasSameOrigin, isRootUrl } = await import('../../../scripts/utils/urlUtils.js');
+    expect(normalizeUrl('https://example.com/page?utm_source=test')).toBe('https://example.com/page');
+    expect(hasSameOrigin('https://example.com/a', 'https://example.com/b')).toBe(true);
+    expect(isRootUrl('https://example.com')).toBe(true);
+    expect(isRootUrl('https://example.com/page')).toBe(false);
+  });
+
+  test('ApiErrorSanitizer: sanitizeApiError', async () => {
+    const { sanitizeApiError } = await import('../../../scripts/utils/ApiErrorSanitizer.js');
+    const result = sanitizeApiError(new Error('something went wrong'), 'fetchDatabase');
+    expect(result).toBe('UNKNOWN_ERROR');
+  });
+
+  test('ErrorHandler: errors and AppError instantiation', async () => {
+    const { AppError, Errors } = await import('../../../scripts/utils/ErrorHandler.js');
+    const err = Errors.internal('Failed operation', { traceId: '123' });
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.message).toBe('Failed operation');
+  });
+
+  test('LogBuffer: basic push and properties', async () => {
+    const { LogBuffer } = await import('../../../scripts/utils/LogBuffer.js');
+    const buffer = new LogBuffer(10);
+    buffer.push({ message: 'log 1', level: 'info' });
+    const logs = buffer.getAll();
+    expect(logs.length).toBe(1);
+    expect(logs[0].message).toBe('log 1');
+  });
+
+  test('LogExportValidator: validateLogExportData', async () => {
+    const { validateLogExportData } = await import('../../../scripts/utils/LogExportValidator.js');
+    const validData = {
+      content: '[]',
+      filename: 'notion_chrome_logs_2026-06-26.json',
+      mimeType: 'application/json',
+    };
+    expect(() => validateLogExportData(validData)).not.toThrow();
+  });
+
+  test('LogExporter: plain text serialization', async () => {
+    const LoggerModule = await import('../../../scripts/utils/Logger.js');
+    const Logger = LoggerModule.default;
+    const { LogExporter } = await import('../../../scripts/utils/LogExporter.js');
+    
+    const mockBuffer = {
+      getAll: () => [{ timestamp: '2026-06-26T12:00:00.000Z', level: 'info', message: 'Hello' }]
+    };
+    const spy = jest.spyOn(Logger, 'getBuffer').mockReturnValue(mockBuffer);
+    
+    const exportResult = LogExporter.exportLogs({ format: 'txt' });
+    expect(exportResult.mimeType).toBe('text/plain');
+    expect(exportResult.content).toContain('Hello');
+    
+    spy.mockRestore();
+  });
+
+  test('LogSanitizer: maskSensitiveString & sanitizeUrlForLogging', async () => {
+    const { maskSensitiveString, sanitizeUrlForLogging } = await import('../../../scripts/utils/LogSanitizer.js');
+    expect(maskSensitiveString('secret_token123', 0, 0)).toBe('***');
+    expect(sanitizeUrlForLogging('https://example.com/page?utm_source=123&token=abc')).toBe('https://example.com/page?token=[REDACTED_TOKEN]');
+  });
+
+  test('Logger: static methods and dispatching', async () => {
+    const { default: Logger } = await import('../../../scripts/utils/Logger.js');
+    Logger.info('Info message');
+    Logger.warn('Warning message');
+    expect(Logger).toBeDefined();
+  });
+
+  test('notionAuth: ensureNotionApiKey & isNonEmptyString', async () => {
+    const { ensureNotionApiKey, isNonEmptyString } = await import('../../../scripts/utils/notionAuth.js');
+    expect(isNonEmptyString('token')).toBe(true);
+    expect(isNonEmptyString('')).toBe(false);
+  });
+
+  test('pageComplexityDetector: selectExtractor', async () => {
+    const { selectExtractor } = await import('../../../scripts/utils/pageComplexityDetector.js');
+    expect(selectExtractor).toBeDefined();
+  });
+
+  test('securityUtils: validateSafeSvg & separateIconAndText', async () => {
+    const { separateIconAndText, validateSafeSvg } = await import('../../../scripts/utils/securityUtils.js');
+    expect(separateIconAndText('🚀 Hello')).toEqual({ icon: '🚀', text: ' Hello' });
+    expect(validateSafeSvg('<svg></svg>')).toBe(true);
+  });
+
+  test('uiUtils: createSpriteIcon', async () => {
+    const { createSpriteIcon } = await import('../../../scripts/utils/uiUtils.js');
+    const icon = createSpriteIcon('save');
+    expect(icon).toBeDefined();
+  });
+
+  test('LogBufferPersistence: flush and restore', async () => {
+    const { LogBufferPersistence } = await import('../../../scripts/utils/LogBufferPersistence.js');
+    expect(LogBufferPersistence.flush).toBeDefined();
+    expect(LogBufferPersistence.restore).toBeDefined();
+  });
+
+  test('imageUtils: named exports availability', async () => {
+    const { cleanImageUrl, isValidImageUrl } = await import('../../../scripts/utils/imageUtils.js');
+    expect(cleanImageUrl).toBeDefined();
+    expect(isValidImageUrl).toBeDefined();
+  });
+
+  test('RetryManager: withRetry execution', async () => {
+    const { withRetry, RetryManager } = await import('../../../scripts/utils/RetryManager.js');
+    expect(RetryManager).toBeDefined();
+    const result = await withRetry(async () => 'success_data');
+    expect(result).toBe('success_data');
+  });
+});
+

--- a/tests/unit/config/workflowPolicyContract.test.js
+++ b/tests/unit/config/workflowPolicyContract.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-non-literal-fs-filename */
-const fs = require('node:fs');
-const path = require('node:path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const rootDir = path.resolve(__dirname, '../../..');
 const activeWorkflowDir = path.join(rootDir, '.github/workflows');

--- a/tests/unit/scripts/report-native-esm-threshold-simulation.test.js
+++ b/tests/unit/scripts/report-native-esm-threshold-simulation.test.js
@@ -250,7 +250,12 @@ describe('tools/report-native-esm-threshold-simulation', () => {
   });
 
   test('compareCoverageSummaries reports threshold parity and material native drift', () => {
-    const { gates, drift } = compareMaterialDriftCoverage(reporter, projectRoot);
+    const result = compareMaterialDriftCoverage(reporter, projectRoot);
+    const { gates, drift } = result;
+
+    expect(result.blockerLedger).toBeInstanceOf(Array);
+    expect(result.blockerLedger).toHaveLength(4);
+    expect(result.blockerLedger[0].path).toBe('scripts/background.js');
 
     expect(gates).toEqual(
       expect.arrayContaining([
@@ -372,6 +377,9 @@ describe('tools/report-native-esm-threshold-simulation', () => {
     expect(markdown).toContain('official-scope-parity');
     expect(markdown).toContain('native nonzero official 檔案數');
     expect(markdown).toContain('## Native Zero / Incumbent Nonzero');
+    expect(markdown).toContain('## Blocker Ledger');
+    expect(markdown).toContain('scripts/background.js');
+    expect(markdown).toContain('entrypoint-side-effect-boundary');
   });
 
   test('markdown summary renders missing thresholds as 不適用', () => {

--- a/tests/unit/utils/RetryManager.test.js
+++ b/tests/unit/utils/RetryManager.test.js
@@ -28,8 +28,12 @@ function evaluateRetryManagerWithoutModule(envOptions = {}) {
   sandbox.globalThis = sandbox;
   vm.createContext(sandbox);
 
+  const rawSource = fs.readFileSync(retryManagerSourcePath, 'utf8');
+  // 移除靜態 export 以防在 VM script 執行時報 SyntaxError
+  const filteredSource = rawSource.replaceAll(/export\s+\{[\s\S]*?\};/g, '');
+
   // eslint-disable-next-line sonarjs/code-eval -- Intentional VM execution of trusted local source for isolated global export testing.
-  vm.runInContext(fs.readFileSync(retryManagerSourcePath, 'utf8'), sandbox, {
+  vm.runInContext(filteredSource, sandbox, {
     filename: retryManagerSourcePath,
   });
 

--- a/tests/unit/utils/RetryManager.test.js
+++ b/tests/unit/utils/RetryManager.test.js
@@ -3,11 +3,11 @@
  * 覆蓋重試條件、Retry-After、AbortSignal、超時、jitter 注入、DOM context 與覆寫回應判斷。
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
 
-const { RetryManager, withRetry, fetchWithRetry } = require('../../../scripts/utils/RetryManager');
+import { RetryManager, withRetry, fetchWithRetry } from '../../../scripts/utils/RetryManager.js';
 
 const retryManagerSourcePath = path.resolve(__dirname, '../../../scripts/utils/RetryManager.js');
 

--- a/tools/report-native-esm-threshold-simulation-core.cjs
+++ b/tools/report-native-esm-threshold-simulation-core.cjs
@@ -12,6 +12,38 @@ const DEFAULT_ADAPTER_BASELINE = Object.freeze({
     'scripts/utils': 20,
   }),
 });
+
+const BLOCKER_LEDGER = Object.freeze([
+  {
+    path: 'scripts/background.js',
+    category: 'entrypoint-side-effect-boundary',
+    reason: '擴充套件背景服務進入點具有頂層副作用，無法在無完整瀏覽器/擴充套件環境下安全導入。',
+    expectedOwner: 'Browser Runtime',
+    conditionForRemoval: '重構進入點以延遲載入副作用，或建立穩定的 chrome 擴充套件執行期模擬。',
+  },
+  {
+    path: 'scripts/content/index.js',
+    category: 'entrypoint-side-effect-boundary',
+    reason: 'Content script 進入點具有頂層副作用，無法在無完整 DOM/擴充套件環境下安全導入。',
+    expectedOwner: 'Browser Runtime',
+    conditionForRemoval: '重構進入點以延遲載入副作用，或建立穩定的 DOM/JSDOM 執行期模擬。',
+  },
+  {
+    path: 'scripts/postinstall.js',
+    category: 'node-script-cjs-boundary',
+    reason: 'Node.js 生命週期腳本採用 CommonJS 撰寫，非原生 ESM 執行期診斷之對象。',
+    expectedOwner: 'Build Tooling',
+    conditionForRemoval: '專案全面遷移至 type: module 或替換 Node 生命週期腳本。',
+  },
+  {
+    path: 'scripts/background/handlers/saveHandlers.js',
+    category: 'high-complexity-mocking-blocker',
+    reason: '高複雜度請求/回應模擬阻礙（1500+ 行與 Notion API 互動的遺留 CJS 程式碼）。',
+    expectedOwner: 'Refactoring Owner',
+    conditionForRemoval: '將 Notion API 互動解耦為可模擬的 ESM 服務。',
+  },
+]);
+
 const REPORT_MESSAGES = Object.freeze({
   NO_DRIFT_ROW: '| 無 |  |  |  |',
   NO_NATIVE_ZERO_FILES: '沒有 native 0% 但 incumbent nonzero 的檔案。',
@@ -450,6 +482,7 @@ function compareCoverageSummaries({
       sourceLineSummary,
       baseline: adapterBaseline,
     }),
+    blockerLedger: BLOCKER_LEDGER,
     drift,
     scope: {
       incumbentOnlyFiles,
@@ -660,6 +693,12 @@ ${zeroGroupRows}
 ### Files
 
 ${zeroRows}
+
+## Blocker Ledger
+
+| 檔案路徑 | 阻礙類別 | 排除理由 | 預期所有權者 | 移除條件 |
+| --- | --- | --- | --- | --- |
+${summary.blockerLedger.map(blocker => `| \`${blocker.path}\` | \`${blocker.category}\` | ${escapeMarkdownTableCell(blocker.reason)} | \`${blocker.expectedOwner}\` | ${escapeMarkdownTableCell(blocker.conditionForRemoval)} |`).join('\n')}
 `;
 }
 


### PR DESCRIPTION
### 摘要
進行了原生 ESM 的測試清理，並引入了阻礙日誌機制以改善覆蓋率報告。

### 變更內容
- 將 CommonJS 模組轉換為原生 ESM 模組。
- 實施阻礙日誌以追蹤無法安全導入的進入點。
- 修復了測試中的 lint 錯誤，並清理了測試診斷。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

