### PR TITLE
refactor: 🧹 Remove Deprecated API Key Fallback in DataSourceManager

### DIFF
--- a/pages/options/DataSourceManager.js
+++ b/pages/options/DataSourceManager.js
@@ -80,9 +80,12 @@ export class DataSourceManager {
    * 建構資料來源管理器
    *
    * @param {object} uiManager - UI 管理器實例
-   * @param {Function|null} getApiKey - 取得 API Key 的函式（可選，用於依賴注入提升可測試性）
+   * @param {Function} getApiKey - 取得 API Key 的函式（必填）
    */
-  constructor(uiManager, getApiKey = null) {
+  constructor(uiManager, getApiKey) {
+    if (typeof getApiKey !== 'function') {
+      throw new TypeError('DataSourceManager 需要 getApiKey 函式');
+    }
     this.ui = uiManager;
     this.getApiKey = getApiKey;
     this.selector = null;
@@ -328,21 +331,10 @@ export class DataSourceManager {
       this.selector = new SearchableDatabaseSelector({
         showStatus: this.ui.showStatus.bind(this.ui),
         loadDataSources: this.loadDataSources.bind(this),
-        getApiKey: this.getApiKey || (() => this._fallbackGetApiKey()),
+        getApiKey: this.getApiKey,
       });
     }
     return this.selector;
-  }
-
-  /**
-   * 備用的 API Key 取得方式（Deprecated）
-   *
-   * @returns {string} API Key
-   * @private
-   */
-  _fallbackGetApiKey() {
-    Logger.warn('[DataSource] Fallback to DOM query for API Key (Deprecated)');
-    return document.querySelector('#api-key')?.value || '';
   }
 
   /**

--- a/tests/unit/options/DataSourceManager.test.js
+++ b/tests/unit/options/DataSourceManager.test.js
@@ -596,39 +596,14 @@ describe('DataSourceManager', () => {
       expect(constructorConfig.getApiKey()).toBe('custom-key');
     });
 
-    test('無注入 getApiKey 時，fallback 到 DOM 查詢（且有 API Key）', () => {
-      const manager = new DataSourceManager(mockUiManager, null);
+    test('無注入 getApiKey 時，應拋出 TypeError', () => {
+      expect(() => {
+        new DataSourceManager(mockUiManager, null);
+      }).toThrow(TypeError);
 
-      const input = document.createElement('input');
-      input.id = 'api-key';
-      input.value = 'dom-api-key';
-      document.body.append(input);
-
-      try {
-        const mockData = [{ id: 'db-1', object: 'database' }];
-        manager.populateDataSourceSelect(mockData);
-
-        expect(SearchableDatabaseSelectorMock).toHaveBeenCalledTimes(1);
-        const constructorConfig = SearchableDatabaseSelectorMock.mock.calls[0][0];
-
-        const apiKey = constructorConfig.getApiKey();
-        expect(apiKey).toBe('dom-api-key');
-        expect(Logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Fallback to DOM query for API Key')
-        );
-      } finally {
-        input.remove();
-      }
-    });
-
-    test('無注入 getApiKey 且 DOM 中無 #api-key 時，fallback 返回空字串', () => {
-      const manager = new DataSourceManager(mockUiManager, null);
-      const mockData = [{ id: 'db-1', object: 'database' }];
-      manager.populateDataSourceSelect(mockData);
-
-      const constructorConfig = SearchableDatabaseSelectorMock.mock.calls[0][0];
-      const apiKey = constructorConfig.getApiKey();
-      expect(apiKey).toBe('');
+      expect(() => {
+        new DataSourceManager(mockUiManager);
+      }).toThrow('DataSourceManager 需要 getApiKey 函式');
     });
 
     test.each([

--- a/tests/unit/options/DataSourceManager.test.js
+++ b/tests/unit/options/DataSourceManager.test.js
@@ -597,13 +597,11 @@ describe('DataSourceManager', () => {
     });
 
     test('無注入 getApiKey 時，應拋出 TypeError', () => {
-      expect(() => {
-        new DataSourceManager(mockUiManager, null);
-      }).toThrow(TypeError);
+      expect(() => new DataSourceManager(mockUiManager, null)).toThrow(TypeError);
 
-      expect(() => {
-        new DataSourceManager(mockUiManager);
-      }).toThrow('DataSourceManager 需要 getApiKey 函式');
+      expect(() => new DataSourceManager(mockUiManager)).toThrow(
+        'DataSourceManager 需要 getApiKey 函式'
+      );
     });
 
     test.each([


### PR DESCRIPTION
🎯 **What:** 
移除了 `DataSourceManager` 中被標記為 deprecated 的 `_fallbackGetApiKey` 備用 API Key 取得邏輯，並在 constructor 中強制要求傳入 `getApiKey` 函式。

💡 **Why:** 
原有的 fallback 邏輯會嘗試從 DOM 中查詢 API key，這部分屬於不再使用的舊代碼（legacy code）。將其移除並透過 constructor 參數（dependency injection）強制要求傳入 `getApiKey`，可以提升模組的可測試性與職責單一性，同時減少維護負擔。

✅ **Verification:** 
1. 執行並通過所有單元測試（包含替換 fallback 測試為 TypeError 拋出測試）。
2. 檢查了應用程式初始化代碼（`pages/options/options.js`），確認其實例化 `DataSourceManager` 時已正確傳入 `getApiKey` 函式。
3. 執行 ESLint 通過。

✨ **Result:** 
成功清理了不必要的舊版 fallback 邏輯，並提升了代碼的防禦性（防禦未提供 `getApiKey` 的情況）。代碼庫變得更加精簡與乾淨。

---
*PR created automatically by Jules for task [16110956465118358642](https://jules.google.com/task/16110956465118358642) started by @cowcfj*