### PR TITLE
test: clean up static analysis warnings

### DIFF
--- a/tests/e2e/specs/preloader.spec.js
+++ b/tests/e2e/specs/preloader.spec.js
@@ -30,6 +30,21 @@ test.describe('Preloader E2E Tests', () => {
     );
   };
 
+  const waitForPreloaderPing = async worker => {
+    let pingResult;
+    await expect
+      .poll(
+        async () => {
+          pingResult = await sendPreloaderMessage(worker, 'PING');
+          return pingResult.ok ? pingResult.response.status : pingResult.error;
+        },
+        { message: 'wait for preloader PING response' }
+      )
+      .toBe('preloader_only');
+
+    return pingResult;
+  };
+
   test('should initialize and respond to PING', async ({ page, context }) => {
     // 1. 導航到測試頁面
     await page.goto('https://example.com');
@@ -41,7 +56,7 @@ test.describe('Preloader E2E Tests', () => {
     }
 
     // 3. 通過 Service Worker 發送 PING 消息給 Content Script (Preloader)
-    const result = await sendPreloaderMessage(worker, 'PING');
+    const result = await waitForPreloaderPing(worker);
 
     // 驗證 Preloader 有回應且成功
     expect(result.ok).toBe(true);
@@ -58,11 +73,8 @@ test.describe('Preloader E2E Tests', () => {
       worker = await context.waitForEvent('serviceworker');
     }
 
-    // 2. 等待 Preloader 準備就緒
-    await page.waitForTimeout(500); // 給 preloader 時間初始化
-
-    // 3. 驗證 Preloader 已載入並響應
-    const pingResult = await sendPreloaderMessage(worker, 'PING');
+    // 2. 驗證 Preloader 已載入並響應
+    const pingResult = await waitForPreloaderPing(worker);
 
     if (!pingResult.ok || !pingResult.response.status) {
       test.skip(
@@ -71,19 +83,16 @@ test.describe('Preloader E2E Tests', () => {
       );
     }
 
-    // 4. 模擬按下 Ctrl+S（現在可以確保會被緩衝）
+    // 3. 模擬按下 Ctrl+S（現在可以確保會被緩衝）
     await page.keyboard.press('Control+s');
 
-    // 5. 給事件緩衝時間
-    await page.waitForTimeout(200);
-
-    // 6. 測試 INIT_BUNDLE 是否顯示有緩衝事件
+    // 4. 測試 INIT_BUNDLE 是否顯示有緩衝事件
     const initResult = await sendPreloaderMessage(worker, 'INIT_BUNDLE');
 
     expect(initResult.ok).toBe(true);
     expect(initResult.response.ready).toBe(true);
 
-    // 7. 測試 REPLAY_BUFFERED_EVENTS
+    // 5. 測試 REPLAY_BUFFERED_EVENTS
     const replayResult = await sendPreloaderMessage(worker, 'REPLAY_BUFFERED_EVENTS');
 
     expect(replayResult.ok).toBe(true);

--- a/tests/unit/content/converters/ConverterFactory.test.js
+++ b/tests/unit/content/converters/ConverterFactory.test.js
@@ -6,32 +6,12 @@ import { ConverterFactory } from '../../../../scripts/content/converters/Convert
 import { domConverter } from '../../../../scripts/content/converters/DomConverter.js';
 
 describe('ConverterFactory', () => {
-  test('should return domConverter for "markdown"', () => {
-    // Markdown now falls back to DomConverter or a specific handler
-    // But ConverterFactory just returns domConverter for everything now
-    const converter = ConverterFactory.getConverter('markdown');
-    expect(converter).toBe(domConverter);
-  });
-
-  test('should return domConverter for "md"', () => {
-    const converter = ConverterFactory.getConverter('md');
-    expect(converter).toBe(domConverter);
-  });
-
-  test('should return domConverter for "html"', () => {
-    const converter = ConverterFactory.getConverter('html');
-    expect(converter).toBe(domConverter);
-  });
-
-  test('should return domConverter for "dom"', () => {
-    const converter = ConverterFactory.getConverter('dom');
-    expect(converter).toBe(domConverter);
-  });
-
-  test('should return domConverter by default', () => {
-    const converter = ConverterFactory.getConverter('unknown');
-    expect(converter).toBe(domConverter);
-  });
+  test.each(['markdown', 'md', 'html', 'dom', 'unknown'])(
+    'should return domConverter for "%s"',
+    format => {
+      expect(ConverterFactory.getConverter(format)).toBe(domConverter);
+    }
+  );
 
   test('should return domConverter for null/undefined', () => {
     expect(ConverterFactory.getConverter(null)).toBe(domConverter);

--- a/tests/unit/content/converters/DomConverter.edge-cases.test.js
+++ b/tests/unit/content/converters/DomConverter.edge-cases.test.js
@@ -46,27 +46,12 @@ describe('DomConverter 覆蓋率補強', () => {
   });
 
   describe('initStrategies H4-H6 處理', () => {
-    test('H4 應該創建加粗段落', () => {
-      const html = '<h4>Heading 4</h4>';
-      const blocks = converter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].type).toBe('paragraph');
-      expect(blocks[0].paragraph.rich_text[0].annotations.bold).toBe(true);
-    });
-
-    test('H5 應該創建加粗段落', () => {
-      const html = '<h5>Heading 5</h5>';
-      const blocks = converter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].type).toBe('paragraph');
-      expect(blocks[0].paragraph.rich_text[0].annotations.bold).toBe(true);
-    });
-
-    test('H6 應該創建加粗段落', () => {
-      const html = '<h6>Heading 6</h6>';
-      const blocks = converter.convert(html);
+    test.each([
+      ['h4', 'Heading 4'],
+      ['h5', 'Heading 5'],
+      ['h6', 'Heading 6'],
+    ])('%s 應該創建加粗段落', (tagName, headingText) => {
+      const blocks = converter.convert(`<${tagName}>${headingText}</${tagName}>`);
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].type).toBe('paragraph');
@@ -273,25 +258,19 @@ describe('DomConverter 覆蓋率補強', () => {
   });
 
   describe('processInlineNode 樣式處理', () => {
-    test('U 和 INS 應該設置 underline', () => {
-      const html = '<p><u>Underline</u> <ins>Inserted</ins></p>';
+    test.each([
+      ['underline', '<p><u>Underline</u> <ins>Inserted</ins></p>', rt => rt.annotations.underline],
+      [
+        'strikethrough',
+        '<p><s>Strike</s> <del>Deleted</del></p>',
+        rt => rt.annotations.strikethrough,
+      ],
+      ['code', '<p><code>code</code> <kbd>kbd</kbd></p>', rt => rt.annotations.code],
+    ])('%s inline tags should set annotation', (_label, html, hasAnnotation) => {
       const blocks = converter.convert(html);
 
       expect(blocks).toHaveLength(1);
-    });
-
-    test('S, DEL, STRIKE 應該設置 strikethrough', () => {
-      const html = '<p><s>Strike</s> <del>Deleted</del></p>';
-      const blocks = converter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-    });
-
-    test('CODE, KBD, SAMP, TT 應該設置 code', () => {
-      const html = '<p><code>code</code> <kbd>kbd</kbd></p>';
-      const blocks = converter.convert(html);
-
-      expect(blocks).toHaveLength(1);
+      expect(blocks[0].paragraph.rich_text.some(richText => hasAnnotation(richText))).toBe(true);
     });
 
     test('A 標籤中的子節點應該繼承 link', () => {
@@ -302,19 +281,11 @@ describe('DomConverter 覆蓋率補強', () => {
       expect(blocks[0].paragraph.rich_text.some(rt => rt.text?.link?.url)).toBe(true);
     });
 
-    test('非安全協議 URL（如 javascript:）應該被忽略', () => {
-      // skipcq: JS-0087, JS-0096 -- 測試危險 URL 過濾功能
-      const jsUrl = 'javascript:void(0)';
-      const html = `<p><a href="${jsUrl}">Click me</a></p>`;
-      const blocks = converter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].paragraph.rich_text[0].text.link).toBeUndefined();
-    });
-
-    test('data: URL 應該被忽略', () => {
-      const html = '<p><a href="data:text/html,<script>alert(1)</script>">Click me</a></p>';
-      const blocks = converter.convert(html);
+    test.each([
+      ['javascript:', 'javascript:void(0)'], // skipcq: JS-0087, JS-0096 -- 測試危險 URL 過濾功能
+      ['data:', 'data:text/html,<script>alert(1)</script>'],
+    ])('%s URL 應該被忽略', (_label, url) => {
+      const blocks = converter.convert(`<p><a href="${url}">Click me</a></p>`);
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].paragraph.rich_text[0].text.link).toBeUndefined();

--- a/tests/unit/content/converters/DomConverter.test.js
+++ b/tests/unit/content/converters/DomConverter.test.js
@@ -89,42 +89,34 @@ describe('DomConverter', () => {
       expect(blocks).toHaveLength(0);
     });
 
-    test('preserves whitespace around inline formatting boundaries', () => {
-      const html = '<p>Hello <strong>world</strong> !</p>';
+    test.each([
+      [
+        'preserves whitespace around inline formatting boundaries',
+        '<p>Hello <strong>world</strong> !</p>',
+        'Hello world !',
+      ],
+      [
+        'preserves whitespace around links',
+        '<p>Read <a href="https://example.com">more</a> please</p>',
+        'Read more please',
+      ],
+      [
+        'preserves whitespace across multiple inline format switches',
+        '<p><em>A</em> <strong>B</strong> <code>C</code></p>',
+        'A B C',
+      ],
+      [
+        'still trims leading and trailing whitespace of entire block',
+        '<p>  Hello world  </p>',
+        'Hello world',
+      ],
+    ])('%s', (_description, html, expectedText) => {
       const blocks = domConverter.convert(html);
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].type).toBe('paragraph');
       expect(blocks[0].paragraph.rich_text.map(item => item.text.content).join('')).toBe(
-        'Hello world !'
-      );
-    });
-
-    test('preserves whitespace around links', () => {
-      const html = '<p>Read <a href="https://example.com">more</a> please</p>';
-      const blocks = domConverter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].paragraph.rich_text.map(item => item.text.content).join('')).toBe(
-        'Read more please'
-      );
-    });
-
-    test('preserves whitespace across multiple inline format switches', () => {
-      const html = '<p><em>A</em> <strong>B</strong> <code>C</code></p>';
-      const blocks = domConverter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].paragraph.rich_text.map(item => item.text.content).join('')).toBe('A B C');
-    });
-
-    test('still trims leading and trailing whitespace of entire block', () => {
-      const html = '<p>  Hello world  </p>';
-      const blocks = domConverter.convert(html);
-
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].paragraph.rich_text.map(item => item.text.content).join('')).toBe(
-        'Hello world'
+        expectedText
       );
     });
 
@@ -345,39 +337,38 @@ describe('DomConverter', () => {
   });
 
   describe('Long Text Handling', () => {
-    test('should truncate long LI text', () => {
-      const longText = 'A'.repeat(5200);
-      const html = `<ul><li>${longText}</li></ul>`;
-      const blocks = domConverter.convert(html);
+    test.each([
+      [
+        'should truncate long LI text',
+        text => `<ul><li>${text}</li></ul>`,
+        'A',
+        5200,
+        'bulleted_list_item',
+        block => block.bulleted_list_item.rich_text[0].text.content,
+      ],
+      [
+        'should truncate long BLOCKQUOTE text',
+        text => `<blockquote>${text}</blockquote>`,
+        'B',
+        4500,
+        'quote',
+        block => block.quote.rich_text[0].text.content,
+      ],
+      [
+        'should truncate long paragraph text',
+        text => `<p>${text}</p>`,
+        'C',
+        4000,
+        'paragraph',
+        block => block.paragraph.rich_text[0].text.content,
+      ],
+    ])('%s', (_description, buildHtml, repeatedChar, length, expectedType, getContent) => {
+      const blocks = domConverter.convert(buildHtml(repeatedChar.repeat(length)));
 
       // DomConverter truncates instead of splitting
       expect(blocks).toHaveLength(1);
-      expect(blocks[0].type).toBe('bulleted_list_item');
-      expect(blocks[0].bulleted_list_item.rich_text[0].text.content.length).toBeLessThanOrEqual(
-        2000
-      );
-    });
-
-    test('should truncate long BLOCKQUOTE text', () => {
-      const longText = 'B'.repeat(4500);
-      const html = `<blockquote>${longText}</blockquote>`;
-      const blocks = domConverter.convert(html);
-
-      // DomConverter truncates instead of splitting
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].type).toBe('quote');
-      expect(blocks[0].quote.rich_text[0].text.content.length).toBeLessThanOrEqual(2000);
-    });
-
-    test('should truncate long paragraph text', () => {
-      const longText = 'C'.repeat(4000);
-      const html = `<p>${longText}</p>`;
-      const blocks = domConverter.convert(html);
-
-      // DomConverter truncates instead of splitting
-      expect(blocks).toHaveLength(1);
-      expect(blocks[0].type).toBe('paragraph');
-      expect(blocks[0].paragraph.rich_text[0].text.content.length).toBeLessThanOrEqual(2000);
+      expect(blocks[0].type).toBe(expectedType);
+      expect(getContent(blocks[0]).length).toBeLessThanOrEqual(2000);
     });
 
     test('should not split text under 2000 characters', () => {

--- a/tests/unit/content/converters/DomConverter.test.js
+++ b/tests/unit/content/converters/DomConverter.test.js
@@ -338,31 +338,31 @@ describe('DomConverter', () => {
 
   describe('Long Text Handling', () => {
     test.each([
-      [
-        'should truncate long LI text',
-        text => `<ul><li>${text}</li></ul>`,
-        'A',
-        5200,
-        'bulleted_list_item',
-        block => block.bulleted_list_item.rich_text[0].text.content,
-      ],
-      [
-        'should truncate long BLOCKQUOTE text',
-        text => `<blockquote>${text}</blockquote>`,
-        'B',
-        4500,
-        'quote',
-        block => block.quote.rich_text[0].text.content,
-      ],
-      [
-        'should truncate long paragraph text',
-        text => `<p>${text}</p>`,
-        'C',
-        4000,
-        'paragraph',
-        block => block.paragraph.rich_text[0].text.content,
-      ],
-    ])('%s', (_description, buildHtml, repeatedChar, length, expectedType, getContent) => {
+      {
+        name: 'should truncate long LI text',
+        buildHtml: text => `<ul><li>${text}</li></ul>`,
+        repeatedChar: 'A',
+        length: 5200,
+        expectedType: 'bulleted_list_item',
+        getContent: block => block.bulleted_list_item.rich_text[0].text.content,
+      },
+      {
+        name: 'should truncate long BLOCKQUOTE text',
+        buildHtml: text => `<blockquote>${text}</blockquote>`,
+        repeatedChar: 'B',
+        length: 4500,
+        expectedType: 'quote',
+        getContent: block => block.quote.rich_text[0].text.content,
+      },
+      {
+        name: 'should truncate long paragraph text',
+        buildHtml: text => `<p>${text}</p>`,
+        repeatedChar: 'C',
+        length: 4000,
+        expectedType: 'paragraph',
+        getContent: block => block.paragraph.rich_text[0].text.content,
+      },
+    ])('$name', ({ buildHtml, repeatedChar, length, expectedType, getContent }) => {
       const blocks = domConverter.convert(buildHtml(repeatedChar.repeat(length)));
 
       // DomConverter truncates instead of splitting

--- a/tests/unit/content/extractors/NextJsExtractor.blocks.test.js
+++ b/tests/unit/content/extractors/NextJsExtractor.blocks.test.js
@@ -295,18 +295,27 @@ describe('NextJsExtractor Block Conversion', () => {
       expect(output[0].heading_1.rich_text[0].text.content).toBe('Title Italic');
     });
 
-    it('should strip script tags from content', () => {
-      const input = [{ blockType: 'paragraph', text: '<script>alert("xss")</script>Hello' }];
+    it.each([
+      {
+        name: 'script tags',
+        text: '<script>alert("xss")</script>Hello',
+        expectedContent: 'Hello',
+      },
+      {
+        name: 'style tags',
+        text: '<style>body { color: red; }</style>Hello',
+        expectedContent: 'Hello',
+      },
+      {
+        name: 'paragraph HTML',
+        text: '<p>Hello <b>World</b></p>',
+        expectedContent: 'Hello World',
+      },
+    ])('should strip $name from paragraph content', ({ text, expectedContent }) => {
+      const input = [{ blockType: 'paragraph', text }];
       const output = NextJsExtractor.convertBlocks(input);
       expect(output[0].type).toBe('paragraph');
-      expect(output[0].paragraph.rich_text[0].text.content).toBe('Hello');
-    });
-
-    it('should strip style tags from content', () => {
-      const input = [{ blockType: 'paragraph', text: '<style>body { color: red; }</style>Hello' }];
-      const output = NextJsExtractor.convertBlocks(input);
-      expect(output[0].type).toBe('paragraph');
-      expect(output[0].paragraph.rich_text[0].text.content).toBe('Hello');
+      expect(output[0].paragraph.rich_text[0].text.content).toBe(expectedContent);
     });
 
     it('should strip HTML from quote blocks', () => {
@@ -314,13 +323,6 @@ describe('NextJsExtractor Block Conversion', () => {
       const output = NextJsExtractor.convertBlocks(input);
       expect(output[0].type).toBe('quote');
       expect(output[0].quote.rich_text[0].text.content).toBe('Quote Bold');
-    });
-
-    it('should strip HTML from paragraph text', () => {
-      const input = [{ blockType: 'paragraph', text: '<p>Hello <b>World</b></p>' }];
-      const output = NextJsExtractor.convertBlocks(input);
-      expect(output[0].type).toBe('paragraph');
-      expect(output[0].paragraph.rich_text[0].text.content).toBe('Hello World');
     });
 
     it('should filter out images without URL', () => {

--- a/tests/unit/content/extractors/ReadabilityAdapter.test.js
+++ b/tests/unit/content/extractors/ReadabilityAdapter.test.js
@@ -752,62 +752,62 @@ describe('ReadabilityAdapter - prepareLazyImages', () => {
 
   // [HK01 懶加載修復] CSS opacity-0 容器測試
   test.each([
-    [
-      '應該移除含有 img 的 opacity-0 容器的 opacity-0 class',
-      `<html><body>
+    {
+      name: '應該移除含有 img 的 opacity-0 容器的 opacity-0 class',
+      html: `<html><body>
         <div class="opacity-0 wrapper">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      '.wrapper',
-      container => expect(container.classList.contains('opacity-0')).toBe(false),
-      null,
-    ],
-    [
-      '應該移除含有 img 的 lazyload-* class 容器',
-      `<html><body>
+      selector: '.wrapper',
+      assertContainerState: container =>
+        expect(container.classList.contains('opacity-0')).toBe(false),
+    },
+    {
+      name: '應該移除含有 img 的 lazyload-* class 容器',
+      html: `<html><body>
         <div class="lazyload-wrapper">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      '.lazyload-wrapper',
-      container => expect(container.classList.contains('lazyload-wrapper')).toBe(false),
-      1,
-    ],
-    [
-      '應該只在實際修改 DOM 時移除 lazyload 與可見性樣式並計數',
-      `<html><body>
+      selector: '.lazyload-wrapper',
+      assertContainerState: container =>
+        expect(container.classList.contains('lazyload-wrapper')).toBe(false),
+      expectedCount: 1,
+    },
+    {
+      name: '應該只在實際修改 DOM 時移除 lazyload 與可見性樣式並計數',
+      html: `<html><body>
         <div class="lazyload hero" style="opacity: 0; visibility: hidden;">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      '.hero',
-      container => {
+      selector: '.hero',
+      assertContainerState: container => {
         expect(container.classList.contains('lazyload')).toBe(false);
         expect(container.style.opacity).toBe('');
         expect(container.style.visibility).toBe('');
       },
-      1,
-    ],
-    [
-      '不含 img 的 opacity-0 元素不應被修改（保護非圖片動畫）',
-      `<html><body>
+      expectedCount: 1,
+    },
+    {
+      name: '不含 img 的 opacity-0 元素不應被修改（保護非圖片動畫）',
+      html: `<html><body>
         <div class="opacity-0 fade-in-element">
           <span>動畫文字</span>
         </div>
       </body></html>`,
-      '.fade-in-element',
-      element => expect(element.classList.contains('opacity-0')).toBe(true),
-      null,
-    ],
-  ])('%s', (_description, html, selector, expectContainerState, expectedCount) => {
+      selector: '.fade-in-element',
+      assertContainerState: element => expect(element.classList.contains('opacity-0')).toBe(true),
+    },
+  ])('$name', ({ html, selector, assertContainerState, expectedCount }) => {
     expect.hasAssertions();
     const doc = parseTestDocument(html);
     const container = doc.querySelector(selector);
     const count = prepareLazyImages(doc);
 
-    expectContainerState(container);
-    if (expectedCount !== null) {
+    assertContainerState(container);
+    if (expectedCount !== undefined) {
       expect(count).toBe(expectedCount);
     }
   });

--- a/tests/unit/content/extractors/ReadabilityAdapter.test.js
+++ b/tests/unit/content/extractors/ReadabilityAdapter.test.js
@@ -60,6 +60,15 @@ beforeAll(async () => {
   } = await import('../../../../scripts/content/extractors/ReadabilityAdapter.js'));
 });
 
+const parseTestDocument = html => new DOMParser().parseFromString(html, 'text/html');
+
+const buildContentQualityHtml = ({ textLength, linkLength = 0, listItemCount = 0 }) => {
+  const text = `<p>${'a'.repeat(textLength)}</p>`;
+  const links = linkLength > 0 ? `<a href="#">${'a'.repeat(linkLength)}</a>` : '';
+  const listItems = listItemCount > 0 ? `<ul>${'<li>item</li>'.repeat(listItemCount)}</ul>` : '';
+  return text + links + listItems;
+};
+
 // ... (existing code)
 
 describe('ReadabilityAdapter - expandCollapsibleElements', () => {
@@ -202,128 +211,86 @@ describe('ReadabilityAdapter - isContentGood', () => {
   });
 
   describe('內容長度檢查', () => {
-    test('應該拒絕長度不足 250 字符的內容', () => {
-      const content = 'a'.repeat(249);
-      const result = isContentGood({ content });
-      expect(result).toBe(false);
-      expect(Logger.warn).toHaveBeenCalledWith(
-        '內容長度不足',
-        expect.objectContaining({ action: 'isContentGood' })
-      );
-    });
-
-    test('應該接受長度剛好 250 字符的內容', () => {
-      const content = `<p>${'a'.repeat(250)}</p>`;
-      const result = isContentGood({ content });
-      expect(result).toBe(true);
-    });
-
-    test('應該接受長度超過 250 字符的內容', () => {
-      const content = `<p>${'a'.repeat(500)}</p>`;
-      const result = isContentGood({ content });
-      expect(result).toBe(true);
+    test.each([
+      ['應該拒絕長度不足 250 字符的內容', 'a'.repeat(249), false, '內容長度不足'],
+      ['應該接受長度剛好 250 字符的內容', `<p>${'a'.repeat(250)}</p>`, true, null],
+      ['應該接受長度超過 250 字符的內容', `<p>${'a'.repeat(500)}</p>`, true, null],
+    ])('%s', (_description, content, expectedResult, expectedWarning) => {
+      expect(isContentGood({ content })).toBe(expectedResult);
+      if (expectedWarning) {
+        expect(Logger.warn).toHaveBeenCalledWith(
+          expectedWarning,
+          expect.objectContaining({ action: 'isContentGood' })
+        );
+      }
     });
   });
 
   describe('鏈接密度檢查', () => {
-    test('應該接受低鏈接密度的內容', () => {
-      // 創建真實的 DOM 結構：10% 鏈接密度
-      const content = `<p>${'a'.repeat(900)}</p><a href="#">${'a'.repeat(100)}</a>`;
-
-      const result = isContentGood({ content });
-      // 鏈接密度 = 100 / 1000 = 0.1 < 0.3，應該接受
-      expect(result).toBe(true);
-    });
-
-    test('應該拒絕高鏈接密度的內容（列表項少於 8 個）', () => {
-      // 創建真實的 DOM 結構：35% 鏈接密度，5 個列表項
-      const links = `<a href="#">${'a'.repeat(350)}</a>`;
-      const listItems = `<ul>${'<li>item</li>'.repeat(5)}</ul>`;
-      const text = `<p>${'a'.repeat(650)}</p>`;
-      const content = text + links + listItems;
-
-      const result = isContentGood({ content });
-      // 鏈接密度 = 350 / 1000+ = 0.35 > 0.3，且 liCount = 5 < 8
-      expect(result).toBe(false);
-      expect(Logger.log).toHaveBeenCalledWith(
+    test.each([
+      [
+        '應該接受低鏈接密度的內容',
+        buildContentQualityHtml({ textLength: 900, linkLength: 100 }),
+        true,
+        null,
+      ],
+      [
+        '應該拒絕高鏈接密度的內容（列表項少於 8 個）',
+        buildContentQualityHtml({ textLength: 650, linkLength: 350, listItemCount: 5 }),
+        false,
         '內容因鏈接密度過高被拒絕',
-        expect.objectContaining({ action: 'isContentGood' })
-      );
-    });
-
-    test('應該正確處理沒有 textContent 的鏈接', () => {
-      // 創建真實的 DOM 結構：空鏈接
-      const content = `<p>${'a'.repeat(1000)}</p><a href="#"></a><a href="#"></a>`;
-
-      const result = isContentGood({ content });
-      // 鏈接密度 = 0，應該接受
-      expect(result).toBe(true);
+      ],
+      [
+        '應該正確處理沒有 textContent 的鏈接',
+        `<p>${'a'.repeat(1000)}</p><a href="#"></a><a href="#"></a>`,
+        true,
+        null,
+      ],
+    ])('%s', (_description, content, expectedResult, expectedLog) => {
+      expect(isContentGood({ content })).toBe(expectedResult);
+      if (expectedLog) {
+        expect(Logger.log).toHaveBeenCalledWith(
+          expectedLog,
+          expect.objectContaining({ action: 'isContentGood' })
+        );
+      }
     });
   });
 
   describe('列表項例外處理', () => {
-    test('應該接受低鏈接密度的內容（即使列表項少於 8 個）', () => {
-      // 創建真實的 DOM 結構：10% 鏈接密度，5 個列表項
-      const links = `<a href="#">${'a'.repeat(100)}</a>`;
-      const listItems = `<ul>${'<li>item</li>'.repeat(5)}</ul>`;
-      const text = `<p>${'a'.repeat(900)}</p>`;
-      const content = text + links + listItems;
-
-      const result = isContentGood({ content });
-      // 鏈接密度 = 100 / 1000+ = 0.1 < 0.3，應該接受
-      expect(result).toBe(true);
-    });
-
-    test('應該接受 8 個或更多列表項的內容（即使高鏈接密度）', () => {
-      // 創建真實的 DOM 結構：40% 鏈接密度，8 個列表項
-      const links = `<a href="#">${'a'.repeat(400)}</a>`;
-      const listItems = `<ul>${'<li>item</li>'.repeat(8)}</ul>`;
-      const text = `<p>${'a'.repeat(600)}</p>`;
-      const content = text + links + listItems;
-
-      const result = isContentGood({ content });
-      // 鏈接密度 = 400 / 1000+ = 0.4 > 0.3，但有 8 個 li >= 8（例外）
-      expect(result).toBe(true);
-      expect(Logger.log).toHaveBeenCalledWith(
-        '內容被判定為有效清單',
-        expect.objectContaining({ action: 'isContentGood' })
-      );
-    });
-
-    test('應該接受 10 個列表項的內容', () => {
-      // 創建真實的 DOM 結構：60% 鏈接密度，10 個列表項
-      const links = `<a href="#">${'a'.repeat(600)}</a>`;
-      const listItems = `<ul>${'<li>item</li>'.repeat(10)}</ul>`;
-      const text = `<p>${'a'.repeat(400)}</p>`;
-      const content = text + links + listItems;
-
-      const result = isContentGood({ content });
-      // 即使鏈接密度 = 600 / 1000+ = 0.6 > 0.3，但有 10 個 li >= 8
-      expect(result).toBe(true);
-      expect(Logger.log).toHaveBeenCalledWith(
-        '內容被判定為有效清單',
-        expect.objectContaining({ action: 'isContentGood' })
-      );
+    test.each([
+      [
+        '應該接受低鏈接密度的內容（即使列表項少於 8 個）',
+        buildContentQualityHtml({ textLength: 900, linkLength: 100, listItemCount: 5 }),
+        false,
+      ],
+      [
+        '應該接受 8 個或更多列表項的內容（即使高鏈接密度）',
+        buildContentQualityHtml({ textLength: 600, linkLength: 400, listItemCount: 8 }),
+        true,
+      ],
+      [
+        '應該接受 10 個列表項的內容',
+        buildContentQualityHtml({ textLength: 400, linkLength: 600, listItemCount: 10 }),
+        true,
+      ],
+    ])('%s', (_description, content, expectsValidListLog) => {
+      expect(isContentGood({ content })).toBe(true);
+      if (expectsValidListLog) {
+        expect(Logger.log).toHaveBeenCalledWith(
+          '內容被判定為有效清單',
+          expect.objectContaining({ action: 'isContentGood' })
+        );
+      }
     });
   });
 
   describe('正常內容場景', () => {
-    test('應該接受質量良好的正常文章', () => {
-      // 創建真實的 DOM 結構：5% 鏈接密度
-      const content = `<p>${'a'.repeat(950)}</p><a href="#">${'a'.repeat(50)}</a>`;
-
-      const result = isContentGood({ content });
-      // 長度 = 1000 >= 250，鏈接密度 = 0.05 < 0.3
-      expect(result).toBe(true);
-    });
-
-    test('應該接受包含少量鏈接的文章', () => {
-      // 創建真實的 DOM 結構：20% 鏈接密度
-      const content = `<p>${'a'.repeat(800)}</p><a href="#">${'a'.repeat(200)}</a>`;
-
-      const result = isContentGood({ content });
-      // 長度 = 1000，鏈接密度 = 0.2 < 0.3
-      expect(result).toBe(true);
+    test.each([
+      ['應該接受質量良好的正常文章', buildContentQualityHtml({ textLength: 950, linkLength: 50 })],
+      ['應該接受包含少量鏈接的文章', buildContentQualityHtml({ textLength: 800, linkLength: 200 })],
+    ])('%s', (_description, content) => {
+      expect(isContentGood({ content })).toBe(true);
     });
   });
 
@@ -679,44 +646,33 @@ describe('ReadabilityAdapter - parseArticleWithReadability', () => {
 });
 
 describe('ReadabilityAdapter - prepareLazyImages', () => {
-  test('應該將 data-src 寫入空 src 的圖片', () => {
-    const doc = new DOMParser().parseFromString(
+  test.each([
+    [
+      '應該將 data-src 寫入空 src 的圖片',
       '<html><body><img data-src="https://example.com/photo.jpg" src=""></body></html>',
-      'text/html'
-    );
-    const count = prepareLazyImages(doc);
-    expect(count).toBe(1);
-    expect(doc.querySelector('img').getAttribute('src')).toBe('https://example.com/photo.jpg');
-  });
-
-  test('應該處理 data: 佔位符 src', () => {
-    const doc = new DOMParser().parseFromString(
+      'https://example.com/photo.jpg',
+    ],
+    [
+      '應該處理 data: 佔位符 src',
       '<html><body><img data-src="https://example.com/real.jpg" src="data:image/gif;base64,R0lGODlhAQABAIA"></body></html>',
-      'text/html'
-    );
-    const count = prepareLazyImages(doc);
-    expect(count).toBe(1);
-    expect(doc.querySelector('img').getAttribute('src')).toBe('https://example.com/real.jpg');
-  });
-
-  test('應該處理包含 loading 佔位符的 src', () => {
-    const doc = new DOMParser().parseFromString(
+      'https://example.com/real.jpg',
+    ],
+    [
+      '應該處理包含 loading 佔位符的 src',
       '<html><body><img data-src="https://example.com/real.jpg" src="/images/loading.gif"></body></html>',
-      'text/html'
-    );
-    const count = prepareLazyImages(doc);
-    expect(count).toBe(1);
-    expect(doc.querySelector('img').getAttribute('src')).toBe('https://example.com/real.jpg');
-  });
-
-  test('應該覆蓋已有有效 src 的圖片如果 data-src 存在且不同', () => {
-    const doc = new DOMParser().parseFromString(
+      'https://example.com/real.jpg',
+    ],
+    [
+      '應該覆蓋已有有效 src 的圖片如果 data-src 存在且不同',
       '<html><body><img src="https://example.com/valid.jpg" data-src="https://example.com/other.jpg"></body></html>',
-      'text/html'
-    );
+      'https://example.com/other.jpg',
+    ],
+  ])('%s', (_description, html, expectedSrc) => {
+    const doc = parseTestDocument(html);
     const count = prepareLazyImages(doc);
+
     expect(count).toBe(1);
-    expect(doc.querySelector('img').getAttribute('src')).toBe('https://example.com/other.jpg');
+    expect(doc.querySelector('img').getAttribute('src')).toBe(expectedSrc);
   });
 
   // ... (保留 data-lazy-src 測試) ...
@@ -735,31 +691,26 @@ describe('ReadabilityAdapter - prepareLazyImages', () => {
     expect(count).toBe(2);
   });
 
-  test('應該處理 source 元素的 data-srcset', () => {
-    const doc = new DOMParser().parseFromString(
+  test.each([
+    [
+      '應該處理 source 元素的 data-srcset',
       '<html><body><picture><source data-srcset="img.webp"></picture></body></html>',
-      'text/html'
-    );
-    prepareLazyImages(doc);
-    expect(doc.querySelector('source').getAttribute('srcset')).toBe('img.webp');
-  });
-
-  test('應該覆蓋已有 srcset 的 source 元素如果 data-srcset 存在且不同', () => {
-    const doc = new DOMParser().parseFromString(
+      'img.webp',
+    ],
+    [
+      '應該覆蓋已有 srcset 的 source 元素如果 data-srcset 存在且不同',
       '<html><body><picture><source srcset="existing.webp" data-srcset="other.webp"></picture></body></html>',
-      'text/html'
-    );
-    prepareLazyImages(doc);
-    expect(doc.querySelector('source').getAttribute('srcset')).toBe('other.webp');
-  });
-
-  test('應該處理 source 元素的 data-lazy-srcset', () => {
-    const doc = new DOMParser().parseFromString(
+      'other.webp',
+    ],
+    [
+      '應該處理 source 元素的 data-lazy-srcset',
       '<html><body><picture><source data-lazy-srcset="lazy.webp"></picture></body></html>',
-      'text/html'
-    );
+      'lazy.webp',
+    ],
+  ])('%s', (_description, html, expectedSrcset) => {
+    const doc = parseTestDocument(html);
     prepareLazyImages(doc);
-    expect(doc.querySelector('source').getAttribute('srcset')).toBe('lazy.webp');
+    expect(doc.querySelector('source').getAttribute('srcset')).toBe(expectedSrcset);
   });
 
   test('應該正確處理 data-srcset 屬性並提取第一個 URL 作為 src', () => {
@@ -800,75 +751,65 @@ describe('ReadabilityAdapter - prepareLazyImages', () => {
   });
 
   // [HK01 懶加載修復] CSS opacity-0 容器測試
-  test('應該移除含有 img 的 opacity-0 容器的 opacity-0 class', () => {
-    const doc = new DOMParser().parseFromString(
+  test.each([
+    [
+      '應該移除含有 img 的 opacity-0 容器的 opacity-0 class',
       `<html><body>
         <div class="opacity-0 wrapper">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      'text/html'
-    );
-    const container = doc.querySelector('.wrapper');
-    expect(container.classList.contains('opacity-0')).toBe(true);
-
-    prepareLazyImages(doc);
-
-    expect(container.classList.contains('opacity-0')).toBe(false);
-  });
-
-  test('應該移除含有 img 的 lazyload-* class 容器', () => {
-    const doc = new DOMParser().parseFromString(
+      '.wrapper',
+      container => expect(container.classList.contains('opacity-0')).toBe(false),
+      null,
+    ],
+    [
+      '應該移除含有 img 的 lazyload-* class 容器',
       `<html><body>
         <div class="lazyload-wrapper">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      'text/html'
-    );
-    const container = doc.querySelector('.lazyload-wrapper');
-
-    const count = prepareLazyImages(doc);
-
-    expect(container.classList.contains('lazyload-wrapper')).toBe(false);
-    expect(count).toBe(1);
-  });
-
-  test('應該只在實際修改 DOM 時移除 lazyload 與可見性樣式並計數', () => {
-    const doc = new DOMParser().parseFromString(
+      '.lazyload-wrapper',
+      container => expect(container.classList.contains('lazyload-wrapper')).toBe(false),
+      1,
+    ],
+    [
+      '應該只在實際修改 DOM 時移除 lazyload 與可見性樣式並計數',
       `<html><body>
         <div class="lazyload hero" style="opacity: 0; visibility: hidden;">
           <img src="https://example.com/photo.jpg">
         </div>
       </body></html>`,
-      'text/html'
-    );
-    const container = doc.querySelector('.hero');
-
-    const count = prepareLazyImages(doc);
-
-    expect(container.classList.contains('lazyload')).toBe(false);
-    expect(container.style.opacity).toBe('');
-    expect(container.style.visibility).toBe('');
-    expect(count).toBe(1);
-  });
-
-  test('不含 img 的 opacity-0 元素不應被修改（保護非圖片動畫）', () => {
-    const doc = new DOMParser().parseFromString(
+      '.hero',
+      container => {
+        expect(container.classList.contains('lazyload')).toBe(false);
+        expect(container.style.opacity).toBe('');
+        expect(container.style.visibility).toBe('');
+      },
+      1,
+    ],
+    [
+      '不含 img 的 opacity-0 元素不應被修改（保護非圖片動畫）',
       `<html><body>
         <div class="opacity-0 fade-in-element">
           <span>動畫文字</span>
         </div>
       </body></html>`,
-      'text/html'
-    );
-    const element = doc.querySelector('.fade-in-element');
-    expect(element.classList.contains('opacity-0')).toBe(true);
+      '.fade-in-element',
+      element => expect(element.classList.contains('opacity-0')).toBe(true),
+      null,
+    ],
+  ])('%s', (_description, html, selector, expectContainerState, expectedCount) => {
+    expect.hasAssertions();
+    const doc = parseTestDocument(html);
+    const container = doc.querySelector(selector);
+    const count = prepareLazyImages(doc);
 
-    prepareLazyImages(doc);
-
-    // 不含 img，不應修改
-    expect(element.classList.contains('opacity-0')).toBe(true);
+    expectContainerState(container);
+    if (expectedCount !== null) {
+      expect(count).toBe(expectedCount);
+    }
   });
 });
 
@@ -879,25 +820,29 @@ describe('ReadabilityAdapter - detectCMS Coverage', () => {
     document.body.className = '';
   });
 
-  test('should detect CMS by meta signal', () => {
-    document.head.innerHTML = '<meta name="generator" content="WordPress 6.0">';
+  test.each([
+    [
+      'should detect CMS by meta signal',
+      () => {
+        document.head.innerHTML = '<meta name="generator" content="WordPress 6.0">';
+      },
+      'meta',
+    ],
+    [
+      'should detect CMS by class signal',
+      () => {
+        document.body.className = 'wordpress-theme';
+      },
+      'class',
+    ],
+  ])('%s', (_description, arrangeSignal, expectedSignal) => {
+    arrangeSignal();
 
     expect(detectCMS()).toBe('wordpress');
     expect(Logger.log).toHaveBeenCalledWith('檢測到 CMS', {
       action: 'detectCMS',
       type: 'wordpress',
-      signal: 'meta',
-    });
-  });
-
-  test('should detect CMS by class signal', () => {
-    document.body.className = 'wordpress-theme';
-
-    expect(detectCMS()).toBe('wordpress');
-    expect(Logger.log).toHaveBeenCalledWith('檢測到 CMS', {
-      action: 'detectCMS',
-      type: 'wordpress',
-      signal: 'class',
+      signal: expectedSignal,
     });
   });
 


### PR DESCRIPTION
### 摘要
清理靜態分析警告，提升測試代碼的可讀性和維護性。

### 變更內容
- 使用 `test.each` 簡化多個測試用例，減少重複代碼。
- 增加 `waitForPreloaderPing` 函數以改善 E2E 測試的可讀性。
- 將多個 HTML 標籤的測試合併為一個通用測試，提升測試效率。
- 移除不必要的測試，專注於關鍵功能。

### 測試方式
尚未測試

### 潛在風險
無顯著風險

